### PR TITLE
Remove flake in client.TestGet by pre-emptively caching new jobs in generic transport.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,8 +104,9 @@ jobs:
                   docker version
                   echo "---------------------------------------"
                   go install gotest.tools/gotestsum@latest
-                  export CGO_ENABLED=${CGO} \
-                  LOG_LEVEL=debug gotestsum \
+                  CGO_ENABLED=${CGO} \
+                  LOG_LEVEL=debug \
+                  gotestsum \
                     --junitfile unit-tests.xml \
                     --format standard-verbose \
                     -- \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,8 +104,8 @@ jobs:
                   docker version
                   echo "---------------------------------------"
                   go install gotest.tools/gotestsum@latest
-                  CGO_ENABLED=${CGO} \
-                  gotestsum \
+                  export CGO_ENABLED=${CGO} \
+                  LOG_LEVEL=debug gotestsum \
                     --junitfile unit-tests.xml \
                     --format standard-verbose \
                     -- \

--- a/pkg/devstack/devstack.go
+++ b/pkg/devstack/devstack.go
@@ -383,7 +383,7 @@ func (stack *DevStack) WaitForJobWithLogs(
 ) error {
 	waiter := &system.FunctionWaiter{
 		Name:        "wait for job",
-		MaxAttempts: 100,
+		MaxAttempts: 5,
 		Delay:       time.Second * 1,
 		Handler: func() (bool, error) {
 			// load the current states of the job

--- a/pkg/devstack/devstack.go
+++ b/pkg/devstack/devstack.go
@@ -383,7 +383,7 @@ func (stack *DevStack) WaitForJobWithLogs(
 ) error {
 	waiter := &system.FunctionWaiter{
 		Name:        "wait for job",
-		MaxAttempts: 5,
+		MaxAttempts: 20,
 		Delay:       time.Second * 1,
 		Handler: func() (bool, error) {
 			// load the current states of the job

--- a/pkg/devstack/devstack.go
+++ b/pkg/devstack/devstack.go
@@ -383,7 +383,7 @@ func (stack *DevStack) WaitForJobWithLogs(
 ) error {
 	waiter := &system.FunctionWaiter{
 		Name:        "wait for job",
-		MaxAttempts: 20,
+		MaxAttempts: 50,
 		Delay:       time.Second * 1,
 		Handler: func() (bool, error) {
 			// load the current states of the job

--- a/pkg/transport/generic_transport.go
+++ b/pkg/transport/generic_transport.go
@@ -70,17 +70,7 @@ func (gt *GenericTransport) ReadEvent(ctx context.Context, event *executor.JobEv
 	defer gt.mutex.Unlock()
 
 	// Keep track of the state of jobs we hear about:
-	gt.ensureJobExists(ctx, event)
-
-	// Passed in for create and update events:
-	if event.JobSpec != nil {
-		gt.jobs[event.JobID].Spec = event.JobSpec
-	}
-
-	// Keep track of job owner so we know who can edit a job:
-	if event.JobDeal != nil {
-		gt.jobs[event.JobID].Deal = event.JobDeal
-	}
+	gt.ensureJobState(ctx, event)
 
 	// if for some reason our event does not contain the spec
 	// then let's read it out of our data store
@@ -216,7 +206,6 @@ func (gt *GenericTransport) SubmitJob(ctx context.Context, spec *executor.JobSpe
 	jobCtx, _ := gt.newRootSpanForJob(ctx, jobID)
 	gt.jobContexts[jobID] = jobCtx
 
-	// Cache and send the event to other nodes in the network:
 	event := &executor.JobEvent{
 		JobID:     jobID,
 		EventName: executor.JobEventCreated,
@@ -225,7 +214,8 @@ func (gt *GenericTransport) SubmitJob(ctx context.Context, spec *executor.JobSpe
 		EventTime: time.Now(),
 	}
 
-	gt.ensureJobExists(ctx, event)
+	// Cache and send the event to other nodes in the network:
+	gt.ensureJobState(ctx, event)
 	if err := gt.writeEvent(jobCtx, event); err != nil {
 		return nil, fmt.Errorf("error writing job event: %w", err)
 	}
@@ -447,7 +437,7 @@ func (gt *GenericTransport) newRootSpanForJob(ctx context.Context, jobID string)
 	)
 }
 
-func (gt *GenericTransport) ensureJobExists(ctx context.Context, event *executor.JobEvent) {
+func (gt *GenericTransport) ensureJobState(ctx context.Context, event *executor.JobEvent) {
 	if _, ok := gt.jobs[event.JobID]; !ok {
 		gt.jobs[event.JobID] = &executor.Job{
 			ID:        event.JobID,
@@ -457,5 +447,15 @@ func (gt *GenericTransport) ensureJobExists(ctx context.Context, event *executor
 			State:     make(map[string]*executor.JobState),
 			CreatedAt: time.Now(),
 		}
+	}
+
+	// Passed in for create and update events:
+	if event.JobSpec != nil {
+		gt.jobs[event.JobID].Spec = event.JobSpec
+	}
+
+	// Keep track of job owner so we know who can edit a job:
+	if event.JobDeal != nil {
+		gt.jobs[event.JobID].Deal = event.JobDeal
 	}
 }

--- a/pkg/transport/generic_transport.go
+++ b/pkg/transport/generic_transport.go
@@ -82,11 +82,6 @@ func (gt *GenericTransport) ReadEvent(ctx context.Context, event *executor.JobEv
 		event.JobDeal = gt.jobs[event.JobID].Deal
 	}
 
-	// Jobs have different states on different nodes:
-	if event.JobState != nil && event.NodeID != "" {
-		gt.jobs[event.JobID].State[event.NodeID] = event.JobState
-	}
-
 	jobCtx := gt.getJobNodeContext(ctx, event.JobID)
 	if event.NodeID == gt.NodeID {
 		// Attach metadata to local job lifecycle context:
@@ -208,6 +203,7 @@ func (gt *GenericTransport) SubmitJob(ctx context.Context, spec *executor.JobSpe
 
 	event := &executor.JobEvent{
 		JobID:     jobID,
+		NodeID:    gt.NodeID,
 		EventName: executor.JobEventCreated,
 		JobSpec:   spec,
 		JobDeal:   deal,
@@ -457,5 +453,10 @@ func (gt *GenericTransport) ensureJobState(ctx context.Context, event *executor.
 	// Keep track of job owner so we know who can edit a job:
 	if event.JobDeal != nil {
 		gt.jobs[event.JobID].Deal = event.JobDeal
+	}
+
+	// Jobs have different states on different nodes:
+	if event.JobState != nil && event.NodeID != "" {
+		gt.jobs[event.JobID].State[event.NodeID] = event.JobState
 	}
 }


### PR DESCRIPTION
Prevents this test flake:
https://app.circleci.com/pipelines/github/filecoin-project/bacalhau/278/workflows/41dda6a1-6deb-4aae-8c4e-bfd00c5ce765/jobs/1064
