### PR TITLE
report the engine type directly rather than a index shifted query to …

### DIFF
--- a/cmd/bacalhau/describe.go
+++ b/cmd/bacalhau/describe.go
@@ -82,7 +82,7 @@ var describeCmd = &cobra.Command{
 		jobVMDesc.Memory = job.Spec.Resources.Memory
 
 		jobSpecDesc := jobSpecDescription{}
-		jobSpecDesc.Engine = executor.EngineTypes()[job.Spec.Engine].String()
+		jobSpecDesc.Engine = job.Spec.Engine.String()
 
 		jobDealDesc := jobDealDescription{}
 		jobDealDesc.Concurrency = job.Deal.Concurrency


### PR DESCRIPTION
…an array