### PR TITLE
Replace all context.TODOs with properly threaded contexts.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,8 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/viper v1.11.0
 	github.com/stretchr/testify v1.7.1
+	go.opentelemetry.io/otel v1.7.0
+	go.opentelemetry.io/otel/trace v1.7.0
 	mvdan.cc/sh/v3 v3.4.3
 )
 
@@ -170,8 +172,6 @@ require (
 	github.com/whyrusleeping/cbor-gen v0.0.0-20200123233031-1cdf64d27158 // indirect
 	github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7 // indirect
 	github.com/whyrusleeping/timecache v0.0.0-20160911033111-cfcb2f1abfee // indirect
-	go.opentelemetry.io/otel v1.7.0 // indirect
-	go.opentelemetry.io/otel/trace v1.7.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.21.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,8 @@ require (
 	github.com/flynn/noise v1.0.0 // indirect
 	github.com/francoispqt/gojay v1.2.13 // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
+	github.com/go-logr/logr v1.2.3 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 // indirect
 	github.com/godbus/dbus/v5 v5.0.6 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
@@ -168,6 +170,8 @@ require (
 	github.com/whyrusleeping/cbor-gen v0.0.0-20200123233031-1cdf64d27158 // indirect
 	github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7 // indirect
 	github.com/whyrusleeping/timecache v0.0.0-20160911033111-cfcb2f1abfee // indirect
+	go.opentelemetry.io/otel v1.7.0 // indirect
+	go.opentelemetry.io/otel/trace v1.7.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.21.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -491,7 +491,10 @@ github.com/go-logr/logr v0.4.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTg
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.1/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/logr v1.2.3 h1:2DntVwHkVopvECVRSlL5PSo9eG+cAkDCuckLubN+rq0=
+github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/stdr v1.2.0/go.mod h1:YkVgnZu1ZjjL7xTxrfm/LLZBfkhTqSR1ydtm6jTKKwI=
+github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-openapi/jsonpointer v0.0.0-20160704185906-46af16f9f7b1/go.mod h1:+35s3my2LFTysnkMfxsJBAMHj/DoqoB9knIWoYG/Vk0=
 github.com/go-openapi/jsonpointer v0.19.2/go.mod h1:3akKfEdA7DF1sugOqz1dVQHBcuDBPKZGEoHC/NkiQRg=
@@ -1858,6 +1861,8 @@ go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.2
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.20.0/go.mod h1:2AboqHi0CiIZU0qwhtUfCYD1GeUzvvIXWNkhDt7ZMG4=
 go.opentelemetry.io/otel v0.20.0/go.mod h1:Y3ugLH2oa81t5QO+Lty+zXf8zC9L26ax4Nzoxm/dooo=
 go.opentelemetry.io/otel v1.3.0/go.mod h1:PWIKzi6JCp7sM0k9yZ43VX+T345uNbAkDKwHVjb2PTs=
+go.opentelemetry.io/otel v1.7.0 h1:Z2lA3Tdch0iDcrhJXDIlC94XE+bxok1F9B+4Lz/lGsM=
+go.opentelemetry.io/otel v1.7.0/go.mod h1:5BdUoMIz5WEs0vt0CUEMtSSaTSHBBVwrhnz7+nrD5xk=
 go.opentelemetry.io/otel/exporters/otlp v0.20.0/go.mod h1:YIieizyaN77rtLJra0buKiNBOm9XQfkPEKBeuhoMwAM=
 go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.3.0/go.mod h1:VpP4/RMn8bv8gNo9uK7/IMY4mtWLELsS+JIP0inH0h4=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.3.0/go.mod h1:hO1KLR7jcKaDDKDkvI9dP/FIhpmna5lkqPUQdEjFAM8=
@@ -1871,6 +1876,8 @@ go.opentelemetry.io/otel/sdk/export/metric v0.20.0/go.mod h1:h7RBNMsDJ5pmI1zExLi
 go.opentelemetry.io/otel/sdk/metric v0.20.0/go.mod h1:knxiS8Xd4E/N+ZqKmUPf3gTTZ4/0TjTXukfxjzSTpHE=
 go.opentelemetry.io/otel/trace v0.20.0/go.mod h1:6GjCW8zgDjwGHGa6GkyeB8+/5vjT16gUEi0Nf1iBdgw=
 go.opentelemetry.io/otel/trace v1.3.0/go.mod h1:c/VDhno8888bvQYmbYLqe41/Ldmr/KKunbvWM4/fEjk=
+go.opentelemetry.io/otel/trace v1.7.0 h1:O37Iogk1lEkMRXewVtZ1BBTVn5JEp8GrJvP92bJqC6o=
+go.opentelemetry.io/otel/trace v1.7.0/go.mod h1:fzLSB9nqR2eXzxPXb2JW9IKE+ScyXA48yyE4TNvoHqU=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.opentelemetry.io/proto/otlp v0.11.0/go.mod h1:QpEjXPrNQzrFDZgoTo49dgHR9RYRSrg3NAKnUGl9YpQ=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=

--- a/pkg/ipfs/devstack/devstack.go
+++ b/pkg/ipfs/devstack/devstack.go
@@ -249,14 +249,13 @@ func (server *IPFSDevServer) Start(connectToAddress string) error {
 
 	cmd.Stderr = logfile
 	cmd.Stdout = logfile
-	if err = cmd.Start(); err != nil { // nolint
+	if err = cmd.Start(); err != nil {
 		return err
 	}
-
 	log.Debug().Msgf("IPFS daemon has started")
 
 	testConnectionClient, err := ipfs_http.NewIPFSHttpClient(
-		context.TODO(), server.ApiAddress())
+		server.ApiAddress())
 	if err != nil {
 		return err
 	}
@@ -266,7 +265,8 @@ func (server *IPFSDevServer) Start(connectToAddress string) error {
 		MaxAttempts: 100,
 		Delay:       time.Millisecond * 100,
 		Handler: func() (bool, error) {
-			if _, err := testConnectionClient.GetPeerId(); err != nil {
+			_, err := testConnectionClient.GetPeerId(context.Background())
+			if err != nil {
 				var expectedErr *url.Error
 				if errors.As(err, &expectedErr) {
 					return false, nil // connection not found, so we wait

--- a/pkg/requestor_node/requester_node.go
+++ b/pkg/requestor_node/requester_node.go
@@ -16,7 +16,7 @@ type RequesterNode struct {
 func NewRequesterNode(
 	transport transport.Transport,
 ) (*RequesterNode, error) {
-	ctx := context.TODO()
+	ctx := context.Background() // TODO: instrument with trace
 
 	nodeId, err := transport.HostID(ctx)
 	threadLogger := logger.LoggerWithRuntimeInfo(nodeId)
@@ -73,7 +73,6 @@ func NewRequesterNode(
 // a compute node has bid on the job
 // should we accept the bid or not?
 func (node *RequesterNode) ConsiderBid(job *types.Job, nodeId string) (bool, string, error) {
-
 	threadLogger := logger.LoggerWithNodeAndJobInfo(nodeId, job.Id)
 
 	concurrency := job.Deal.Concurrency

--- a/pkg/storage/ipfs/api_copy/storage.go
+++ b/pkg/storage/ipfs/api_copy/storage.go
@@ -72,7 +72,7 @@ func (dockerIpfs *StorageProvider) PrepareStorage(ctx context.Context,
 
 	err := dockerIpfs.IPFSClient.Api.
 		Request("files/stat", fmt.Sprintf("/ipfs/%s", storageSpec.Cid)).
-		Exec(context.TODO(), &statResult)
+		Exec(ctx, &statResult)
 
 	if err != nil {
 		return nil, err

--- a/pkg/storage/ipfs/fuse_docker/storage.go
+++ b/pkg/storage/ipfs/fuse_docker/storage.go
@@ -300,7 +300,7 @@ func (sp *StorageProvider) startSidecar(ctx context.Context) error {
 		return err
 	}
 
-	err = sp.DockerClient.ContainerStart(context.TODO(),
+	err = sp.DockerClient.ContainerStart(ctx,
 		sidecarContainer.ID, dockertypes.ContainerStartOptions{})
 	if err != nil {
 		return err

--- a/pkg/storage/util/utils.go
+++ b/pkg/storage/util/utils.go
@@ -7,7 +7,7 @@ import (
 	"github.com/filecoin-project/bacalhau/pkg/storage"
 )
 
-func GetStorageProvider(engine string,
+func GetStorageProvider(ctx context.Context, engine string,
 	providers map[string]storage.StorageProvider) (
 	storage.StorageProvider, error) {
 
@@ -16,7 +16,7 @@ func GetStorageProvider(engine string,
 	}
 
 	storageProvider := providers[engine]
-	installed, err := storageProvider.IsInstalled(context.TODO())
+	installed, err := storageProvider.IsInstalled(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/system/tracer.go
+++ b/pkg/system/tracer.go
@@ -1,0 +1,25 @@
+package system
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// TODO: hook up exporter for honeycomb, currently traces go nowhere
+// https://github.com/open-telemetry/opentelemetry-go/tree/main/exporters/otlp/otlptrace
+var tracer trace.Tracer
+
+func init() {
+	tracer = otel.Tracer("github.com/filecoin-project/bacalhau")
+}
+
+// Span creates a span and a context containing the newly-created span.
+// For more information see the otel.Tracer.Start(...) docs:
+//   https://pkg.go.dev/go.opentelemetry.io/otel/trace#Tracer
+func Span(ctx context.Context, spanName string,
+	opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+
+	return tracer.Start(ctx, spanName, opts...)
+}

--- a/pkg/test/devstack/devstack_test.go
+++ b/pkg/test/devstack/devstack_test.go
@@ -65,6 +65,7 @@ func devStackDockerStorageTest(
 	testCase scenario.TestCase,
 	nodeCount int,
 ) {
+	ctx := context.Background()
 	stack, cm := SetupTest(t, nodeCount, 0)
 	defer TeardownTest(stack, cm)
 
@@ -110,10 +111,10 @@ func devStackDockerStorageTest(
 		assert.NoError(t, err)
 
 		ipfsClient, err := ipfs_http.NewIPFSHttpClient(
-			context.TODO(), node.IpfsNode.ApiAddress())
+			node.IpfsNode.ApiAddress())
 		assert.NoError(t, err)
 
-		ipfsClient.DownloadTar(outputDir, state.ResultsId)
+		ipfsClient.DownloadTar(ctx, outputDir, state.ResultsId)
 		testCase.ResultsChecker(outputDir + "/" + state.ResultsId)
 	}
 }

--- a/pkg/test/executor/docker_executor_test.go
+++ b/pkg/test/executor/docker_executor_test.go
@@ -27,6 +27,7 @@ func dockerExecutorStorageTest(
 	// the inner test handler that is given the storage driver factory
 	// and output mode that we are looping over internally
 	runTest := func(getStorageDriver scenario.IGetStorageDriver) {
+		ctx := context.Background()
 		stack, cm := ipfs.SetupTest(t, TEST_NODE_COUNT)
 		defer ipfs.TeardownTest(stack, cm)
 
@@ -43,13 +44,13 @@ func dockerExecutorStorageTest(
 			stack, TEST_STORAGE_DRIVER_NAME, TEST_NODE_COUNT)
 		assert.NoError(t, err)
 
-		isInstalled, err := dockerExecutor.IsInstalled(context.TODO())
+		isInstalled, err := dockerExecutor.IsInstalled(ctx)
 		assert.NoError(t, err)
 		assert.True(t, isInstalled)
 
 		for _, inputStorageSpec := range inputStorageList {
 			hasStorage, err := dockerExecutor.HasStorage(
-				context.TODO(), inputStorageSpec)
+				ctx, inputStorageSpec)
 			assert.NoError(t, err)
 			assert.True(t, hasStorage)
 		}
@@ -69,7 +70,7 @@ func dockerExecutorStorageTest(
 			},
 		}
 
-		resultsDirectory, err := dockerExecutor.RunJob(context.TODO(), job)
+		resultsDirectory, err := dockerExecutor.RunJob(ctx, job)
 		assert.NoError(t, err)
 
 		if err != nil {

--- a/pkg/test/ipfs/ipfs_host_storage_test.go
+++ b/pkg/test/ipfs/ipfs_host_storage_test.go
@@ -21,6 +21,7 @@ type getStorageFunc func(cm *system.CleanupManager, api string) (
 
 func runFileTest(t *testing.T, engine string, getStorageDriver getStorageFunc) {
 	// get a single IPFS server
+	ctx := context.Background()
 	stack, cm := SetupTest(t, 1)
 	defer TeardownTest(stack, cm)
 
@@ -42,12 +43,12 @@ func runFileTest(t *testing.T, engine string, getStorageDriver getStorageFunc) {
 	}
 
 	// does the storage client think we have the cid locally?
-	hasCid, err := storageDriver.HasStorage(context.TODO(), storage)
+	hasCid, err := storageDriver.HasStorage(ctx, storage)
 	assert.NoError(t, err)
 	assert.True(t, hasCid)
 
 	// this should start a sidecar container with a fuse mount
-	volume, err := storageDriver.PrepareStorage(context.TODO(), storage)
+	volume, err := storageDriver.PrepareStorage(ctx, storage)
 	assert.NoError(t, err)
 
 	// we should now be able to read our file content
@@ -61,13 +62,14 @@ func runFileTest(t *testing.T, engine string, getStorageDriver getStorageFunc) {
 
 	fmt.Printf("HERE IS RESULTS: %s\n", result)
 
-	err = storageDriver.CleanupStorage(context.TODO(), storage, volume)
+	err = storageDriver.CleanupStorage(ctx, storage, volume)
 	assert.NoError(t, err)
 }
 
 func runFolderTest(t *testing.T, engine string,
 	getStorageDriver getStorageFunc) {
 
+	ctx := context.Background()
 	dir, err := ioutil.TempDir("", "bacalhau-ipfs-test")
 	assert.NoError(t, err)
 
@@ -96,12 +98,12 @@ func runFolderTest(t *testing.T, engine string,
 	}
 
 	// does the storage client think we have the cid locally?
-	hasCid, err := storageDriver.HasStorage(context.TODO(), storage)
+	hasCid, err := storageDriver.HasStorage(ctx, storage)
 	assert.NoError(t, err)
 	assert.True(t, hasCid)
 
 	// this should start a sidecar container with a fuse mount
-	volume, err := storageDriver.PrepareStorage(context.TODO(), storage)
+	volume, err := storageDriver.PrepareStorage(ctx, storage)
 	assert.NoError(t, err)
 
 	// we should now be able to read our file content
@@ -115,7 +117,7 @@ func runFolderTest(t *testing.T, engine string,
 
 	fmt.Printf("HERE IS RESULTS: %s\n", result)
 
-	err = storageDriver.CleanupStorage(context.TODO(), storage, volume)
+	err = storageDriver.CleanupStorage(ctx, storage, volume)
 	assert.NoError(t, err)
 }
 

--- a/pkg/test/ipfs/ipfs_httpclient_test.go
+++ b/pkg/test/ipfs/ipfs_httpclient_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestIpfsHttpClient(t *testing.T) {
+	ctx := context.Background()
 	stack, cm := SetupTest(t, 2)
 	defer TeardownTest(stack, cm)
 
@@ -18,19 +19,19 @@ func TestIpfsHttpClient(t *testing.T) {
 
 	// test the basic connection and that we can list the IPFS node addresses
 	ipfsMultiAddress := stack.Nodes[0].IpfsNode.ApiAddress()
-	api, err := ipfs_http.NewIPFSHttpClient(context.TODO(), ipfsMultiAddress)
+	api, err := ipfs_http.NewIPFSHttpClient(ipfsMultiAddress)
 	assert.NoError(t, err)
 
-	addrs, err := api.GetLocalAddrs()
+	addrs, err := api.GetLocalAddrs(ctx)
 	assert.NoError(t, err)
 	assert.GreaterOrEqual(t, len(addrs), 1)
 
 	assertNodeHasCid := func(cid string, nodeIndex int, expectedResult bool) {
 		api, err := ipfs_http.NewIPFSHttpClient(
-			context.TODO(), stack.Nodes[nodeIndex].IpfsNode.ApiAddress())
+			stack.Nodes[nodeIndex].IpfsNode.ApiAddress())
 		assert.NoError(t, err)
 
-		result, err := api.HasCidLocally(cid)
+		result, err := api.HasCidLocally(ctx, cid)
 		assert.NoError(t, err)
 
 		assert.Equal(t, expectedResult, result)

--- a/pkg/test/verifier/ipfs_verifier_test.go
+++ b/pkg/test/verifier/ipfs_verifier_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestIPFSVerifier(t *testing.T) {
+	ctx := context.Background()
 	stack, cm := SetupTest(t, 1)
 	defer TeardownTest(stack, cm)
 
@@ -30,15 +31,15 @@ func TestIPFSVerifier(t *testing.T) {
 		cm, stack.Nodes[0].IpfsNode.ApiAddress())
 	assert.NoError(t, err)
 
-	installed, err := verifier.IsInstalled(context.TODO())
+	installed, err := verifier.IsInstalled(ctx)
 	assert.NoError(t, err)
 	assert.True(t, installed)
 
-	resultHash, err := verifier.ProcessResultsFolder(context.TODO(),
+	resultHash, err := verifier.ProcessResultsFolder(ctx,
 		&types.Job{}, inputDir)
 	assert.NoError(t, err)
 
-	err = verifier.IPFSClient.DownloadTar(outputDir, resultHash)
+	err = verifier.IPFSClient.DownloadTar(ctx, outputDir, resultHash)
 	assert.NoError(t, err)
 
 	outputContent, err := os.ReadFile(outputDir + "/" + resultHash + "/file.txt")

--- a/pkg/verifier/ipfs/verifier.go
+++ b/pkg/verifier/ipfs/verifier.go
@@ -17,12 +17,13 @@ type Verifier struct {
 func NewVerifier(cm *system.CleanupManager, ipfsMultiAddress string) (
 	*Verifier, error) {
 
-	api, err := ipfs_http.NewIPFSHttpClient(context.TODO(), ipfsMultiAddress)
+	api, err := ipfs_http.NewIPFSHttpClient(ipfsMultiAddress)
 	if err != nil {
 		return nil, err
 	}
 
-	_, err = api.GetPeerId()
+	ctx := context.Background() // TODO: instrument
+	_, err = api.GetPeerId(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -41,7 +42,7 @@ func NewVerifier(cm *system.CleanupManager, ipfsMultiAddress string) (
 }
 
 func (verifier *Verifier) IsInstalled(ctx context.Context) (bool, error) {
-	_, err := verifier.IPFSClient.GetPeerId()
+	_, err := verifier.IPFSClient.GetPeerId(ctx)
 	return err == nil, err
 }
 
@@ -49,7 +50,7 @@ func (verifier *Verifier) ProcessResultsFolder(ctx context.Context,
 	job *types.Job, resultsFolder string) (string, error) {
 
 	log.Debug().Msgf("Uploading results folder to ipfs: %s %s", job.Id, resultsFolder)
-	return verifier.IPFSClient.UploadTar(resultsFolder)
+	return verifier.IPFSClient.UploadTar(ctx, resultsFolder)
 }
 
 // Compile-time check that Verifier implements the correct interface:


### PR DESCRIPTION
See #228. Last step is to configure a trace exporter and write some traces
here and there!
