### PR TITLE
Refactor Transport interface to use contexts for all APIs, fix IPFS daemon leakage bug.

### DIFF
--- a/cmd/bacalhau/serve.go
+++ b/cmd/bacalhau/serve.go
@@ -53,10 +53,15 @@ var serveCmd = &cobra.Command{
 			return fmt.Errorf("must specify ipfs-connect")
 		}
 
+		// Cleanup manager ensures that resources are freed before exiting:
+		cm := system.NewCleanupManager()
+		defer cm.Cleanup()
+
+		// Context ensures main goroutine waits until killed with ctrl+c:
 		ctx, cancel := system.WithSignalShutdown(context.Background())
 		defer cancel()
 
-		transport, err := libp2p.NewTransport(hostPort)
+		transport, err := libp2p.NewTransport(cm, hostPort)
 		if err != nil {
 			return err
 		}
@@ -66,13 +71,13 @@ var serveCmd = &cobra.Command{
 			return err
 		}
 
-		executors, err := executor.NewDockerIPFSExecutors(ctx, ipfsConnect,
+		executors, err := executor.NewDockerIPFSExecutors(cm, ipfsConnect,
 			fmt.Sprintf("bacalhau-%s", transport.Host.ID().String()))
 		if err != nil {
 			return err
 		}
 
-		verifiers, err := verifier.NewIPFSVerifiers(ctx, ipfsConnect)
+		verifiers, err := verifier.NewIPFSVerifiers(cm, ipfsConnect)
 		if err != nil {
 			return err
 		}
@@ -119,7 +124,7 @@ var serveCmd = &cobra.Command{
 
 		log.Info().Msgf("Bacalhau compute node started - peer id is: %s", transport.Host.ID().String())
 
-		<-ctx.Done() // blocks main goroutine so we don't exit
+		<-ctx.Done() // block until killed
 		return nil
 	},
 }

--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+echo "Running golangci-lint checker..."
+$GOBIN/golangci-lint run
+echo "No linting issues found, continuing with commit."

--- a/pkg/devstack/devstack.go
+++ b/pkg/devstack/devstack.go
@@ -22,9 +22,6 @@ import (
 )
 
 type DevStackNode struct {
-	// Lifecycle context for node:
-	ctx context.Context
-
 	ComputeNode   *compute_node.ComputeNode
 	RequesterNode *requestor_node.RequesterNode
 	IpfsNode      *ipfs_devstack.IPFSDevServer

--- a/pkg/devstack/devstack_ipfs.go
+++ b/pkg/devstack/devstack_ipfs.go
@@ -1,7 +1,6 @@
 package devstack
 
 import (
-	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -19,10 +18,8 @@ type DevStackNode_IPFS struct {
 }
 
 type DevStack_IPFS struct {
-	// Lifecycle context for stack:
-	Ctx context.Context
-
-	Nodes []*DevStackNode_IPFS
+	Nodes          []*DevStackNode_IPFS
+	CleanupManager *system.CleanupManager
 }
 
 // a devstack but with only IPFS servers connected to each other
@@ -64,7 +61,8 @@ func NewDevStack_IPFS(cm *system.CleanupManager, count int) (
 	}
 
 	stack := &DevStack_IPFS{
-		Nodes: nodes,
+		Nodes:          nodes,
+		CleanupManager: cm,
 	}
 
 	return stack, nil

--- a/pkg/devstack/devstack_ipfs.go
+++ b/pkg/devstack/devstack_ipfs.go
@@ -9,13 +9,11 @@ import (
 
 	ipfs_cli "github.com/filecoin-project/bacalhau/pkg/ipfs/cli"
 	ipfs_devstack "github.com/filecoin-project/bacalhau/pkg/ipfs/devstack"
+	"github.com/filecoin-project/bacalhau/pkg/system"
 	"github.com/rs/zerolog/log"
 )
 
 type DevStackNode_IPFS struct {
-	// Lifecycle context for node:
-	ctx context.Context
-
 	IpfsNode *ipfs_devstack.IPFSDevServer
 	IpfsCli  *ipfs_cli.IPFSCli
 }
@@ -28,7 +26,9 @@ type DevStack_IPFS struct {
 }
 
 // a devstack but with only IPFS servers connected to each other
-func NewDevStack_IPFS(ctx context.Context, count int) (*DevStack_IPFS, error) {
+func NewDevStack_IPFS(cm *system.CleanupManager, count int) (
+	*DevStack_IPFS, error) {
+
 	nodes := []*DevStackNode_IPFS{}
 	for i := 0; i < count; i++ {
 		log.Debug().Msgf(`Creating Node #%d`, i)
@@ -45,7 +45,7 @@ func NewDevStack_IPFS(ctx context.Context, count int) (*DevStack_IPFS, error) {
 		}
 
 		// construct the ipfs, scheduler, requester, compute and jsonRpc nodes
-		ipfsNode, err := ipfs_devstack.NewDevServer(ctx, true)
+		ipfsNode, err := ipfs_devstack.NewDevServer(cm, true)
 		if err != nil {
 			return nil, err
 		}
@@ -56,7 +56,6 @@ func NewDevStack_IPFS(ctx context.Context, count int) (*DevStack_IPFS, error) {
 		}
 
 		devStackNode := &DevStackNode_IPFS{
-			ctx:      ctx,
 			IpfsNode: ipfsNode,
 			IpfsCli:  ipfs_cli.NewIPFSCli(ipfsNode.Repo),
 		}
@@ -65,7 +64,6 @@ func NewDevStack_IPFS(ctx context.Context, count int) (*DevStack_IPFS, error) {
 	}
 
 	stack := &DevStack_IPFS{
-		Ctx:   ctx,
 		Nodes: nodes,
 	}
 

--- a/pkg/executor/utils.go
+++ b/pkg/executor/utils.go
@@ -1,28 +1,27 @@
 package executor
 
 import (
-	"context"
-
 	"github.com/filecoin-project/bacalhau/pkg/executor/docker"
 	"github.com/filecoin-project/bacalhau/pkg/storage"
 	"github.com/filecoin-project/bacalhau/pkg/storage/ipfs/api_copy"
 	"github.com/filecoin-project/bacalhau/pkg/storage/ipfs/fuse_docker"
+	"github.com/filecoin-project/bacalhau/pkg/system"
 )
 
-func NewDockerIPFSExecutors(ctx context.Context, ipfsMultiAddress string,
+func NewDockerIPFSExecutors(cm *system.CleanupManager, ipfsMultiAddress string,
 	dockerId string) (map[string]Executor, error) {
 
-	ipfsFuseStorage, err := fuse_docker.NewIpfsFuseDocker(ctx, ipfsMultiAddress)
+	ipfsFuseStorage, err := fuse_docker.NewIpfsFuseDocker(cm, ipfsMultiAddress)
 	if err != nil {
 		return nil, err
 	}
 
-	ipfsApiCopyStorage, err := api_copy.NewIpfsApiCopy(ctx, ipfsMultiAddress)
+	ipfsApiCopyStorage, err := api_copy.NewIpfsApiCopy(cm, ipfsMultiAddress)
 	if err != nil {
 		return nil, err
 	}
 
-	dockerExecutor, err := docker.NewDockerExecutor(ctx, dockerId,
+	dockerExecutor, err := docker.NewDockerExecutor(cm, dockerId,
 		map[string]storage.StorageProvider{
 			storage.IPFS_FUSE_DOCKER: ipfsFuseStorage,
 			storage.IPFS_API_COPY:    ipfsApiCopyStorage,

--- a/pkg/ipfs/devstack/devstack.go
+++ b/pkg/ipfs/devstack/devstack.go
@@ -293,7 +293,12 @@ func (server *IPFSDevServer) Start(connectToAddress string) error {
 		}
 
 		if err := cmd.Wait(); err != nil {
-			return err
+			var exitErr *exec.ExitError
+			if errors.As(err, &exitErr) {
+				// we expect a non-zero exit code as we killed the process
+			} else {
+				return err
+			}
 		}
 
 		log.Debug().Msgf("IPFS daemon has stopped.")

--- a/pkg/requestor_node/requester_node.go
+++ b/pkg/requestor_node/requester_node.go
@@ -1,6 +1,8 @@
 package requestor_node
 
 import (
+	"context"
+
 	"github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/system"
 	"github.com/filecoin-project/bacalhau/pkg/transport"
@@ -14,8 +16,9 @@ type RequesterNode struct {
 func NewRequesterNode(
 	transport transport.Transport,
 ) (*RequesterNode, error) {
+	ctx := context.TODO()
 
-	nodeId, err := transport.HostId()
+	nodeId, err := transport.HostID(ctx)
 	threadLogger := logger.LoggerWithRuntimeInfo(nodeId)
 
 	if err != nil {
@@ -27,8 +30,7 @@ func NewRequesterNode(
 		Transport: transport,
 	}
 
-	transport.Subscribe(func(jobEvent *types.JobEvent, job *types.Job) {
-
+	transport.Subscribe(ctx, func(jobEvent *types.JobEvent, job *types.Job) {
 		// we only care about jobs that we own
 		if job.Owner != nodeId {
 			return
@@ -51,13 +53,13 @@ func NewRequesterNode(
 
 			if bidAccepted {
 				// TODO: Check result of accept job bid
-				err = transport.AcceptJobBid(jobEvent.JobId, jobEvent.NodeId)
+				err = transport.AcceptJobBid(ctx, jobEvent.JobId, jobEvent.NodeId)
 				if err != nil {
 					threadLogger.Error().Err(err)
 				}
 			} else {
 				// TODO: Check result of reject job bid
-				err = transport.RejectJobBid(jobEvent.JobId, jobEvent.NodeId, message)
+				err = transport.RejectJobBid(ctx, jobEvent.JobId, jobEvent.NodeId, message)
 				if err != nil {
 					threadLogger.Error().Err(err)
 				}

--- a/pkg/storage/ipfs/api_copy/storage.go
+++ b/pkg/storage/ipfs/api_copy/storage.go
@@ -18,17 +18,14 @@ import (
 // a job to run - it will remove the folder/file once complete
 
 type IpfsApiCopy struct {
-	// Lifecycle context for storage driver:
-	ctx context.Context
-
 	LocalDir   string
 	IPFSClient *ipfs_http.IPFSHttpClient
 }
 
-func NewIpfsApiCopy(ctx context.Context, ipfsMultiAddress string) (
+func NewIpfsApiCopy(cm *system.CleanupManager, ipfsMultiAddress string) (
 	*IpfsApiCopy, error) {
 
-	api, err := ipfs_http.NewIPFSHttpClient(ctx, ipfsMultiAddress)
+	api, err := ipfs_http.NewIPFSHttpClient(context.TODO(), ipfsMultiAddress)
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +36,6 @@ func NewIpfsApiCopy(ctx context.Context, ipfsMultiAddress string) (
 	}
 
 	storageHandler := &IpfsApiCopy{
-		ctx:        ctx,
 		IPFSClient: api,
 		LocalDir:   dir,
 	}
@@ -73,7 +69,7 @@ func (dockerIpfs *IpfsApiCopy) PrepareStorage(storageSpec types.StorageSpec) (*t
 
 	err := dockerIpfs.IPFSClient.Api.
 		Request("files/stat", fmt.Sprintf("/ipfs/%s", storageSpec.Cid)).
-		Exec(dockerIpfs.ctx, &statResult)
+		Exec(context.TODO(), &statResult)
 
 	if err != nil {
 		return nil, err

--- a/pkg/system/cleanup.go
+++ b/pkg/system/cleanup.go
@@ -1,0 +1,42 @@
+package system
+
+import (
+	"sync"
+
+	"github.com/rs/zerolog/log"
+)
+
+// CleanupManager provides utilities for ensuring that sub-goroutines can
+// clean up their resources before the main goroutine exits. Can be used to
+// register callbacks for long-running system processes.
+type CleanupManager struct {
+	wg  sync.WaitGroup
+	fns []func() error
+}
+
+// NewCleanupManager returns a new CleanupManager instance.
+func NewCleanupManager() *CleanupManager {
+	return &CleanupManager{}
+}
+
+// RegisterCallback registers a clean-up function.
+func (cm *CleanupManager) RegisterCallback(fn func() error) {
+	cm.wg.Add(1)
+	cm.fns = append(cm.fns, fn)
+}
+
+// Cleanup runs all registered clean-up functions in sub-goroutines and
+// waits for them all to complete before exiting.
+func (cm *CleanupManager) Cleanup() {
+	for i := 0; i < len(cm.fns); i++ {
+		go func(fn func() error) {
+			defer cm.wg.Done()
+
+			if err := fn(); err != nil {
+				log.Error().Msgf("Error during clean-up callback: %v", err)
+			}
+		}(cm.fns[i])
+	}
+
+	cm.wg.Wait()
+}

--- a/pkg/system/cleanup_test.go
+++ b/pkg/system/cleanup_test.go
@@ -1,0 +1,20 @@
+package system
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCleanupManager(t *testing.T) {
+	clean := false
+
+	cm := NewCleanupManager()
+	cm.RegisterCallback(func() error {
+		clean = true
+		return nil
+	})
+
+	cm.Cleanup()
+	assert.True(t, clean, "cleanup handler failed to run registered functions")
+}

--- a/pkg/test/executor/docker_executor_test.go
+++ b/pkg/test/executor/docker_executor_test.go
@@ -29,14 +29,14 @@ func dockerExecutorStorageTest(
 		getStorageDriver scenario.IGetStorageDriver,
 	) {
 
-		stack, ctx, cancel := ipfs.SetupTest(t, TEST_NODE_COUNT)
-		defer ipfs.TeardownTest(stack, cancel)
+		stack, cm := ipfs.SetupTest(t, TEST_NODE_COUNT)
+		defer ipfs.TeardownTest(stack, cm)
 
 		storageDriver, err := getStorageDriver(stack)
 		assert.NoError(t, err)
 
 		dockerExecutor, err := docker.NewDockerExecutor(
-			ctx, "dockertest", map[string]storage.StorageProvider{
+			cm, "dockertest", map[string]storage.StorageProvider{
 				TEST_STORAGE_DRIVER_NAME: storageDriver,
 			})
 		assert.NoError(t, err)

--- a/pkg/test/ipfs/ipfs_host_storage_test.go
+++ b/pkg/test/ipfs/ipfs_host_storage_test.go
@@ -1,7 +1,6 @@
 package ipfs
 
 import (
-	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -16,13 +15,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type getStorageFunc func(ctx context.Context, api string) (
+type getStorageFunc func(cm *system.CleanupManager, api string) (
 	storage.StorageProvider, error)
 
 func runFileTest(t *testing.T, engine string, getStorageDriver getStorageFunc) {
 	// get a single IPFS server
-	stack, ctx, cancel := SetupTest(t, 1)
-	defer TeardownTest(stack, cancel)
+	stack, cm := SetupTest(t, 1)
+	defer TeardownTest(stack, cm)
 
 	// add this file to the server
 	EXAMPLE_TEXT := `hello world`
@@ -31,7 +30,7 @@ func runFileTest(t *testing.T, engine string, getStorageDriver getStorageFunc) {
 
 	// construct an ipfs docker storage client
 	ipfsNodeAddress := stack.Nodes[0].IpfsNode.ApiAddress()
-	storageDriver, err := getStorageDriver(ctx, ipfsNodeAddress)
+	storageDriver, err := getStorageDriver(cm, ipfsNodeAddress)
 	assert.NoError(t, err)
 
 	// the storage spec for the cid we added
@@ -76,8 +75,8 @@ func runFolderTest(t *testing.T, engine string,
 	assert.NoError(t, err)
 
 	// get a single IPFS server
-	stack, ctx, cancel := SetupTest(t, 1)
-	defer TeardownTest(stack, cancel)
+	stack, cm := SetupTest(t, 1)
+	defer TeardownTest(stack, cm)
 
 	// add this file to the server
 	folderCid, err := stack.AddFolderToNodes(1, dir)
@@ -85,7 +84,7 @@ func runFolderTest(t *testing.T, engine string,
 
 	// construct an ipfs docker storage client
 	ipfsNodeAddress := stack.Nodes[0].IpfsNode.ApiAddress()
-	storageDriver, err := getStorageDriver(ctx, ipfsNodeAddress)
+	storageDriver, err := getStorageDriver(cm, ipfsNodeAddress)
 	assert.NoError(t, err)
 
 	// the storage spec for the cid we added
@@ -125,10 +124,10 @@ func TestIpfsFuseDockerFile(t *testing.T) {
 	runFileTest(
 		t,
 		storage.IPFS_FUSE_DOCKER,
-		func(ctx context.Context, api string) (
+		func(cm *system.CleanupManager, api string) (
 			storage.StorageProvider, error) {
 
-			return fuse_docker.NewIpfsFuseDocker(ctx, api)
+			return fuse_docker.NewIpfsFuseDocker(cm, api)
 		},
 	)
 }
@@ -139,10 +138,10 @@ func TestIpfsFuseDockerFolder(t *testing.T) {
 	runFolderTest(
 		t,
 		storage.IPFS_FUSE_DOCKER,
-		func(ctx context.Context, api string) (
+		func(cm *system.CleanupManager, api string) (
 			storage.StorageProvider, error) {
 
-			return fuse_docker.NewIpfsFuseDocker(ctx, api)
+			return fuse_docker.NewIpfsFuseDocker(cm, api)
 		},
 	)
 
@@ -153,10 +152,10 @@ func TestIpfsApiCopyFile(t *testing.T) {
 	runFileTest(
 		t,
 		storage.IPFS_API_COPY,
-		func(ctx context.Context, api string) (
+		func(cm *system.CleanupManager, api string) (
 			storage.StorageProvider, error) {
 
-			return api_copy.NewIpfsApiCopy(ctx, api)
+			return api_copy.NewIpfsApiCopy(cm, api)
 		},
 	)
 
@@ -167,10 +166,10 @@ func TestIpfsApiCopyFolder(t *testing.T) {
 	runFolderTest(
 		t,
 		storage.IPFS_API_COPY,
-		func(ctx context.Context, api string) (
+		func(cm *system.CleanupManager, api string) (
 			storage.StorageProvider, error) {
 
-			return api_copy.NewIpfsApiCopy(ctx, api)
+			return api_copy.NewIpfsApiCopy(cm, api)
 		},
 	)
 }

--- a/pkg/test/ipfs/ipfs_httpclient_test.go
+++ b/pkg/test/ipfs/ipfs_httpclient_test.go
@@ -1,6 +1,7 @@
 package ipfs
 
 import (
+	"context"
 	"testing"
 
 	ipfs_http "github.com/filecoin-project/bacalhau/pkg/ipfs/http"
@@ -9,15 +10,15 @@ import (
 )
 
 func TestIpfsHttpClient(t *testing.T) {
-	stack, ctx, cancel := SetupTest(t, 2)
-	defer TeardownTest(stack, cancel)
+	stack, cm := SetupTest(t, 2)
+	defer TeardownTest(stack, cm)
 
 	fileCid, err := stack.AddTextToNodes(1, []byte(`hello world`))
 	assert.NoError(t, err)
 
 	// test the basic connection and that we can list the IPFS node addresses
 	ipfsMultiAddress := stack.Nodes[0].IpfsNode.ApiAddress()
-	api, err := ipfs_http.NewIPFSHttpClient(ctx, ipfsMultiAddress)
+	api, err := ipfs_http.NewIPFSHttpClient(context.TODO(), ipfsMultiAddress)
 	assert.NoError(t, err)
 
 	addrs, err := api.GetLocalAddrs()
@@ -26,7 +27,7 @@ func TestIpfsHttpClient(t *testing.T) {
 
 	assertNodeHasCid := func(cid string, nodeIndex int, expectedResult bool) {
 		api, err := ipfs_http.NewIPFSHttpClient(
-			ctx, stack.Nodes[nodeIndex].IpfsNode.ApiAddress())
+			context.TODO(), stack.Nodes[nodeIndex].IpfsNode.ApiAddress())
 		assert.NoError(t, err)
 
 		result, err := api.HasCidLocally(cid)

--- a/pkg/test/ipfs/testutils.go
+++ b/pkg/test/ipfs/testutils.go
@@ -1,7 +1,6 @@
 package ipfs
 
 import (
-	"context"
 	"testing"
 
 	"github.com/filecoin-project/bacalhau/pkg/devstack"
@@ -10,16 +9,16 @@ import (
 )
 
 func SetupTest(t *testing.T, nodes int) (
-	*devstack.DevStack_IPFS, context.Context, context.CancelFunc) {
+	*devstack.DevStack_IPFS, *system.CleanupManager) {
 
-	ctx, cancel := system.WithSignalShutdown(context.Background())
-	stack, err := devstack.NewDevStack_IPFS(ctx, nodes)
+	cm := system.NewCleanupManager()
+	stack, err := devstack.NewDevStack_IPFS(cm, nodes)
 	assert.NoError(t, err)
 
-	return stack, ctx, cancel
+	return stack, cm
 }
 
-func TeardownTest(stack *devstack.DevStack_IPFS, cancel context.CancelFunc) {
+func TeardownTest(stack *devstack.DevStack_IPFS, cm *system.CleanupManager) {
 	stack.PrintNodeInfo()
-	cancel()
+	cm.Cleanup()
 }

--- a/pkg/test/scenario/utils.go
+++ b/pkg/test/scenario/utils.go
@@ -50,14 +50,14 @@ func FuseStorageDriverFactoryHandler(stack *devstack.DevStack_IPFS) (
 	storage.StorageProvider, error) {
 
 	return fuse_docker.NewIpfsFuseDocker(
-		stack.Ctx, stack.Nodes[0].IpfsNode.ApiAddress())
+		stack.CleanupManager, stack.Nodes[0].IpfsNode.ApiAddress())
 }
 
 func ApiCopyStorageDriverFactoryHandler(stack *devstack.DevStack_IPFS) (
 	storage.StorageProvider, error) {
 
 	return api_copy.NewIpfsApiCopy(
-		stack.Ctx, stack.Nodes[0].IpfsNode.ApiAddress())
+		stack.CleanupManager, stack.Nodes[0].IpfsNode.ApiAddress())
 }
 
 var FuseStorageDriverFactory = StorageDriverFactory{

--- a/pkg/test/verifier/ipfs_verifier_test.go
+++ b/pkg/test/verifier/ipfs_verifier_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 func TestIPFSVerifier(t *testing.T) {
-	stack, ctx, cancel := SetupTest(t, 1)
-	defer TeardownTest(stack, cancel)
+	stack, cm := SetupTest(t, 1)
+	defer TeardownTest(stack, cm)
 
 	inputDir, err := ioutil.TempDir("", "bacalhau-ipfs-verifier-test")
 	assert.NoError(t, err)
@@ -26,7 +26,7 @@ func TestIPFSVerifier(t *testing.T) {
 	assert.NoError(t, err)
 
 	verifier, err := ipfs_verifier.NewIPFSVerifier(
-		ctx, stack.Nodes[0].IpfsNode.ApiAddress())
+		cm, stack.Nodes[0].IpfsNode.ApiAddress())
 	assert.NoError(t, err)
 
 	installed, err := verifier.IsInstalled()

--- a/pkg/test/verifier/utils.go
+++ b/pkg/test/verifier/utils.go
@@ -1,7 +1,6 @@
 package verifier
 
 import (
-	"context"
 	"testing"
 
 	"github.com/filecoin-project/bacalhau/pkg/devstack"
@@ -10,16 +9,16 @@ import (
 )
 
 func SetupTest(t *testing.T, nodes int) (
-	*devstack.DevStack_IPFS, context.Context, context.CancelFunc) {
+	*devstack.DevStack_IPFS, *system.CleanupManager) {
 
-	ctx, cancel := system.WithSignalShutdown(context.Background())
-	stack, err := devstack.NewDevStack_IPFS(ctx, nodes)
+	cm := system.NewCleanupManager()
+	stack, err := devstack.NewDevStack_IPFS(cm, nodes)
 	assert.NoError(t, err, "unable to create devstack")
 
-	return stack, ctx, cancel
+	return stack, cm
 }
 
-func TeardownTest(stack *devstack.DevStack_IPFS, cancel context.CancelFunc) {
+func TeardownTest(stack *devstack.DevStack_IPFS, cm *system.CleanupManager) {
 	stack.PrintNodeInfo()
-	cancel()
+	cm.Cleanup()
 }

--- a/pkg/transport/generic_transport.go
+++ b/pkg/transport/generic_transport.go
@@ -40,8 +40,7 @@ func (transport *GenericTransport) writeEvent(event *types.JobEvent) error {
 	return transport.WriteEventHandler(event)
 }
 
-func (transport *GenericTransport) ReadEvent(event *types.JobEvent) {
-
+func (transport *GenericTransport) BroadcastEvent(event *types.JobEvent) {
 	transport.Mutex.Lock()
 	defer transport.Mutex.Unlock()
 

--- a/pkg/transport/inprocess/inprocess.go
+++ b/pkg/transport/inprocess/inprocess.go
@@ -13,7 +13,6 @@ import (
 // testing purposes. Should not be used in production.
 type Transport struct {
 	id               string
-	subscribeFuncs   []func(jobEvent *types.JobEvent, job *types.Job)
 	genericTransport *transport.GenericTransport
 
 	// Public for testing purposes:

--- a/pkg/transport/interface.go
+++ b/pkg/transport/interface.go
@@ -1,56 +1,68 @@
 package transport
 
 import (
+	"context"
+
 	"github.com/filecoin-project/bacalhau/pkg/types"
 )
 
+// Transport is an interface representing a communication channel between
+// nodes, through which they can submit, bid on and complete jobs.
 type Transport interface {
-
 	/////////////////////////////////////////////////////////////
 	/// LIFECYCLE
 	/////////////////////////////////////////////////////////////
 
-	// Start the scheduler. You must call Subscribe _before_ starting.
-	Start() error
-	// A unique string per host in whatever network the scheduler is connecting
-	// to. Must be unique per instance.
-	HostId() (string, error)
+	// Start the job scheduler. Not that this is blocking and can be managed
+	// via the context parameter. You must call Subscribe _before_ starting.
+	Start(ctx context.Context) error
+
+	// HostID returns a unique string per host in whatever network the
+	// scheduler is connecting to. Must be unique per instance.
+	HostID(ctx context.Context) (string, error)
 
 	/////////////////////////////////////////////////////////////
 	/// READ OPERATIONS
 	/////////////////////////////////////////////////////////////
 
-	// List of known jobs (smart contract will have persistence; libp2p will be
-	// lossy).  JobSpec contains everything to do with a job including state,
-	// results.
-	List() (types.ListResponse, error)
-	// get a single job
-	Get(id string) (*types.Job, error)
-	// Listen for updates (subscribe with a callback) about any change to a job
+	// List returns a list of of known jobs (smart contract will have
+	// persistence; libp2p will be lossy).  JobSpec contains everything
+	// to do with a job including state, results.
+	List(ctx context.Context) (types.ListResponse, error)
+
+	// Get returns information about the given job.
+	Get(ctx context.Context, jobID string) (*types.Job, error)
+
+	// Subscribe registers a callback for updates about any change to a job
 	// or its results.  This is in-memory, global, singleton and scoped to the
 	// lifetime of the process so no need for an unsubscribe right now.
-	Subscribe(func(jobEvent *types.JobEvent, job *types.Job))
+	Subscribe(ctx context.Context, fn func(
+		jobEvent *types.JobEvent, job *types.Job))
 
 	/////////////////////////////////////////////////////////////
-	/// WRITE OPERATIONS - "CLIENT" / REQUESTER
+	/// WRITE OPERATIONS - "CLIENT" / REQUESTER NODE
 	/////////////////////////////////////////////////////////////
 
 	// Executed by the client (Connie) requesting the work, puts the job into a
 	// mempool of work that is available to be done.
-	SubmitJob(spec *types.JobSpec, deal *types.JobDeal) (*types.Job, error)
+	SubmitJob(ctx context.Context, spec *types.JobSpec,
+		deal *types.JobDeal) (*types.Job, error)
 
 	// Update the job deal - for example updating concurrency
-	UpdateDeal(jobId string, deal *types.JobDeal) error
+	UpdateDeal(ctx context.Context, jobID string, deal *types.JobDeal) error
+
 	// Client has decided they no longer want the work done. Can only happen
 	// when no runs of the job are in progress.
-	CancelJob(jobId string) error
+	CancelJob(ctx context.Context, jobID string) error
+
 	// Executed by the client (Connie) to tell Prue they are good to start.
 	// Enables coordination to avoid excess job starting, also allows client to
 	// be selective about reputation.
-	AcceptJobBid(jobId string, hostId string) error
+	AcceptJobBid(ctx context.Context, jobID, hostID string) error
+
 	// Executed by the client (Connie) to tell Prue they shouldn't try to run
 	// this job.
-	RejectJobBid(jobId, hostId, message string) error
+	RejectJobBid(ctx context.Context, jobID, hostID, message string) error
 
 	/////////////////////////////////////////////////////////////
 	/// WRITE OPERATIONS - "SERVER" / COMPUTE NODE
@@ -58,16 +70,16 @@ type Transport interface {
 
 	// Executed by the compute node (Prue) when they want to start working on a
 	// job.
-	BidJob(jobId string) error
+	BidJob(ctx context.Context, jobID string) error
 
 	// Executed by the compute node when they have completed a job.
-	SubmitResult(jobId, status, resultsId string) error
+	SubmitResult(ctx context.Context, jobID, status, resultsID string) error
 
 	// something has gone wrong with running the job
-	// called by the compute node and so will have the nodeId auto-filled
-	ErrorJob(jobId string, status string) error
+	// called by the compute node and so will have the nodeID auto-filled
+	ErrorJob(ctx context.Context, jobID, status string) error
 
 	// something has gone wrong is checking the job from the requester node
-	// called by the requester node and so we need to be given the nodeId
-	ErrorJobForNode(jobId string, nodeId string, status string) error
+	// called by the requester node and so we need to be given the nodeID.
+	ErrorJobForNode(ctx context.Context, jobID, nodeID, status string) error
 }

--- a/pkg/verifier/ipfs/verifier.go
+++ b/pkg/verifier/ipfs/verifier.go
@@ -4,21 +4,19 @@ import (
 	"context"
 
 	ipfs_http "github.com/filecoin-project/bacalhau/pkg/ipfs/http"
+	"github.com/filecoin-project/bacalhau/pkg/system"
 	"github.com/filecoin-project/bacalhau/pkg/types"
 	"github.com/rs/zerolog/log"
 )
 
 type IPFSVerifier struct {
-	// Lifecycle context for verifier:
-	ctx context.Context
-
 	IPFSClient *ipfs_http.IPFSHttpClient
 }
 
-func NewIPFSVerifier(ctx context.Context, ipfsMultiAddress string) (
+func NewIPFSVerifier(cm *system.CleanupManager, ipfsMultiAddress string) (
 	*IPFSVerifier, error) {
 
-	api, err := ipfs_http.NewIPFSHttpClient(ctx, ipfsMultiAddress)
+	api, err := ipfs_http.NewIPFSHttpClient(context.TODO(), ipfsMultiAddress)
 	if err != nil {
 		return nil, err
 	}
@@ -29,7 +27,6 @@ func NewIPFSVerifier(ctx context.Context, ipfsMultiAddress string) (
 	}
 
 	verifier := &IPFSVerifier{
-		ctx:        ctx,
 		IPFSClient: api,
 	}
 

--- a/pkg/verifier/utils.go
+++ b/pkg/verifier/utils.go
@@ -1,13 +1,12 @@
 package verifier
 
 import (
-	"context"
-
+	"github.com/filecoin-project/bacalhau/pkg/system"
 	"github.com/filecoin-project/bacalhau/pkg/verifier/ipfs"
 	"github.com/filecoin-project/bacalhau/pkg/verifier/noop"
 )
 
-func NewIPFSVerifiers(ctx context.Context, ipfsMultiAddress string) (
+func NewIPFSVerifiers(cm *system.CleanupManager, ipfsMultiAddress string) (
 	map[string]Verifier, error) {
 
 	noopVerifier, err := noop.NewNoopVerifier()
@@ -15,7 +14,7 @@ func NewIPFSVerifiers(ctx context.Context, ipfsMultiAddress string) (
 		return nil, err
 	}
 
-	ipfsVerifier, err := ipfs.NewIPFSVerifier(ctx, ipfsMultiAddress)
+	ipfsVerifier, err := ipfs.NewIPFSVerifier(cm, ipfsMultiAddress)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
See #228. I've implemented a CleanupManager that the various nodes can use to
register clean-up routines when the main goroutine exits, fixing the leakage
bug in a (hopefully) more robust way. Every API in the Transport interface now
takes contexts as an argument so we can thread traces.
