### PR TITLE
Refactor remaining interfaces to use contexts.

### DIFF
--- a/cmd/bacalhau/devstack.go
+++ b/cmd/bacalhau/devstack.go
@@ -6,9 +6,10 @@ import (
 
 	"github.com/filecoin-project/bacalhau/pkg/devstack"
 	"github.com/filecoin-project/bacalhau/pkg/executor"
-	"github.com/filecoin-project/bacalhau/pkg/executor/util"
+	executor_util "github.com/filecoin-project/bacalhau/pkg/executor/util"
 	"github.com/filecoin-project/bacalhau/pkg/system"
 	"github.com/filecoin-project/bacalhau/pkg/verifier"
+	verifier_util "github.com/filecoin-project/bacalhau/pkg/verifier/util"
 
 	"github.com/spf13/cobra"
 )
@@ -43,12 +44,17 @@ var devstackCmd = &cobra.Command{
 		ctx, cancel := system.WithSignalShutdown(context.Background())
 		defer cancel()
 
-		getExecutors := func(ipfsMultiAddress string, nodeIndex int) (map[string]executor.Executor, error) {
-			return util.NewDockerIPFSExecutors(cm, ipfsMultiAddress, fmt.Sprintf("devstacknode%d", nodeIndex))
+		getExecutors := func(ipfsMultiAddress string, nodeIndex int) (
+			map[string]executor.Executor, error) {
+
+			return executor_util.NewDockerIPFSExecutors(cm,
+				ipfsMultiAddress, fmt.Sprintf("devstacknode%d", nodeIndex))
 		}
 
-		getVerifiers := func(ipfsMultiAddress string, nodeIndex int) (map[string]verifier.Verifier, error) {
-			return verifier.NewIPFSVerifiers(cm, ipfsMultiAddress)
+		getVerifiers := func(ipfsMultiAddress string, nodeIndex int) (
+			map[string]verifier.Verifier, error) {
+
+			return verifier_util.NewIPFSVerifiers(cm, ipfsMultiAddress)
 		}
 
 		stack, err := devstack.NewDevStack(

--- a/cmd/bacalhau/devstack.go
+++ b/cmd/bacalhau/devstack.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/filecoin-project/bacalhau/pkg/devstack"
 	"github.com/filecoin-project/bacalhau/pkg/executor"
+	"github.com/filecoin-project/bacalhau/pkg/executor/util"
 	"github.com/filecoin-project/bacalhau/pkg/system"
 	"github.com/filecoin-project/bacalhau/pkg/verifier"
 
@@ -43,7 +44,7 @@ var devstackCmd = &cobra.Command{
 		defer cancel()
 
 		getExecutors := func(ipfsMultiAddress string, nodeIndex int) (map[string]executor.Executor, error) {
-			return executor.NewDockerIPFSExecutors(cm, ipfsMultiAddress, fmt.Sprintf("devstacknode%d", nodeIndex))
+			return util.NewDockerIPFSExecutors(cm, ipfsMultiAddress, fmt.Sprintf("devstacknode%d", nodeIndex))
 		}
 
 		getVerifiers := func(ipfsMultiAddress string, nodeIndex int) (map[string]verifier.Verifier, error) {

--- a/cmd/bacalhau/serve.go
+++ b/cmd/bacalhau/serve.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 
 	"github.com/filecoin-project/bacalhau/pkg/compute_node"
-	"github.com/filecoin-project/bacalhau/pkg/executor/util"
+	executor_util "github.com/filecoin-project/bacalhau/pkg/executor/util"
 	"github.com/filecoin-project/bacalhau/pkg/publicapi"
 	"github.com/filecoin-project/bacalhau/pkg/requestor_node"
 	"github.com/filecoin-project/bacalhau/pkg/system"
 	"github.com/filecoin-project/bacalhau/pkg/transport/libp2p"
-	"github.com/filecoin-project/bacalhau/pkg/verifier"
+	verifier_util "github.com/filecoin-project/bacalhau/pkg/verifier/util"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
@@ -71,13 +71,13 @@ var serveCmd = &cobra.Command{
 			return err
 		}
 
-		executors, err := util.NewDockerIPFSExecutors(cm, ipfsConnect,
+		executors, err := executor_util.NewDockerIPFSExecutors(cm, ipfsConnect,
 			fmt.Sprintf("bacalhau-%s", transport.Host.ID().String()))
 		if err != nil {
 			return err
 		}
 
-		verifiers, err := verifier.NewIPFSVerifiers(cm, ipfsConnect)
+		verifiers, err := verifier_util.NewIPFSVerifiers(cm, ipfsConnect)
 		if err != nil {
 			return err
 		}

--- a/cmd/bacalhau/serve.go
+++ b/cmd/bacalhau/serve.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/filecoin-project/bacalhau/pkg/compute_node"
-	"github.com/filecoin-project/bacalhau/pkg/executor"
+	"github.com/filecoin-project/bacalhau/pkg/executor/util"
 	"github.com/filecoin-project/bacalhau/pkg/publicapi"
 	"github.com/filecoin-project/bacalhau/pkg/requestor_node"
 	"github.com/filecoin-project/bacalhau/pkg/system"
@@ -71,7 +71,7 @@ var serveCmd = &cobra.Command{
 			return err
 		}
 
-		executors, err := executor.NewDockerIPFSExecutors(cm, ipfsConnect,
+		executors, err := util.NewDockerIPFSExecutors(cm, ipfsConnect,
 			fmt.Sprintf("bacalhau-%s", transport.Host.ID().String()))
 		if err != nil {
 			return err

--- a/pkg/compute_node/compute_node.go
+++ b/pkg/compute_node/compute_node.go
@@ -72,7 +72,6 @@ func NewComputeNode(
 
 		// we have been given the goahead to run the job
 		case system.JOB_EVENT_BID_ACCEPTED:
-
 			// we only care if the accepted bid is for us
 			if jobEvent.NodeId != nodeId {
 				return
@@ -81,7 +80,6 @@ func NewComputeNode(
 			log.Debug().Msgf("Bid accepted: Server (id: %s) - Job (id: %s)", nodeId, job.Id)
 
 			resultFolder, err := computeNode.RunJob(job)
-
 			if err != nil {
 				log.Error().Msgf("Error running the job: %s %+v", err, job)
 				_ = transport.ErrorJob(ctx, job.Id, fmt.Sprintf("Error running the job: %s", err))
@@ -89,15 +87,14 @@ func NewComputeNode(
 			}
 
 			verifier, err := computeNode.getVerifier(job.Spec.Verifier)
-
 			if err != nil {
 				log.Error().Msgf("Error geting the verifier for the job: %s %+v", err, job)
 				_ = transport.ErrorJob(ctx, job.Id, fmt.Sprintf("Error geting the verifier for the job: %s", err))
 				return
 			}
 
-			resultValue, err := verifier.ProcessResultsFolder(job, resultFolder)
-
+			resultValue, err := verifier.ProcessResultsFolder(
+				context.TODO(), job, resultFolder)
 			if err != nil {
 				log.Error().Msgf("Error verifying results: %s %+v", err, job)
 				_ = transport.ErrorJob(ctx, job.Id, fmt.Sprintf("Error verifying results: %s", err))
@@ -110,7 +107,6 @@ func NewComputeNode(
 				fmt.Sprintf("Got job result: %s", resultValue),
 				resultValue,
 			)
-
 			if err != nil {
 				log.Error().Msgf("Error submitting result: %s %+v", err, job)
 				_ = transport.ErrorJob(ctx, job.Id, fmt.Sprintf("Error running the job: %s", err))
@@ -207,7 +203,7 @@ func (node *ComputeNode) getVerifier(name string) (verifier.Verifier, error) {
 		return nil, fmt.Errorf("No matching verifier found on this server: %s.", name)
 	}
 	verifier := node.Verifiers[name]
-	installed, err := verifier.IsInstalled()
+	installed, err := verifier.IsInstalled(context.TODO())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/compute_node/compute_node.go
+++ b/pkg/compute_node/compute_node.go
@@ -153,7 +153,7 @@ func (node *ComputeNode) SelectJob(job *types.JobSpec) (bool, error) {
 	for _, input := range job.Inputs {
 
 		// see if the storage engine reports that we have the resource locally
-		hasStorage, err := executor.HasStorage(input)
+		hasStorage, err := executor.HasStorage(context.TODO(), input)
 		if err != nil {
 			log.Error().Msgf("Error checking for storage resource locality: %s", err.Error())
 			return false, err
@@ -178,7 +178,7 @@ func (node *ComputeNode) RunJob(job *types.Job) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return executor.RunJob(job)
+	return executor.RunJob(context.TODO(), job)
 }
 
 func (node *ComputeNode) getExecutor(name string) (executor.Executor, error) {
@@ -189,7 +189,7 @@ func (node *ComputeNode) getExecutor(name string) (executor.Executor, error) {
 		return nil, fmt.Errorf("No matching executor found on this server: %s.", name)
 	}
 	executorEngine := node.Executors[name]
-	installed, err := executorEngine.IsInstalled()
+	installed, err := executorEngine.IsInstalled(context.TODO())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/executor/docker/executor.go
+++ b/pkg/executor/docker/executor.go
@@ -12,13 +12,14 @@ import (
 	"github.com/docker/docker/api/types/network"
 	dockerclient "github.com/docker/docker/client"
 	"github.com/filecoin-project/bacalhau/pkg/docker"
+	"github.com/filecoin-project/bacalhau/pkg/executor"
 	"github.com/filecoin-project/bacalhau/pkg/storage"
 	"github.com/filecoin-project/bacalhau/pkg/system"
 	"github.com/filecoin-project/bacalhau/pkg/types"
 	"github.com/rs/zerolog/log"
 )
 
-type DockerExecutor struct {
+type Executor struct {
 	// used to allow multiple docker executors to run against the same docker server
 	Id string
 
@@ -31,11 +32,11 @@ type DockerExecutor struct {
 	Client *dockerclient.Client
 }
 
-func NewDockerExecutor(
+func NewExecutor(
 	cm *system.CleanupManager,
 	id string,
 	storageProviders map[string]storage.StorageProvider,
-) (*DockerExecutor, error) {
+) (*Executor, error) {
 	dockerClient, err := docker.NewDockerClient()
 	if err != nil {
 		return nil, err
@@ -46,7 +47,7 @@ func NewDockerExecutor(
 		return nil, err
 	}
 
-	de := &DockerExecutor{
+	de := &Executor{
 		Id:               id,
 		ResultsDir:       dir,
 		StorageProviders: storageProviders,
@@ -61,21 +62,22 @@ func NewDockerExecutor(
 	return de, nil
 }
 
-func (dockerExecutor *DockerExecutor) getStorageProvider(engine string) (
+func (e *Executor) getStorageProvider(engine string) (
 	storage.StorageProvider, error) {
 
-	return storage.GetStorageProvider(engine, dockerExecutor.StorageProviders)
+	return storage.GetStorageProvider(engine, e.StorageProviders)
 }
 
 // IsInstalled checks if docker itself is installed.
-func (dockerExecutor *DockerExecutor) IsInstalled() (bool, error) {
-	return docker.IsInstalled(dockerExecutor.Client), nil
+func (e *Executor) IsInstalled(ctx context.Context) (bool, error) {
+
+	return docker.IsInstalled(e.Client), nil
 }
 
-func (dockerExecutor *DockerExecutor) HasStorage(volume types.StorageSpec) (
+func (e *Executor) HasStorage(ctx context.Context, volume types.StorageSpec) (
 	bool, error) {
 
-	storage, err := dockerExecutor.getStorageProvider(volume.Engine)
+	storage, err := e.getStorageProvider(volume.Engine)
 	if err != nil {
 		return false, err
 	}
@@ -83,13 +85,15 @@ func (dockerExecutor *DockerExecutor) HasStorage(volume types.StorageSpec) (
 	return storage.HasStorage(volume)
 }
 
-func (dockerExecutor *DockerExecutor) RunJob(job *types.Job) (string, error) {
+func (e *Executor) RunJob(ctx context.Context, job *types.Job) (
+	string, error) {
+
 	spec := job.Spec
 	if spec == nil {
 		return "", fmt.Errorf("no job spec provided to docker executor")
 	}
 
-	jobResultsDir, err := dockerExecutor.ensureJobResultsDir(job)
+	jobResultsDir, err := e.ensureJobResultsDir(job)
 	if err != nil {
 		return "", err
 	}
@@ -100,7 +104,7 @@ func (dockerExecutor *DockerExecutor) RunJob(job *types.Job) (string, error) {
 
 	// loop over the job storage inputs and prepare them
 	for _, inputStorage := range job.Spec.Inputs {
-		storageProvider, err := dockerExecutor.getStorageProvider(
+		storageProvider, err := e.getStorageProvider(
 			inputStorage.Engine)
 		if err != nil {
 			return "", err
@@ -171,7 +175,7 @@ func (dockerExecutor *DockerExecutor) RunJob(job *types.Job) (string, error) {
 
 	if os.Getenv("SKIP_IMAGE_PULL") == "" {
 		// TODO: work out why this does not work in github actions
-		// err = docker.PullImage(dockerExecutor.Client, job.Spec.Vm.Image)
+		// err = docker.PullImage(e.Client, job.Spec.Vm.Image)
 
 		// if err != nil {
 		// 	return "", err
@@ -193,13 +197,13 @@ func (dockerExecutor *DockerExecutor) RunJob(job *types.Job) (string, error) {
 		Tty:             false,
 		Env:             job.Spec.Vm.Env,
 		Entrypoint:      job.Spec.Vm.Entrypoint,
-		Labels:          dockerExecutor.jobContainerLabels(job),
+		Labels:          e.jobContainerLabels(job),
 		NetworkDisabled: true,
 	}
 
 	log.Trace().Msgf("Container: %+v %+v", containerConfig, mounts)
 
-	jobContainer, err := dockerExecutor.Client.ContainerCreate(
+	jobContainer, err := e.Client.ContainerCreate(
 		context.TODO(),
 		containerConfig,
 		&container.HostConfig{
@@ -207,14 +211,14 @@ func (dockerExecutor *DockerExecutor) RunJob(job *types.Job) (string, error) {
 		},
 		&network.NetworkingConfig{},
 		nil,
-		dockerExecutor.jobContainerName(job),
+		e.jobContainerName(job),
 	)
 	if err != nil {
 		return "", err
 	}
 
-	defer dockerExecutor.cleanupJob(job)
-	err = dockerExecutor.Client.ContainerStart(
+	defer e.cleanupJob(job)
+	err = e.Client.ContainerStart(
 		context.TODO(),
 		jobContainer.ID,
 		dockertypes.ContainerStartOptions{},
@@ -226,12 +230,12 @@ func (dockerExecutor *DockerExecutor) RunJob(job *types.Job) (string, error) {
 	// TODO: we should record all logs and as much diagnostics as possible
 	// in the error case so a user can debug why their job failed
 	handleErrorLogs := func() {
-		stdout, stderr, _ := docker.GetLogs(dockerExecutor.Client, jobContainer.ID)
+		stdout, stderr, _ := docker.GetLogs(e.Client, jobContainer.ID)
 		log.Error().Msgf("Container stdout: %s", stdout)
 		log.Error().Msgf("Container stderr: %s", stderr)
 	}
 
-	statusCh, errCh := dockerExecutor.Client.ContainerWait(
+	statusCh, errCh := e.Client.ContainerWait(
 		context.TODO(),
 		jobContainer.ID,
 		container.WaitConditionNotRunning,
@@ -255,7 +259,7 @@ func (dockerExecutor *DockerExecutor) RunJob(job *types.Job) (string, error) {
 
 	log.Debug().Msgf("Container stopped: %s", jobContainer.ID)
 
-	stdout, stderr, err := docker.GetLogs(dockerExecutor.Client, jobContainer.ID)
+	stdout, stderr, err := docker.GetLogs(e.Client, jobContainer.ID)
 	if err != nil {
 		return "", err
 	}
@@ -273,49 +277,52 @@ func (dockerExecutor *DockerExecutor) RunJob(job *types.Job) (string, error) {
 	return jobResultsDir, nil
 }
 
-func (dockerExecutor *DockerExecutor) cleanupJob(job *types.Job) {
+func (e *Executor) cleanupJob(job *types.Job) {
 	if system.ShouldKeepStack() {
 		return
 	}
-	err := docker.RemoveContainer(dockerExecutor.Client, dockerExecutor.jobContainerName(job))
+	err := docker.RemoveContainer(e.Client, e.jobContainerName(job))
 	if err != nil {
 		log.Error().Msgf("Docker remove container error: %s", err.Error())
 	}
 }
 
-func (dockerExecutor *DockerExecutor) cleanupAll() {
+func (e *Executor) cleanupAll() {
 	if system.ShouldKeepStack() {
 		return
 	}
-	containersWithLabel, err := docker.GetContainersWithLabel(dockerExecutor.Client, "bacalhau-executor", dockerExecutor.Id)
+	containersWithLabel, err := docker.GetContainersWithLabel(e.Client, "bacalhau-executor", e.Id)
 	if err != nil {
 		log.Error().Msgf("Docker executor stop error: %s", err.Error())
 		return
 	}
 	for _, container := range containersWithLabel {
-		err = docker.RemoveContainer(dockerExecutor.Client, container.ID)
+		err = docker.RemoveContainer(e.Client, container.ID)
 		if err != nil {
 			log.Error().Msgf("Docker remove container error: %s", err.Error())
 		}
 	}
 }
 
-func (dockerExecutor *DockerExecutor) jobContainerName(job *types.Job) string {
-	return fmt.Sprintf("bacalhau-%s-%s", dockerExecutor.Id, job.Id)
+func (e *Executor) jobContainerName(job *types.Job) string {
+	return fmt.Sprintf("bacalhau-%s-%s", e.Id, job.Id)
 }
 
-func (dockerExecutor *DockerExecutor) jobContainerLabels(job *types.Job) map[string]string {
+func (e *Executor) jobContainerLabels(job *types.Job) map[string]string {
 	return map[string]string{
-		"bacalhau-executor": dockerExecutor.Id,
+		"bacalhau-executor": e.Id,
 	}
 }
 
-func (dockerExecutor *DockerExecutor) jobResultsDir(job *types.Job) string {
-	return fmt.Sprintf("%s/%s", dockerExecutor.ResultsDir, job.Id)
+func (e *Executor) jobResultsDir(job *types.Job) string {
+	return fmt.Sprintf("%s/%s", e.ResultsDir, job.Id)
 }
 
-func (dockerExecutor *DockerExecutor) ensureJobResultsDir(job *types.Job) (string, error) {
-	dir := dockerExecutor.jobResultsDir(job)
+func (e *Executor) ensureJobResultsDir(job *types.Job) (string, error) {
+	dir := e.jobResultsDir(job)
 	err := os.MkdirAll(dir, 0777)
 	return dir, err
 }
+
+// Compile-time check that Executor implements the Executor interface.
+var _ executor.Executor = (*Executor)(nil)

--- a/pkg/executor/docker/executor.go
+++ b/pkg/executor/docker/executor.go
@@ -14,6 +14,7 @@ import (
 	"github.com/filecoin-project/bacalhau/pkg/docker"
 	"github.com/filecoin-project/bacalhau/pkg/executor"
 	"github.com/filecoin-project/bacalhau/pkg/storage"
+	storage_util "github.com/filecoin-project/bacalhau/pkg/storage/util"
 	"github.com/filecoin-project/bacalhau/pkg/system"
 	"github.com/filecoin-project/bacalhau/pkg/types"
 	"github.com/rs/zerolog/log"
@@ -65,7 +66,7 @@ func NewExecutor(
 func (e *Executor) getStorageProvider(engine string) (
 	storage.StorageProvider, error) {
 
-	return storage.GetStorageProvider(engine, e.StorageProviders)
+	return storage_util.GetStorageProvider(engine, e.StorageProviders)
 }
 
 // IsInstalled checks if docker itself is installed.
@@ -82,7 +83,7 @@ func (e *Executor) HasStorage(ctx context.Context, volume types.StorageSpec) (
 		return false, err
 	}
 
-	return storage.HasStorage(volume)
+	return storage.HasStorage(ctx, volume)
 }
 
 func (e *Executor) RunJob(ctx context.Context, job *types.Job) (
@@ -110,7 +111,7 @@ func (e *Executor) RunJob(ctx context.Context, job *types.Job) (
 			return "", err
 		}
 
-		volumeMount, err := storageProvider.PrepareStorage(inputStorage)
+		volumeMount, err := storageProvider.PrepareStorage(ctx, inputStorage)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/executor/interface.go
+++ b/pkg/executor/interface.go
@@ -1,18 +1,22 @@
 package executor
 
 import (
+	"context"
+
 	"github.com/filecoin-project/bacalhau/pkg/types"
 )
 
+// Executor is an interface representing something that can execute jobs
+// on some kind of backend, such as a docker daemon.
 type Executor interface {
 	// tells you if the required software is installed on this machine
 	// this is used in job selection
-	IsInstalled() (bool, error)
+	IsInstalled(ctx context.Context) (bool, error)
 
 	// used to filter and select jobs
-	HasStorage(volume types.StorageSpec) (bool, error)
+	HasStorage(ctx context.Context, volume types.StorageSpec) (bool, error)
 
 	// run the given job - it's expected that we have already prepared the job
 	// this will return a local filesystem path to the jobs results
-	RunJob(job *types.Job) (string, error)
+	RunJob(ctx context.Context, job *types.Job) (string, error)
 }

--- a/pkg/executor/noop/executor.go
+++ b/pkg/executor/noop/executor.go
@@ -1,29 +1,39 @@
-package noop
+package e
 
 import (
+	"context"
+
+	"github.com/filecoin-project/bacalhau/pkg/executor"
 	"github.com/filecoin-project/bacalhau/pkg/types"
 )
 
-type NoopExecutor struct {
+type Executor struct {
 	Jobs []*types.Job
 }
 
-func NewNoopExecutor() (*NoopExecutor, error) {
-	NoopExecutor := &NoopExecutor{
+func NewExecutor() (*Executor, error) {
+	Executor := &Executor{
 		Jobs: []*types.Job{},
 	}
-	return NoopExecutor, nil
+	return Executor, nil
 }
 
-func (noop *NoopExecutor) IsInstalled() (bool, error) {
+func (e *Executor) IsInstalled(ctx context.Context) (bool, error) {
 	return true, nil
 }
 
-func (noop *NoopExecutor) HasStorage(volume types.StorageSpec) (bool, error) {
+func (e *Executor) HasStorage(ctx context.Context,
+	volume types.StorageSpec) (bool, error) {
+
 	return true, nil
 }
 
-func (noop *NoopExecutor) RunJob(job *types.Job) (string, error) {
-	noop.Jobs = append(noop.Jobs, job)
+func (e *Executor) RunJob(ctx context.Context, job *types.Job) (
+	string, error) {
+
+	e.Jobs = append(e.Jobs, job)
 	return "", nil
 }
+
+// Compile-time check that Executor implements the Executor interface.
+var _ executor.Executor = (*Executor)(nil)

--- a/pkg/executor/util/utils.go
+++ b/pkg/executor/util/utils.go
@@ -1,6 +1,7 @@
-package executor
+package util
 
 import (
+	"github.com/filecoin-project/bacalhau/pkg/executor"
 	"github.com/filecoin-project/bacalhau/pkg/executor/docker"
 	"github.com/filecoin-project/bacalhau/pkg/storage"
 	"github.com/filecoin-project/bacalhau/pkg/storage/ipfs/api_copy"
@@ -9,7 +10,7 @@ import (
 )
 
 func NewDockerIPFSExecutors(cm *system.CleanupManager, ipfsMultiAddress string,
-	dockerId string) (map[string]Executor, error) {
+	dockerId string) (map[string]executor.Executor, error) {
 
 	ipfsFuseStorage, err := fuse_docker.NewIpfsFuseDocker(cm, ipfsMultiAddress)
 	if err != nil {
@@ -21,7 +22,7 @@ func NewDockerIPFSExecutors(cm *system.CleanupManager, ipfsMultiAddress string,
 		return nil, err
 	}
 
-	dockerExecutor, err := docker.NewDockerExecutor(cm, dockerId,
+	ex, err := docker.NewExecutor(cm, dockerId,
 		map[string]storage.StorageProvider{
 			storage.IPFS_FUSE_DOCKER: ipfsFuseStorage,
 			storage.IPFS_API_COPY:    ipfsApiCopyStorage,
@@ -33,7 +34,7 @@ func NewDockerIPFSExecutors(cm *system.CleanupManager, ipfsMultiAddress string,
 		return nil, err
 	}
 
-	return map[string]Executor{
-		string(EXECUTOR_DOCKER): dockerExecutor,
+	return map[string]executor.Executor{
+		string(executor.EXECUTOR_DOCKER): ex,
 	}, nil
 }

--- a/pkg/executor/util/utils.go
+++ b/pkg/executor/util/utils.go
@@ -12,12 +12,12 @@ import (
 func NewDockerIPFSExecutors(cm *system.CleanupManager, ipfsMultiAddress string,
 	dockerId string) (map[string]executor.Executor, error) {
 
-	ipfsFuseStorage, err := fuse_docker.NewIpfsFuseDocker(cm, ipfsMultiAddress)
+	ipfsFuseStorage, err := fuse_docker.NewStorageProvider(cm, ipfsMultiAddress)
 	if err != nil {
 		return nil, err
 	}
 
-	ipfsApiCopyStorage, err := api_copy.NewIpfsApiCopy(cm, ipfsMultiAddress)
+	ipfsApiCopyStorage, err := api_copy.NewStorageProvider(cm, ipfsMultiAddress)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/interface.go
+++ b/pkg/storage/interface.go
@@ -1,12 +1,20 @@
 package storage
 
 import (
+	"context"
+
 	"github.com/filecoin-project/bacalhau/pkg/types"
 )
 
 type StorageProvider interface {
-	IsInstalled() (bool, error)
-	HasStorage(storageSpec types.StorageSpec) (bool, error)
-	PrepareStorage(storageSpec types.StorageSpec) (*types.StorageVolume, error)
-	CleanupStorage(storageSpec types.StorageSpec, volume *types.StorageVolume) error
+	IsInstalled(ctx context.Context) (bool, error)
+
+	HasStorage(ctx context.Context, storageSpec types.StorageSpec) (
+		bool, error)
+
+	PrepareStorage(ctx context.Context, storageSpec types.StorageSpec) (
+		*types.StorageVolume, error)
+
+	CleanupStorage(ctx context.Context, storageSpec types.StorageSpec,
+		volume *types.StorageVolume) error
 }

--- a/pkg/storage/util/utils.go
+++ b/pkg/storage/util/utils.go
@@ -1,18 +1,28 @@
-package storage
+package util
 
-import "fmt"
+import (
+	"context"
+	"fmt"
 
-func GetStorageProvider(engine string, providers map[string]StorageProvider) (StorageProvider, error) {
+	"github.com/filecoin-project/bacalhau/pkg/storage"
+)
+
+func GetStorageProvider(engine string,
+	providers map[string]storage.StorageProvider) (
+	storage.StorageProvider, error) {
+
 	if _, ok := providers[engine]; !ok {
 		return nil, fmt.Errorf("No matching storage provider found: %s.", engine)
 	}
+
 	storageProvider := providers[engine]
-	installed, err := storageProvider.IsInstalled()
+	installed, err := storageProvider.IsInstalled(context.TODO())
 	if err != nil {
 		return nil, err
 	}
 	if !installed {
 		return nil, fmt.Errorf("Storage provider is not installed: %s.", engine)
 	}
+
 	return storageProvider, nil
 }

--- a/pkg/test/devstack/devstack_test.go
+++ b/pkg/test/devstack/devstack_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/filecoin-project/bacalhau/pkg/devstack"
 	"github.com/filecoin-project/bacalhau/pkg/executor"
+	"github.com/filecoin-project/bacalhau/pkg/executor/util"
 	ipfs_http "github.com/filecoin-project/bacalhau/pkg/ipfs/http"
 	_ "github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/publicapi"
@@ -31,7 +32,7 @@ func SetupTest(t *testing.T, nodes int, badActors int) (
 	getExecutors := func(ipfsMultiAddress string, nodeIndex int) (
 		map[string]executor.Executor, error) {
 
-		return executor.NewDockerIPFSExecutors(
+		return util.NewDockerIPFSExecutors(
 			cm, ipfsMultiAddress, fmt.Sprintf("devstacknode%d", nodeIndex))
 	}
 	getVerifiers := func(ipfsMultiAddress string, nodeIndex int) (

--- a/pkg/test/devstack/devstack_test.go
+++ b/pkg/test/devstack/devstack_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/filecoin-project/bacalhau/pkg/devstack"
 	"github.com/filecoin-project/bacalhau/pkg/executor"
-	"github.com/filecoin-project/bacalhau/pkg/executor/util"
+	executor_util "github.com/filecoin-project/bacalhau/pkg/executor/util"
 	ipfs_http "github.com/filecoin-project/bacalhau/pkg/ipfs/http"
 	_ "github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/publicapi"
@@ -17,6 +17,7 @@ import (
 	"github.com/filecoin-project/bacalhau/pkg/test/scenario"
 	"github.com/filecoin-project/bacalhau/pkg/types"
 	"github.com/filecoin-project/bacalhau/pkg/verifier"
+	verifier_util "github.com/filecoin-project/bacalhau/pkg/verifier/util"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -32,13 +33,13 @@ func SetupTest(t *testing.T, nodes int, badActors int) (
 	getExecutors := func(ipfsMultiAddress string, nodeIndex int) (
 		map[string]executor.Executor, error) {
 
-		return util.NewDockerIPFSExecutors(
+		return executor_util.NewDockerIPFSExecutors(
 			cm, ipfsMultiAddress, fmt.Sprintf("devstacknode%d", nodeIndex))
 	}
 	getVerifiers := func(ipfsMultiAddress string, nodeIndex int) (
 		map[string]verifier.Verifier, error) {
 
-		return verifier.NewIPFSVerifiers(cm, ipfsMultiAddress)
+		return verifier_util.NewIPFSVerifiers(cm, ipfsMultiAddress)
 	}
 	stack, err := devstack.NewDevStack(
 		cm,

--- a/pkg/test/ipfs/ipfs_host_storage_test.go
+++ b/pkg/test/ipfs/ipfs_host_storage_test.go
@@ -1,6 +1,7 @@
 package ipfs
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -41,12 +42,12 @@ func runFileTest(t *testing.T, engine string, getStorageDriver getStorageFunc) {
 	}
 
 	// does the storage client think we have the cid locally?
-	hasCid, err := storageDriver.HasStorage(storage)
+	hasCid, err := storageDriver.HasStorage(context.TODO(), storage)
 	assert.NoError(t, err)
 	assert.True(t, hasCid)
 
 	// this should start a sidecar container with a fuse mount
-	volume, err := storageDriver.PrepareStorage(storage)
+	volume, err := storageDriver.PrepareStorage(context.TODO(), storage)
 	assert.NoError(t, err)
 
 	// we should now be able to read our file content
@@ -60,7 +61,7 @@ func runFileTest(t *testing.T, engine string, getStorageDriver getStorageFunc) {
 
 	fmt.Printf("HERE IS RESULTS: %s\n", result)
 
-	err = storageDriver.CleanupStorage(storage, volume)
+	err = storageDriver.CleanupStorage(context.TODO(), storage, volume)
 	assert.NoError(t, err)
 }
 
@@ -95,12 +96,12 @@ func runFolderTest(t *testing.T, engine string,
 	}
 
 	// does the storage client think we have the cid locally?
-	hasCid, err := storageDriver.HasStorage(storage)
+	hasCid, err := storageDriver.HasStorage(context.TODO(), storage)
 	assert.NoError(t, err)
 	assert.True(t, hasCid)
 
 	// this should start a sidecar container with a fuse mount
-	volume, err := storageDriver.PrepareStorage(storage)
+	volume, err := storageDriver.PrepareStorage(context.TODO(), storage)
 	assert.NoError(t, err)
 
 	// we should now be able to read our file content
@@ -114,7 +115,7 @@ func runFolderTest(t *testing.T, engine string,
 
 	fmt.Printf("HERE IS RESULTS: %s\n", result)
 
-	err = storageDriver.CleanupStorage(storage, volume)
+	err = storageDriver.CleanupStorage(context.TODO(), storage, volume)
 	assert.NoError(t, err)
 }
 
@@ -127,7 +128,7 @@ func TestIpfsFuseDockerFile(t *testing.T) {
 		func(cm *system.CleanupManager, api string) (
 			storage.StorageProvider, error) {
 
-			return fuse_docker.NewIpfsFuseDocker(cm, api)
+			return fuse_docker.NewStorageProvider(cm, api)
 		},
 	)
 }
@@ -141,7 +142,7 @@ func TestIpfsFuseDockerFolder(t *testing.T) {
 		func(cm *system.CleanupManager, api string) (
 			storage.StorageProvider, error) {
 
-			return fuse_docker.NewIpfsFuseDocker(cm, api)
+			return fuse_docker.NewStorageProvider(cm, api)
 		},
 	)
 
@@ -155,7 +156,7 @@ func TestIpfsApiCopyFile(t *testing.T) {
 		func(cm *system.CleanupManager, api string) (
 			storage.StorageProvider, error) {
 
-			return api_copy.NewIpfsApiCopy(cm, api)
+			return api_copy.NewStorageProvider(cm, api)
 		},
 	)
 
@@ -169,7 +170,7 @@ func TestIpfsApiCopyFolder(t *testing.T) {
 		func(cm *system.CleanupManager, api string) (
 			storage.StorageProvider, error) {
 
-			return api_copy.NewIpfsApiCopy(cm, api)
+			return api_copy.NewStorageProvider(cm, api)
 		},
 	)
 }

--- a/pkg/test/scenario/utils.go
+++ b/pkg/test/scenario/utils.go
@@ -49,14 +49,14 @@ type IGetJobSpec func() types.JobSpecVm
 func FuseStorageDriverFactoryHandler(stack *devstack.DevStack_IPFS) (
 	storage.StorageProvider, error) {
 
-	return fuse_docker.NewIpfsFuseDocker(
+	return fuse_docker.NewStorageProvider(
 		stack.CleanupManager, stack.Nodes[0].IpfsNode.ApiAddress())
 }
 
 func ApiCopyStorageDriverFactoryHandler(stack *devstack.DevStack_IPFS) (
 	storage.StorageProvider, error) {
 
-	return api_copy.NewIpfsApiCopy(
+	return api_copy.NewStorageProvider(
 		stack.CleanupManager, stack.Nodes[0].IpfsNode.ApiAddress())
 }
 

--- a/pkg/test/transport/transport_test.go
+++ b/pkg/test/transport/transport_test.go
@@ -22,10 +22,10 @@ import (
 
 func setupTest(t *testing.T) (
 	*inprocess.Transport,
-	*executor_noop.NoopExecutor,
+	*executor_noop.Executor,
 	*verifier_noop.NoopVerifier,
 ) {
-	noopExecutor, err := executor_noop.NewNoopExecutor()
+	noopExecutor, err := executor_noop.NewExecutor()
 	assert.NoError(t, err)
 
 	noopVerifier, err := verifier_noop.NewNoopVerifier()

--- a/pkg/test/transport/transport_test.go
+++ b/pkg/test/transport/transport_test.go
@@ -23,12 +23,12 @@ import (
 func setupTest(t *testing.T) (
 	*inprocess.Transport,
 	*executor_noop.Executor,
-	*verifier_noop.NoopVerifier,
+	*verifier_noop.Verifier,
 ) {
 	noopExecutor, err := executor_noop.NewExecutor()
 	assert.NoError(t, err)
 
-	noopVerifier, err := verifier_noop.NewNoopVerifier()
+	noopVerifier, err := verifier_noop.NewVerifier()
 	assert.NoError(t, err)
 
 	executors := map[string]executor.Executor{

--- a/pkg/test/verifier/ipfs_verifier_test.go
+++ b/pkg/test/verifier/ipfs_verifier_test.go
@@ -1,13 +1,14 @@
 package verifier
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"testing"
 
 	_ "github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/types"
-	ipfs_verifier "github.com/filecoin-project/bacalhau/pkg/verifier/ipfs"
+	"github.com/filecoin-project/bacalhau/pkg/verifier/ipfs"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -25,15 +26,16 @@ func TestIPFSVerifier(t *testing.T) {
 	err = os.WriteFile(inputDir+"/file.txt", []byte(fixtureContent), 0644)
 	assert.NoError(t, err)
 
-	verifier, err := ipfs_verifier.NewIPFSVerifier(
+	verifier, err := ipfs.NewVerifier(
 		cm, stack.Nodes[0].IpfsNode.ApiAddress())
 	assert.NoError(t, err)
 
-	installed, err := verifier.IsInstalled()
+	installed, err := verifier.IsInstalled(context.TODO())
 	assert.NoError(t, err)
 	assert.True(t, installed)
 
-	resultHash, err := verifier.ProcessResultsFolder(&types.Job{}, inputDir)
+	resultHash, err := verifier.ProcessResultsFolder(context.TODO(),
+		&types.Job{}, inputDir)
 	assert.NoError(t, err)
 
 	err = verifier.IPFSClient.DownloadTar(outputDir, resultHash)

--- a/pkg/verifier/interface.go
+++ b/pkg/verifier/interface.go
@@ -1,19 +1,20 @@
 package verifier
 
 import (
+	"context"
+
 	"github.com/filecoin-project/bacalhau/pkg/types"
 )
 
+// Verifier is an interface representing something that can verify the results
+// of a job.
 type Verifier interface {
-
 	// tells you if the required software is installed on this machine
-	IsInstalled() (bool, error)
+	IsInstalled(ctx context.Context) (bool, error)
 
 	// the executor has completed the job and produced a local folder of results
 	// the verifier will now "process" this local folder into the result
 	// that will be broadcast back to the network
-	ProcessResultsFolder(
-		job *types.Job,
-		resultsFolder string,
-	) (string, error)
+	ProcessResultsFolder(ctx context.Context, job *types.Job,
+		resultsFolder string) (string, error)
 }

--- a/pkg/verifier/ipfs/verifier.go
+++ b/pkg/verifier/ipfs/verifier.go
@@ -6,15 +6,16 @@ import (
 	ipfs_http "github.com/filecoin-project/bacalhau/pkg/ipfs/http"
 	"github.com/filecoin-project/bacalhau/pkg/system"
 	"github.com/filecoin-project/bacalhau/pkg/types"
+	"github.com/filecoin-project/bacalhau/pkg/verifier"
 	"github.com/rs/zerolog/log"
 )
 
-type IPFSVerifier struct {
+type Verifier struct {
 	IPFSClient *ipfs_http.IPFSHttpClient
 }
 
-func NewIPFSVerifier(cm *system.CleanupManager, ipfsMultiAddress string) (
-	*IPFSVerifier, error) {
+func NewVerifier(cm *system.CleanupManager, ipfsMultiAddress string) (
+	*Verifier, error) {
 
 	api, err := ipfs_http.NewIPFSHttpClient(context.TODO(), ipfsMultiAddress)
 	if err != nil {
@@ -26,7 +27,7 @@ func NewIPFSVerifier(cm *system.CleanupManager, ipfsMultiAddress string) (
 		return nil, err
 	}
 
-	verifier := &IPFSVerifier{
+	verifier := &Verifier{
 		IPFSClient: api,
 	}
 
@@ -39,12 +40,17 @@ func NewIPFSVerifier(cm *system.CleanupManager, ipfsMultiAddress string) (
 	return verifier, nil
 }
 
-func (verifier *IPFSVerifier) IsInstalled() (bool, error) {
+func (verifier *Verifier) IsInstalled(ctx context.Context) (bool, error) {
 	_, err := verifier.IPFSClient.GetPeerId()
 	return err == nil, err
 }
 
-func (verifier *IPFSVerifier) ProcessResultsFolder(job *types.Job, resultsFolder string) (string, error) {
+func (verifier *Verifier) ProcessResultsFolder(ctx context.Context,
+	job *types.Job, resultsFolder string) (string, error) {
+
 	log.Debug().Msgf("Uploading results folder to ipfs: %s %s", job.Id, resultsFolder)
 	return verifier.IPFSClient.UploadTar(resultsFolder)
 }
+
+// Compile-time check that Verifier implements the correct interface:
+var _ verifier.Verifier = (*Verifier)(nil)

--- a/pkg/verifier/noop/verifier.go
+++ b/pkg/verifier/noop/verifier.go
@@ -1,20 +1,24 @@
 package noop
 
 import (
+	"context"
+
 	"github.com/filecoin-project/bacalhau/pkg/types"
 )
 
-type NoopVerifier struct {
+type Verifier struct {
 }
 
-func NewNoopVerifier() (*NoopVerifier, error) {
-	return &NoopVerifier{}, nil
+func NewVerifier() (*Verifier, error) {
+	return &Verifier{}, nil
 }
 
-func (verifier *NoopVerifier) IsInstalled() (bool, error) {
+func (verifier *Verifier) IsInstalled(ctx context.Context) (bool, error) {
 	return true, nil
 }
 
-func (verifier *NoopVerifier) ProcessResultsFolder(job *types.Job, resultsFolder string) (string, error) {
+func (verifier *Verifier) ProcessResultsFolder(ctx context.Context,
+	job *types.Job, resultsFolder string) (string, error) {
+
 	return resultsFolder, nil
 }

--- a/pkg/verifier/util/utils.go
+++ b/pkg/verifier/util/utils.go
@@ -1,26 +1,27 @@
-package verifier
+package util
 
 import (
 	"github.com/filecoin-project/bacalhau/pkg/system"
+	"github.com/filecoin-project/bacalhau/pkg/verifier"
 	"github.com/filecoin-project/bacalhau/pkg/verifier/ipfs"
 	"github.com/filecoin-project/bacalhau/pkg/verifier/noop"
 )
 
 func NewIPFSVerifiers(cm *system.CleanupManager, ipfsMultiAddress string) (
-	map[string]Verifier, error) {
+	map[string]verifier.Verifier, error) {
 
-	noopVerifier, err := noop.NewNoopVerifier()
+	noopVerifier, err := noop.NewVerifier()
 	if err != nil {
 		return nil, err
 	}
 
-	ipfsVerifier, err := ipfs.NewIPFSVerifier(cm, ipfsMultiAddress)
+	ipfsVerifier, err := ipfs.NewVerifier(cm, ipfsMultiAddress)
 	if err != nil {
 		return nil, err
 	}
 
-	return map[string]Verifier{
-		string(VERIFIER_NOOP): noopVerifier,
-		string(VERIFIER_IPFS): ipfsVerifier,
+	return map[string]verifier.Verifier{
+		string(verifier.VERIFIER_NOOP): noopVerifier,
+		string(verifier.VERIFIER_IPFS): ipfsVerifier,
 	}, nil
 }


### PR DESCRIPTION
See #228. Refactors the Transport, StorageProvider and Executor interfaces to
use contexts for all APIs. Next step is to integrate otel trace IDs with the
`pkg/system/context` package and start wiring up the `context.TODO` objects in
the codebase.
