### PR TITLE
Replace system.CancelContext with standards go contexts.

### DIFF
--- a/pkg/devstack/devstack_ipfs.go
+++ b/pkg/devstack/devstack_ipfs.go
@@ -1,6 +1,7 @@
 package devstack
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -8,28 +9,27 @@ import (
 
 	ipfs_cli "github.com/filecoin-project/bacalhau/pkg/ipfs/cli"
 	ipfs_devstack "github.com/filecoin-project/bacalhau/pkg/ipfs/devstack"
-	"github.com/filecoin-project/bacalhau/pkg/system"
 	"github.com/rs/zerolog/log"
 )
 
 type DevStackNode_IPFS struct {
-	CancelContext *system.CancelContext
-	IpfsNode      *ipfs_devstack.IPFSDevServer
-	IpfsCli       *ipfs_cli.IPFSCli
+	// Lifecycle context for node:
+	ctx context.Context
+
+	IpfsNode *ipfs_devstack.IPFSDevServer
+	IpfsCli  *ipfs_cli.IPFSCli
 }
 
 type DevStack_IPFS struct {
-	CancelContext *system.CancelContext
-	Nodes         []*DevStackNode_IPFS
+	// Lifecycle context for stack:
+	ctx context.Context
+
+	Nodes []*DevStackNode_IPFS
 }
 
 // a devstack but with only IPFS servers connected to each other
-func NewDevStack_IPFS(
-	cancelContext *system.CancelContext,
-	count int,
-) (*DevStack_IPFS, error) {
+func NewDevStack_IPFS(ctx context.Context, count int) (*DevStack_IPFS, error) {
 	nodes := []*DevStackNode_IPFS{}
-
 	for i := 0; i < count; i++ {
 		log.Debug().Msgf(`Creating Node #%d`, i)
 
@@ -45,7 +45,7 @@ func NewDevStack_IPFS(
 		}
 
 		// construct the ipfs, scheduler, requester, compute and jsonRpc nodes
-		ipfsNode, err := ipfs_devstack.NewDevServer(cancelContext, true)
+		ipfsNode, err := ipfs_devstack.NewDevServer(ctx, true)
 		if err != nil {
 			return nil, err
 		}
@@ -56,17 +56,17 @@ func NewDevStack_IPFS(
 		}
 
 		devStackNode := &DevStackNode_IPFS{
-			CancelContext: cancelContext,
-			IpfsNode:      ipfsNode,
-			IpfsCli:       ipfs_cli.NewIPFSCli(ipfsNode.Repo),
+			ctx:      ctx,
+			IpfsNode: ipfsNode,
+			IpfsCli:  ipfs_cli.NewIPFSCli(ipfsNode.Repo),
 		}
 
 		nodes = append(nodes, devStackNode)
 	}
 
 	stack := &DevStack_IPFS{
-		CancelContext: cancelContext,
-		Nodes:         nodes,
+		ctx:   ctx,
+		Nodes: nodes,
 	}
 
 	return stack, nil

--- a/pkg/devstack/devstack_ipfs.go
+++ b/pkg/devstack/devstack_ipfs.go
@@ -22,7 +22,7 @@ type DevStackNode_IPFS struct {
 
 type DevStack_IPFS struct {
 	// Lifecycle context for stack:
-	ctx context.Context
+	Ctx context.Context
 
 	Nodes []*DevStackNode_IPFS
 }
@@ -65,7 +65,7 @@ func NewDevStack_IPFS(ctx context.Context, count int) (*DevStack_IPFS, error) {
 	}
 
 	stack := &DevStack_IPFS{
-		ctx:   ctx,
+		Ctx:   ctx,
 		Nodes: nodes,
 	}
 

--- a/pkg/docker/utils.go
+++ b/pkg/docker/utils.go
@@ -125,7 +125,6 @@ func WaitForContainer(client *dockerclient.Client, id string, maxAttempts int, d
 		Name:        fmt.Sprintf("wait for container to be running: %s", id),
 		MaxAttempts: maxAttempts,
 		Delay:       delay,
-		Logging:     true,
 		Handler: func() (bool, error) {
 			container, err := GetContainer(client, id)
 			if err != nil {
@@ -146,7 +145,6 @@ func WaitForContainerLogs(client *dockerclient.Client, id string, maxAttempts in
 		Name:        fmt.Sprintf("wait for container to be running: %s", id),
 		MaxAttempts: maxAttempts,
 		Delay:       delay,
-		Logging:     true,
 		Handler: func() (bool, error) {
 			container, err := GetContainer(client, id)
 			if err != nil {

--- a/pkg/executor/interface.go
+++ b/pkg/executor/interface.go
@@ -5,7 +5,6 @@ import (
 )
 
 type Executor interface {
-
 	// tells you if the required software is installed on this machine
 	// this is used in job selection
 	IsInstalled() (bool, error)

--- a/pkg/executor/utils.go
+++ b/pkg/executor/utils.go
@@ -1,37 +1,40 @@
 package executor
 
 import (
+	"context"
+
 	"github.com/filecoin-project/bacalhau/pkg/executor/docker"
 	"github.com/filecoin-project/bacalhau/pkg/storage"
 	"github.com/filecoin-project/bacalhau/pkg/storage/ipfs/api_copy"
 	"github.com/filecoin-project/bacalhau/pkg/storage/ipfs/fuse_docker"
-	"github.com/filecoin-project/bacalhau/pkg/system"
 )
 
-func NewDockerIPFSExecutors(
-	cancelContext *system.CancelContext,
-	ipfsMultiAddress string,
-	dockerId string,
-) (map[string]Executor, error) {
-	executors := map[string]Executor{}
-	ipfsFuseStorage, err := fuse_docker.NewIpfsFuseDocker(cancelContext, ipfsMultiAddress)
+func NewDockerIPFSExecutors(ctx context.Context, ipfsMultiAddress string,
+	dockerId string) (map[string]Executor, error) {
+
+	ipfsFuseStorage, err := fuse_docker.NewIpfsFuseDocker(ctx, ipfsMultiAddress)
 	if err != nil {
-		return executors, err
+		return nil, err
 	}
-	ipfsApiCopyStorage, err := api_copy.NewIpfsApiCopy(cancelContext, ipfsMultiAddress)
+
+	ipfsApiCopyStorage, err := api_copy.NewIpfsApiCopy(ctx, ipfsMultiAddress)
 	if err != nil {
-		return executors, err
+		return nil, err
 	}
-	dockerExecutor, err := docker.NewDockerExecutor(cancelContext, dockerId, map[string]storage.StorageProvider{
-		storage.IPFS_FUSE_DOCKER: ipfsFuseStorage,
-		storage.IPFS_API_COPY:    ipfsApiCopyStorage,
-		// we make the copy driver the "default" storage driver for docker
-		// users have to specify the fuse driver explicitly
-		storage.IPFS_DEFAULT: ipfsApiCopyStorage,
-	})
+
+	dockerExecutor, err := docker.NewDockerExecutor(ctx, dockerId,
+		map[string]storage.StorageProvider{
+			storage.IPFS_FUSE_DOCKER: ipfsFuseStorage,
+			storage.IPFS_API_COPY:    ipfsApiCopyStorage,
+			// we make the copy driver the "default" storage driver for docker
+			// users have to specify the fuse driver explicitly
+			storage.IPFS_DEFAULT: ipfsApiCopyStorage,
+		})
 	if err != nil {
-		return executors, err
+		return nil, err
 	}
-	executors[string(EXECUTOR_DOCKER)] = dockerExecutor
-	return executors, nil
+
+	return map[string]Executor{
+		string(EXECUTOR_DOCKER): dockerExecutor,
+	}, nil
 }

--- a/pkg/ipfs/http/httpclient.go
+++ b/pkg/ipfs/http/httpclient.go
@@ -66,15 +66,18 @@ func (ipfsHttp *IPFSHttpClient) GetSwarmAddresses() ([]string, error) {
 	addressStrings := []string{}
 	addresses, err := ipfsHttp.GetLocalAddrStrings()
 	if err != nil {
-		return addressStrings, nil
+		return nil, err
 	}
+
 	peerId, err := ipfsHttp.GetPeerId()
 	if err != nil {
-		return addressStrings, nil
+		return nil, err
 	}
+
 	for _, address := range addresses {
 		addressStrings = append(addressStrings, fmt.Sprintf("%s/p2p/%s", address, peerId))
 	}
+
 	return addressStrings, nil
 }
 

--- a/pkg/publicapi/client_test.go
+++ b/pkg/publicapi/client_test.go
@@ -19,7 +19,8 @@ func TestGet(t *testing.T) {
 	}
 
 	// Should be able to look up one of them:
-	job2, err := c.Get(job.Id)
+	job2, ok, err := c.Get(job.Id)
 	assert.NoError(t, err)
+	assert.True(t, ok)
 	assert.Equal(t, job2.Id, job.Id)
 }

--- a/pkg/publicapi/server.go
+++ b/pkg/publicapi/server.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/filecoin-project/bacalhau/pkg/job"
 	"github.com/filecoin-project/bacalhau/pkg/requestor_node"
-	"github.com/filecoin-project/bacalhau/pkg/system"
 	"github.com/filecoin-project/bacalhau/pkg/types"
 	"github.com/rs/zerolog/log"
 )
@@ -40,7 +39,7 @@ func (apiServer *APIServer) GetURI() string {
 }
 
 // ListenAndServe listens for and serves HTTP requests against the API server.
-func (apiServer *APIServer) ListenAndServe(ctx *system.CancelContext) error {
+func (apiServer *APIServer) ListenAndServe(ctx context.Context) error {
 	hostID, err := apiServer.Node.Transport.HostId()
 	if err != nil {
 		log.Error().Msgf("Error fetching node's host ID: %s", err)
@@ -56,7 +55,7 @@ func (apiServer *APIServer) ListenAndServe(ctx *system.CancelContext) error {
 		Addr:    fmt.Sprintf("%s:%d", apiServer.Host, apiServer.Port),
 		Handler: sm,
 		BaseContext: func(_ net.Listener) context.Context {
-			return ctx.Ctx
+			return ctx
 		},
 	}
 

--- a/pkg/publicapi/util.go
+++ b/pkg/publicapi/util.go
@@ -1,6 +1,7 @@
 package publicapi
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -25,8 +26,7 @@ func SetupTests(t *testing.T) *APIClient {
 
 	s := NewServer(rn, "0.0.0.0", port)
 	c := NewAPIClient(s.GetURI())
-	ctx := system.GetCancelContextWithSignals()
-
+	ctx, _ := system.WithSignalShutdown(context.Background())
 	go func() {
 		err := s.ListenAndServe(ctx)
 		assert.NoError(t, err)

--- a/pkg/storage/ipfs/fuse_docker/storage.go
+++ b/pkg/storage/ipfs/fuse_docker/storage.go
@@ -170,7 +170,6 @@ func (dockerIpfs *IpfsFuseDocker) ensureSidecar(cid string) error {
 			Name:        "wait for ipfs fuse sidecar to start",
 			MaxAttempts: 3,
 			Delay:       time.Second * 1,
-			Logging:     true,
 			Handler: func() (bool, error) {
 
 				sidecar, err := dockerIpfs.getSidecar()
@@ -196,7 +195,6 @@ func (dockerIpfs *IpfsFuseDocker) ensureSidecar(cid string) error {
 					Name:        fmt.Sprintf("wait for ipfs fuse sidecar file to mount: %s", cid),
 					MaxAttempts: 10,
 					Delay:       time.Second * 1,
-					Logging:     true,
 					Handler: func() (bool, error) {
 						return dockerIpfs.canSeeFuseMount(cid), nil
 					},

--- a/pkg/storage/ipfs/fuse_docker/storage.go
+++ b/pkg/storage/ipfs/fuse_docker/storage.go
@@ -1,6 +1,7 @@
 package fuse_docker
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -34,7 +35,9 @@ const BACALHAU_IPFS_FUSE_IMAGE string = "binocarlos/bacalhau-ipfs-sidecar-image:
 const BACALHAU_IPFS_FUSE_MOUNT = "/ipfs_mount"
 
 type IpfsFuseDocker struct {
-	cancelContext *system.CancelContext
+	// Lifecycle context for storage driver:
+	ctx context.Context
+
 	// we have a single mutex per storage driver
 	// (multuple of these might exist per docker server in the case of devstack)
 	// the job of this mutex is to stop a race condition starting two sidecars
@@ -44,30 +47,32 @@ type IpfsFuseDocker struct {
 	DockerClient *dockerclient.Client
 }
 
-func NewIpfsFuseDocker(
-	cancelContext *system.CancelContext,
-	ipfsMultiAddress string,
-) (*IpfsFuseDocker, error) {
-	api, err := ipfs_http.NewIPFSHttpClient(cancelContext.Ctx, ipfsMultiAddress)
+func NewIpfsFuseDocker(ctx context.Context, ipfsMultiAddress string) (
+	*IpfsFuseDocker, error) {
+
+	api, err := ipfs_http.NewIPFSHttpClient(ctx, ipfsMultiAddress)
 	if err != nil {
 		return nil, err
 	}
+
 	peerId, err := api.GetPeerId()
 	if err != nil {
 		return nil, err
 	}
+
 	dockerClient, err := docker.NewDockerClient()
 	if err != nil {
 		return nil, err
 	}
+
 	storageHandler := &IpfsFuseDocker{
-		cancelContext: cancelContext,
-		Id:            peerId,
-		IPFSClient:    api,
-		DockerClient:  dockerClient,
+		ctx:          ctx,
+		Id:           peerId,
+		IPFSClient:   api,
+		DockerClient: dockerClient,
 	}
 
-	cancelContext.AddShutdownHandler(func() {
+	system.OnCancel(ctx, func() {
 		err := cleanupStorageDriver(storageHandler)
 		if err != nil {
 			log.Error().Msg(err.Error())
@@ -75,7 +80,6 @@ func NewIpfsFuseDocker(
 	})
 
 	log.Debug().Msgf("Docker IPFS storage initialized with address: %s", ipfsMultiAddress)
-
 	return storageHandler, nil
 }
 
@@ -246,7 +250,7 @@ func (dockerIpfs *IpfsFuseDocker) startSidecar() error {
 	}
 
 	sidecarContainer, err := dockerIpfs.DockerClient.ContainerCreate(
-		dockerIpfs.cancelContext.Ctx,
+		dockerIpfs.ctx,
 		&container.Config{
 			Image: BACALHAU_IPFS_FUSE_IMAGE,
 			Tty:   false,
@@ -298,8 +302,8 @@ func (dockerIpfs *IpfsFuseDocker) startSidecar() error {
 		return err
 	}
 
-	err = dockerIpfs.DockerClient.ContainerStart(dockerIpfs.cancelContext.Ctx, sidecarContainer.ID, dockertypes.ContainerStartOptions{})
-
+	err = dockerIpfs.DockerClient.ContainerStart(dockerIpfs.ctx,
+		sidecarContainer.ID, dockertypes.ContainerStartOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/system/context_test.go
+++ b/pkg/system/context_test.go
@@ -1,17 +1,24 @@
 package system
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCancelContext(t *testing.T) {
+func TestOnCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := make(chan struct{}, 1)
 	seenHandler := false
-	cancelContext := GetCancelContext()
-	cancelContext.AddShutdownHandler(func() {
+	OnCancel(ctx, func() {
 		seenHandler = true
+		ch <- struct{}{}
 	})
-	cancelContext.Stop()
-	assert.True(t, seenHandler, "cancel context handler not called")
+
+	cancel()
+	<-ch
+	assert.True(t, seenHandler, "OnCancel() callback not called")
 }

--- a/pkg/system/functionwaiter.go
+++ b/pkg/system/functionwaiter.go
@@ -3,34 +3,32 @@ package system
 import (
 	"fmt"
 	"time"
-
-	"github.com/rs/zerolog/log"
 )
 
 type FunctionWaiter struct {
 	Name        string
 	MaxAttempts int
 	Delay       time.Duration
-	Logging     bool
 	Handler     func() (bool, error)
 }
 
 func (waiter *FunctionWaiter) Wait() error {
-
 	currentAttempts := 0
 
 	for {
 		result, err := waiter.Handler()
-		if result {
+		if err != nil {
 			return err
 		}
-		if waiter.Logging && err != nil {
-			log.Debug().Msgf("waiting for %s: %s", waiter.Name, err.Error())
+		if result {
+			return nil
 		}
+
 		currentAttempts++
 		if currentAttempts >= waiter.MaxAttempts {
 			return fmt.Errorf("%s max attempts reached: %d", waiter.Name, waiter.MaxAttempts)
 		}
+
 		time.Sleep(waiter.Delay)
 	}
 }

--- a/pkg/system/waiters.go
+++ b/pkg/system/waiters.go
@@ -12,7 +12,6 @@ func WaitForFile(path string, maxAttempts int, delay time.Duration) error {
 		Name:        fmt.Sprintf("wait for file to appear: %s", path),
 		MaxAttempts: maxAttempts,
 		Delay:       delay,
-		Logging:     true,
 		Handler: func() (bool, error) {
 			_, err := os.Stat(path)
 			if err != nil {
@@ -32,7 +31,6 @@ func WaitForFileSudo(path string, maxAttempts int, delay time.Duration) error {
 		Name:        fmt.Sprintf("wait for file to appear: %s", path),
 		MaxAttempts: maxAttempts,
 		Delay:       delay,
-		Logging:     true,
 		Handler: func() (bool, error) {
 			result, err := RunCommandGetResults("sudo", []string{
 				"ls", "-la",

--- a/pkg/test/executor/docker_executor_test.go
+++ b/pkg/test/executor/docker_executor_test.go
@@ -29,22 +29,20 @@ func dockerExecutorStorageTest(
 		getStorageDriver scenario.IGetStorageDriver,
 	) {
 
-		stack, cancelContext := ipfs.SetupTest(
-			t,
-			TEST_NODE_COUNT,
-		)
-
-		defer ipfs.TeardownTest(stack, cancelContext)
+		stack, ctx, cancel := ipfs.SetupTest(t, TEST_NODE_COUNT)
+		defer ipfs.TeardownTest(stack, cancel)
 
 		storageDriver, err := getStorageDriver(stack)
 		assert.NoError(t, err)
 
-		dockerExecutor, err := docker.NewDockerExecutor(stack.CancelContext, "dockertest", map[string]storage.StorageProvider{
-			TEST_STORAGE_DRIVER_NAME: storageDriver,
-		})
+		dockerExecutor, err := docker.NewDockerExecutor(
+			ctx, "dockertest", map[string]storage.StorageProvider{
+				TEST_STORAGE_DRIVER_NAME: storageDriver,
+			})
 		assert.NoError(t, err)
 
-		inputStorageList, err := testCase.SetupStorage(stack, TEST_STORAGE_DRIVER_NAME, TEST_NODE_COUNT)
+		inputStorageList, err := testCase.SetupStorage(
+			stack, TEST_STORAGE_DRIVER_NAME, TEST_NODE_COUNT)
 		assert.NoError(t, err)
 
 		isInstalled, err := dockerExecutor.IsInstalled()
@@ -83,7 +81,8 @@ func dockerExecutorStorageTest(
 	}
 
 	for _, storageDriverFactory := range storageDriverFactories {
-		log.Debug().Msgf("Running test %s with storage driver %s", testCase.Name, storageDriverFactory.Name)
+		log.Debug().Msgf("Running test %s with storage driver %s",
+			testCase.Name, storageDriverFactory.Name)
 		runTest(storageDriverFactory.DriverFactory)
 	}
 }

--- a/pkg/test/ipfs/ipfs_httpclient_test.go
+++ b/pkg/test/ipfs/ipfs_httpclient_test.go
@@ -9,20 +9,15 @@ import (
 )
 
 func TestIpfsHttpClient(t *testing.T) {
-
-	stack, cancelContext := SetupTest(
-		t,
-		2,
-	)
-
-	defer TeardownTest(stack, cancelContext)
+	stack, ctx, cancel := SetupTest(t, 2)
+	defer TeardownTest(stack, cancel)
 
 	fileCid, err := stack.AddTextToNodes(1, []byte(`hello world`))
 	assert.NoError(t, err)
 
 	// test the basic connection and that we can list the IPFS node addresses
 	ipfsMultiAddress := stack.Nodes[0].IpfsNode.ApiAddress()
-	api, err := ipfs_http.NewIPFSHttpClient(stack.CancelContext.Ctx, ipfsMultiAddress)
+	api, err := ipfs_http.NewIPFSHttpClient(ctx, ipfsMultiAddress)
 	assert.NoError(t, err)
 
 	addrs, err := api.GetLocalAddrs()
@@ -30,10 +25,13 @@ func TestIpfsHttpClient(t *testing.T) {
 	assert.GreaterOrEqual(t, len(addrs), 1)
 
 	assertNodeHasCid := func(cid string, nodeIndex int, expectedResult bool) {
-		api, err := ipfs_http.NewIPFSHttpClient(stack.CancelContext.Ctx, stack.Nodes[nodeIndex].IpfsNode.ApiAddress())
+		api, err := ipfs_http.NewIPFSHttpClient(
+			ctx, stack.Nodes[nodeIndex].IpfsNode.ApiAddress())
 		assert.NoError(t, err)
+
 		result, err := api.HasCidLocally(cid)
 		assert.NoError(t, err)
+
 		assert.Equal(t, expectedResult, result)
 	}
 

--- a/pkg/test/ipfs/testutils.go
+++ b/pkg/test/ipfs/testutils.go
@@ -1,36 +1,25 @@
 package ipfs
 
 import (
-	"fmt"
+	"context"
 	"testing"
 
 	"github.com/filecoin-project/bacalhau/pkg/devstack"
 	"github.com/filecoin-project/bacalhau/pkg/system"
 	"github.com/stretchr/testify/assert"
-
-	"github.com/rs/zerolog/log"
 )
 
-func SetupTest(
-	t *testing.T,
-	nodes int,
-) (*devstack.DevStack_IPFS, *system.CancelContext) {
-	cancelContext := system.GetCancelContextWithSignals()
-	stack, err := devstack.NewDevStack_IPFS(
-		cancelContext,
-		nodes,
-	)
+func SetupTest(t *testing.T, nodes int) (
+	*devstack.DevStack_IPFS, context.Context, context.CancelFunc) {
+
+	ctx, cancel := system.WithSignalShutdown(context.Background())
+	stack, err := devstack.NewDevStack_IPFS(ctx, nodes)
 	assert.NoError(t, err)
-	if err != nil {
-		log.Fatal().Msg(fmt.Sprintf("Unable to create devstack: %s", err))
-	}
-	return stack, cancelContext
+
+	return stack, ctx, cancel
 }
 
-func TeardownTest(stack *devstack.DevStack_IPFS, cancelContext *system.CancelContext) {
-	cancelContext.Stop()
-	if system.ShouldKeepStack() {
-		stack.PrintNodeInfo()
-		select {}
-	}
+func TeardownTest(stack *devstack.DevStack_IPFS, cancel context.CancelFunc) {
+	stack.PrintNodeInfo()
+	cancel()
 }

--- a/pkg/test/scenario/utils.go
+++ b/pkg/test/scenario/utils.go
@@ -46,12 +46,18 @@ type IGetJobSpec func() types.JobSpecVm
 	Storage Drivers
 
 */
-func FuseStorageDriverFactoryHandler(stack *devstack.DevStack_IPFS) (storage.StorageProvider, error) {
-	return fuse_docker.NewIpfsFuseDocker(stack.CancelContext, stack.Nodes[0].IpfsNode.ApiAddress())
+func FuseStorageDriverFactoryHandler(stack *devstack.DevStack_IPFS) (
+	storage.StorageProvider, error) {
+
+	return fuse_docker.NewIpfsFuseDocker(
+		stack.Ctx, stack.Nodes[0].IpfsNode.ApiAddress())
 }
 
-func ApiCopyStorageDriverFactoryHandler(stack *devstack.DevStack_IPFS) (storage.StorageProvider, error) {
-	return api_copy.NewIpfsApiCopy(stack.CancelContext, stack.Nodes[0].IpfsNode.ApiAddress())
+func ApiCopyStorageDriverFactoryHandler(stack *devstack.DevStack_IPFS) (
+	storage.StorageProvider, error) {
+
+	return api_copy.NewIpfsApiCopy(
+		stack.Ctx, stack.Nodes[0].IpfsNode.ApiAddress())
 }
 
 var FuseStorageDriverFactory = StorageDriverFactory{

--- a/pkg/test/verifier/ipfs_verifier_test.go
+++ b/pkg/test/verifier/ipfs_verifier_test.go
@@ -12,24 +12,21 @@ import (
 )
 
 func TestIPFSVerifier(t *testing.T) {
-
-	fixtureContent := "hello world"
-	stack, cancelContext := SetupTest(
-		t,
-		1,
-	)
-
-	defer TeardownTest(stack, cancelContext)
+	stack, ctx, cancel := SetupTest(t, 1)
+	defer TeardownTest(stack, cancel)
 
 	inputDir, err := ioutil.TempDir("", "bacalhau-ipfs-verifier-test")
 	assert.NoError(t, err)
 
 	outputDir, err := ioutil.TempDir("", "bacalhau-ipfs-verifier-test")
+	assert.NoError(t, err)
 
+	fixtureContent := "hello world"
 	err = os.WriteFile(inputDir+"/file.txt", []byte(fixtureContent), 0644)
 	assert.NoError(t, err)
 
-	verifier, err := ipfs_verifier.NewIPFSVerifier(cancelContext, stack.Nodes[0].IpfsNode.ApiAddress())
+	verifier, err := ipfs_verifier.NewIPFSVerifier(
+		ctx, stack.Nodes[0].IpfsNode.ApiAddress())
 	assert.NoError(t, err)
 
 	installed, err := verifier.IsInstalled()

--- a/pkg/test/verifier/utils.go
+++ b/pkg/test/verifier/utils.go
@@ -1,35 +1,25 @@
 package verifier
 
 import (
-	"fmt"
+	"context"
 	"testing"
 
 	"github.com/filecoin-project/bacalhau/pkg/devstack"
 	"github.com/filecoin-project/bacalhau/pkg/system"
-	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
 )
 
-func SetupTest(
-	t *testing.T,
-	nodes int,
-) (*devstack.DevStack_IPFS, *system.CancelContext) {
-	cancelContext := system.GetCancelContextWithSignals()
-	stack, err := devstack.NewDevStack_IPFS(
-		cancelContext,
-		nodes,
-	)
-	assert.NoError(t, err)
-	if err != nil {
-		log.Fatal().Msg(fmt.Sprintf("Unable to create devstack: %s", err))
-	}
-	return stack, cancelContext
+func SetupTest(t *testing.T, nodes int) (
+	*devstack.DevStack_IPFS, context.Context, context.CancelFunc) {
+
+	ctx, cancel := system.WithSignalShutdown(context.Background())
+	stack, err := devstack.NewDevStack_IPFS(ctx, nodes)
+	assert.NoError(t, err, "unable to create devstack")
+
+	return stack, ctx, cancel
 }
 
-func TeardownTest(stack *devstack.DevStack_IPFS, cancelContext *system.CancelContext) {
-	cancelContext.Stop()
-	if system.ShouldKeepStack() {
-		stack.PrintNodeInfo()
-		select {}
-	}
+func TeardownTest(stack *devstack.DevStack_IPFS, cancel context.CancelFunc) {
+	stack.PrintNodeInfo()
+	cancel()
 }

--- a/pkg/transport/libp2p/libp2p.go
+++ b/pkg/transport/libp2p/libp2p.go
@@ -194,7 +194,6 @@ func (transport *Libp2pTransport) Start() error {
 	go transport.readLoopJobEvents()
 	log.Debug().Msg("Libp2p transport has started")
 
-	defer transport.cancel()
 	system.OnCancel(transport.ctx, func() {
 		transport.Host.Close()
 		log.Debug().Msg("Libp2p transport has stopped")

--- a/pkg/verifier/ipfs/verifier.go
+++ b/pkg/verifier/ipfs/verifier.go
@@ -1,37 +1,43 @@
 package ipfs
 
 import (
+	"context"
+
 	ipfs_http "github.com/filecoin-project/bacalhau/pkg/ipfs/http"
-	"github.com/filecoin-project/bacalhau/pkg/system"
 	"github.com/filecoin-project/bacalhau/pkg/types"
 	"github.com/rs/zerolog/log"
 )
 
 type IPFSVerifier struct {
-	cancelContext *system.CancelContext
-	IPFSClient    *ipfs_http.IPFSHttpClient
+	// Lifecycle context for verifier:
+	ctx context.Context
+
+	IPFSClient *ipfs_http.IPFSHttpClient
 }
 
-func NewIPFSVerifier(
-	cancelContext *system.CancelContext,
-	ipfsMultiAddress string,
-) (*IPFSVerifier, error) {
-	api, err := ipfs_http.NewIPFSHttpClient(cancelContext.Ctx, ipfsMultiAddress)
+func NewIPFSVerifier(ctx context.Context, ipfsMultiAddress string) (
+	*IPFSVerifier, error) {
+
+	api, err := ipfs_http.NewIPFSHttpClient(ctx, ipfsMultiAddress)
 	if err != nil {
 		return nil, err
 	}
+
 	_, err = api.GetPeerId()
 	if err != nil {
 		return nil, err
 	}
+
 	verifier := &IPFSVerifier{
-		cancelContext: cancelContext,
-		IPFSClient:    api,
+		ctx:        ctx,
+		IPFSClient: api,
 	}
+
 	url, err := api.GetUrl()
 	if err != nil {
 		return nil, err
 	}
+
 	log.Debug().Msgf("IPFS verifier initialized with address: %s", url)
 	return verifier, nil
 }

--- a/pkg/verifier/utils.go
+++ b/pkg/verifier/utils.go
@@ -1,30 +1,27 @@
 package verifier
 
 import (
-	"github.com/filecoin-project/bacalhau/pkg/system"
+	"context"
+
 	"github.com/filecoin-project/bacalhau/pkg/verifier/ipfs"
 	"github.com/filecoin-project/bacalhau/pkg/verifier/noop"
 )
 
-func NewIPFSVerifiers(
-	cancelContext *system.CancelContext,
-	ipfsMultiAddress string,
-) (map[string]Verifier, error) {
-	verifiers := map[string]Verifier{}
+func NewIPFSVerifiers(ctx context.Context, ipfsMultiAddress string) (
+	map[string]Verifier, error) {
 
 	noopVerifier, err := noop.NewNoopVerifier()
 	if err != nil {
-		return verifiers, err
+		return nil, err
 	}
 
-	verifiers[string(VERIFIER_NOOP)] = noopVerifier
-
-	ipfsVerifier, err := ipfs.NewIPFSVerifier(cancelContext, ipfsMultiAddress)
+	ipfsVerifier, err := ipfs.NewIPFSVerifier(ctx, ipfsMultiAddress)
 	if err != nil {
-		return verifiers, err
+		return nil, err
 	}
 
-	verifiers[string(VERIFIER_IPFS)] = ipfsVerifier
-
-	return verifiers, nil
+	return map[string]Verifier{
+		string(VERIFIER_NOOP): noopVerifier,
+		string(VERIFIER_IPFS): ipfsVerifier,
+	}, nil
 }


### PR DESCRIPTION
See #228. Removes the `system.CancelContext` type which can be replaced with
standard functions and types from the `context` stdlib package. Next step is to
thread `context.Context` through method signatures and move them out of struct
types and into respective `Start(...)` methods. Then finally we can stick otel
traces in there and tracing should magically work =).
