### PR TITLE
Remove TEMP_SKIP lines from tests, so we run integration tests again.

### DIFF
--- a/pkg/executor/docker/executor.go
+++ b/pkg/executor/docker/executor.go
@@ -305,7 +305,7 @@ func (e *Executor) cleanupAll() {
 	for _, container := range containersWithLabel {
 		err = docker.RemoveContainer(e.Client, container.ID)
 		if err != nil {
-			log.Error().Msgf("Docker remove container error: %s", err.Error())
+			log.Error().Msgf("Non-critical error cleaning up container: %s", err.Error())
 		}
 	}
 }

--- a/pkg/publicapi/client_test.go
+++ b/pkg/publicapi/client_test.go
@@ -10,8 +10,6 @@ import (
 )
 
 func TestGet(t *testing.T) {
-	t.Skip("TEMP_SKIP_FOR_NULL_POINTER_FAST_FAIL_TEST")
-
 	c, cm := SetupTests(t)
 	defer cm.Cleanup()
 

--- a/pkg/test/devstack/devstack_test.go
+++ b/pkg/test/devstack/devstack_test.go
@@ -29,7 +29,6 @@ func devStackDockerStorageTest(
 	testCase scenario.TestCase,
 	nodeCount int,
 ) {
-	t.Skip("TEMP_SKIP_FOR_NULL_POINTER_FAST_FAIL_TEST")
 	ctx, span := newSpan(testCase.Name)
 	defer span.End()
 

--- a/pkg/test/devstack/jobselection_test.go
+++ b/pkg/test/devstack/jobselection_test.go
@@ -17,8 +17,6 @@ import (
 // re-use the docker executor tests but full end to end with libp2p transport
 // and 3 nodes
 func TestSelectAllJobs(t *testing.T) {
-	t.Skip("TEMP_SKIP_FOR_NULL_POINTER_FAST_FAIL_TEST")
-
 	type TestCase struct {
 		name            string
 		policy          computenode.JobSelectionPolicy

--- a/pkg/test/devstack/pythonwasm_test.go
+++ b/pkg/test/devstack/pythonwasm_test.go
@@ -26,8 +26,6 @@ import (
 //   context mounted in
 
 func TestSimplestPythonWasmDashC(t *testing.T) {
-	t.Skip("TEMP_SKIP_FOR_NULL_POINTER_FAST_FAIL_TEST")
-
 	ctx, span := newSpan("TestSimplestPythonWasmDashC")
 	defer span.End()
 	stack, cm := SetupTest(t, 1, 0, computenode.NewDefaultComputeNodeConfig())
@@ -69,8 +67,6 @@ func TestSimplestPythonWasmDashC(t *testing.T) {
 // TODO: test that > 10MB context is rejected
 
 func TestSimplePythonWasm(t *testing.T) {
-	t.Skip("TEMP_SKIP_FOR_NULL_POINTER_FAST_FAIL_TEST")
-
 	ctx, span := newSpan("TestSimplePythonWasm")
 	defer span.End()
 	stack, cm := SetupTest(t, 1, 0, computenode.NewDefaultComputeNodeConfig())


### PR DESCRIPTION
See #336. Can't seem to reproduce non-deterministic tests locally, so will try
on CI to see if that breaks anything.
