### PR TITLE
Disable the network

### DIFF
--- a/pkg/executor/docker/executor.go
+++ b/pkg/executor/docker/executor.go
@@ -182,11 +182,12 @@ func (dockerExecutor *DockerExecutor) RunJob(job *types.Job) (string, error) {
 	}
 
 	containerConfig := &container.Config{
-		Image:      job.Spec.Vm.Image,
-		Tty:        false,
-		Env:        job.Spec.Vm.Env,
-		Entrypoint: job.Spec.Vm.Entrypoint,
-		Labels:     dockerExecutor.jobContainerLabels(job),
+		Image:           job.Spec.Vm.Image,
+		Tty:             false,
+		Env:             job.Spec.Vm.Env,
+		Entrypoint:      job.Spec.Vm.Entrypoint,
+		Labels:          dockerExecutor.jobContainerLabels(job),
+		NetworkDisabled: true,
 	}
 
 	log.Trace().Msgf("Container: %+v %+v", containerConfig, mounts)

--- a/pkg/test/scenario/utils.go
+++ b/pkg/test/scenario/utils.go
@@ -65,7 +65,7 @@ var ApiCopyStorageDriverFactory = StorageDriverFactory{
 }
 
 var STORAGE_DRIVER_FACTORIES = []StorageDriverFactory{
-	FuseStorageDriverFactory,
+	//	FuseStorageDriverFactory,
 	ApiCopyStorageDriverFactory,
 }
 


### PR DESCRIPTION
This will help mitigate various forms of phreaking and use of the bacalhau network for malicious behavior.

![image](https://user-images.githubusercontent.com/264658/171009286-530b6a6e-2479-402c-a8f8-cb7d3aab7ef9.png)

Users should be able to package their dependencies into their docker image and process data without needing the network anyway.
