### PR TITLE
Early-exit devstack wait code if all job states are terminal.

### DIFF
--- a/pkg/devstack/devstack.go
+++ b/pkg/devstack/devstack.go
@@ -394,6 +394,7 @@ func (stack *DevStack) WaitForJobWithLogs(
 			if err != nil {
 				return false, err
 			}
+
 			allOk := true
 			for _, checkFunction := range checkJobStateFunctions {
 				stepOk, err := checkFunction(states)
@@ -404,6 +405,20 @@ func (stack *DevStack) WaitForJobWithLogs(
 					allOk = false
 				}
 			}
+
+			// If all the jobs are in terminal states, then nothing is going
+			// to change if we keep polling, so we should exit early.
+			allTerminal := len(states) == len(stack.Nodes)
+			for _, state := range states {
+				if !state.IsTerminal() {
+					allTerminal = false
+					break
+				}
+			}
+			if allTerminal && !allOk {
+				return false, fmt.Errorf("all jobs are in terminal states and conditions aren't met")
+			}
+
 			return allOk, nil
 		},
 	}

--- a/pkg/executor/constants.go
+++ b/pkg/executor/constants.go
@@ -89,6 +89,8 @@ func JobEventTypes() []JobEventType {
 }
 
 //go:generate stringer -type=JobStateType --trimprefix=JobState
+// JobStateType is the state of a job on a particular node. Note that the job
+// will typically have different states on different nodes.
 type JobStateType int
 
 const (
@@ -100,6 +102,13 @@ const (
 	JobStateComplete
 	jobStateDone // must be last
 )
+
+// IsTerminal returns true if the given job type signals the end of the
+// lifecycle of that job on a particular node. After this, the job can be
+// safely ignored by the node.
+func (event JobStateType) IsTerminal() bool {
+	return event == JobStateComplete || event == JobStateError || event == JobStateBidRejected
+}
 
 func ParseJobStateType(str string) (JobStateType, error) {
 	for typ := jobStateUnknown + 1; typ < jobStateDone; typ++ {


### PR DESCRIPTION
A small optimisation to stop devstack tests from spinning forever if all jobs
end up in terminal states, but the condition isn't met yet.
