### PR TITLE
Add docker util for streaming logs while container is running.

### DIFF
--- a/pkg/docker/logs.go
+++ b/pkg/docker/logs.go
@@ -1,0 +1,102 @@
+package docker
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/docker/docker/api/types"
+	dockerclient "github.com/docker/docker/client"
+	"github.com/moby/moby/pkg/stdcopy"
+)
+
+// LogStreamer tails the logs of a container until it exits.
+type LogStreamer struct {
+	reader io.ReadCloser
+	buffer *bytes.Buffer
+	cancel context.CancelFunc
+	mu     sync.Mutex
+}
+
+// Logs returns a copy of the container's logs up until now.
+func (ls *LogStreamer) Logs() (string, string, error) { // nolint:gocritic
+	ls.mu.Lock()
+	defer ls.mu.Unlock()
+
+	buffer := new(bytes.Buffer)
+	if _, err := io.Copy(buffer, ls.buffer); err != nil {
+		return "", "", fmt.Errorf("failed to copy logs: %w", err)
+	}
+
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	if _, err := stdcopy.StdCopy(stdout, stderr, buffer); err != nil {
+		return "", "", fmt.Errorf("failed to de-multiplex log streams: %w", err)
+	}
+
+	return stdout.String(), stderr.String(), nil
+}
+
+// Close cancels the log streamer and releases underlying resources.
+func (ls *LogStreamer) Close() {
+	ls.cancel()
+}
+
+// StreamLogs uses "docker logs --follow" to stream the logs of a container
+// until it is stopped. This provides a more robust way of fetching logs from
+// an ephemeral container, as the container may be flagged for deletion by the
+// daemon before we can poll the logs from it.
+// NOTE: If the container is not running, this will exit immediately with the
+//       container's current logs (if any). If the container has not been
+//       started yet, this will be an empty buffer!
+func StreamLogs(ctx context.Context, client *dockerclient.Client, id string) (*LogStreamer, error) {
+	cctx, cancel := context.WithCancel(ctx)
+	reader, err := client.ContainerLogs(
+		cctx,
+		id,
+		types.ContainerLogsOptions{
+			ShowStdout: true,
+			ShowStderr: true,
+			Follow:     true,
+		})
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("failed to stream logs: %w", err)
+	}
+
+	ls := &LogStreamer{
+		reader: reader,
+		buffer: new(bytes.Buffer),
+		cancel: cancel,
+	}
+
+	go func() {
+		defer reader.Close()
+		defer cancel()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				buf := make([]byte, 1024) // nolint:gomnd
+				n, err := reader.Read(buf)
+				if err != nil && err != io.EOF {
+					return
+				}
+
+				ls.mu.Lock()
+				ls.buffer.Write(buf[:n])
+				ls.mu.Unlock()
+
+				if err == io.EOF {
+					return
+				}
+			}
+		}
+	}()
+
+	return ls, nil
+}

--- a/pkg/docker/logs_test.go
+++ b/pkg/docker/logs_test.go
@@ -1,0 +1,69 @@
+package docker
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStreamLogs(t *testing.T) {
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(10*time.Second))
+	defer cancel()
+
+	cl, err := NewDockerClient()
+	require.NoError(t, err)
+
+	if !IsInstalled(cl) {
+		t.Skip("docker is not installed")
+	}
+
+	cfg := container.Config{
+		Image: "ubuntu",
+		Tty:   false,
+		Cmd: []string{
+			"/bin/bash",
+			"-c",
+			"echo 'hello stdout' && >&2 echo 'hello stderr'",
+		},
+		NetworkDisabled: true,
+	}
+
+	c, err := cl.ContainerCreate(ctx, &cfg, nil, nil, nil, "")
+	require.NoError(t, err)
+
+	defer func() {
+		if err := RemoveContainer(cl, c.ID); err != nil {
+			t.Fatal(err.Error())
+		}
+	}()
+
+	err = cl.ContainerStart(ctx, c.ID, types.ContainerStartOptions{})
+	require.NoError(t, err)
+
+	ls, err := StreamLogs(ctx, cl, c.ID)
+	require.NoError(t, err)
+	defer ls.Close()
+
+	statusCh, errCh := cl.ContainerWait(ctx, c.ID, container.WaitConditionNotRunning)
+	select {
+	case err = <-errCh:
+		t.Fatal(err)
+	case status := <-statusCh:
+		if status.StatusCode != 0 {
+			t.Fatal("container exited with non-zero status")
+		}
+		if status.Error != nil {
+			t.Fatal(status.Error.Message)
+		}
+	}
+
+	// Let's see what the logs look like...
+	stdout, stderr, err := ls.Logs()
+	require.NoError(t, err)
+	require.Equal(t, "hello stdout\n", stdout)
+	require.Equal(t, "hello stderr\n", stderr)
+}


### PR DESCRIPTION
See #356. There's a race between the docker daemon cleaning up the job container
and us fetching logs from it. This adds a utility that can stream logs while
the container is running and cache them, so we don't have to poll the logs
once the container stops.
