### PR TITLE
feat(ops): add code to provision GPU capable nodes

### DIFF
--- a/ops/terraform/development.tfvars
+++ b/ops/terraform/development.tfvars
@@ -12,3 +12,4 @@ protect_resources      = true
 auto_subnets           = false
 ingress_cidrs          = ["0.0.0.0/0"]
 ssh_access_cidrs       = ["0.0.0.0/0"]
+num_gpu_machines       = 0

--- a/ops/terraform/production.tfvars
+++ b/ops/terraform/production.tfvars
@@ -13,3 +13,4 @@ protect_resources      = true
 auto_subnets           = true
 ingress_cidrs          = ["0.0.0.0/0"]
 ssh_access_cidrs       = ["0.0.0.0/0"]
+num_gpu_machines       = 0

--- a/ops/terraform/remote_files/scripts/install-node.sh
+++ b/ops/terraform/remote_files/scripts/install-node.sh
@@ -19,6 +19,28 @@ function install-docker() {
   sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
 }
 
+function install-gpu() {
+  if [ "${GPU_NODE}" = "true" ]; then
+    echo "Installing GPU drivers"
+    distribution=$(. /etc/os-release;echo $ID$VERSION_ID | sed -e 's/\.//g') \
+      && wget https://developer.download.nvidia.com/compute/cuda/repos/$distribution/x86_64/cuda-keyring_1.0-1_all.deb \
+      && sudo dpkg -i cuda-keyring_1.0-1_all.deb
+    distribution=$(. /etc/os-release;echo $ID$VERSION_ID) \
+      && curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
+      && curl -s -L https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.list | \
+            sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
+            sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+    sudo apt-get update && sudo apt-get install -y \
+      linux-headers-$(uname -r) \
+      cuda-drivers \
+      nvidia-docker2
+    sudo systemctl restart docker
+    nvidia-smi # No idea why we have to run this once, but we do. Only then does nvidia-container-cli work.
+  else
+    echo "Not installing GPU drivers because GPU_NODE=${GPU_NODE}"
+  fi
+}
+
 # Lay down a very basic web server to report when the node is healthy
 function install-healthcheck() {
   sudo apt-get -y install --no-install-recommends wget gnupg ca-certificates
@@ -108,6 +130,7 @@ function start-services() {
 
 function install() {
   install-docker
+  install-gpu
   install-healthcheck
   install-ipfs
   install-bacalhau

--- a/ops/terraform/shortlived_example.tfvars
+++ b/ops/terraform/shortlived_example.tfvars
@@ -12,5 +12,6 @@ machine_type            = "e2-standard-4"
 protect_resources       = false
 bacalhau_unsafe_cluster = true
 auto_subnets            = false
+num_gpu_machines        = 0
 
 # gcloud compute instances create performance-test-$(git rev-parse --short HEAD) --project=bacalhau-cicd --zone=europe-north1-c --machine-type=e2-standard-4 --network-interface=network-tier=PREMIUM,subnet=default --no-restart-on-failure --maintenance-policy=TERMINATE --provisioning-model=SPOT --instance-termination-action=DELETE --service-account=702126710047-compute@developer.gserviceaccount.com --scopes=https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring.write,https://www.googleapis.com/auth/servicecontrol,https://www.googleapis.com/auth/service.management.readonly,https://www.googleapis.com/auth/trace.append --create-disk=auto-delete=yes,boot=yes,device-name=performance-test-$(git rev-parse --short HEAD)-disk,image=projects/ubuntu-os-cloud/global/images/ubuntu-2204-jammy-v20220712a,mode=rw,size=100,type=projects/bacalhau-cicd/zones/europe-north1-c/diskTypes/pd-balanced --no-shielded-secure-boot --shielded-vtpm --shielded-integrity-monitoring --reservation-affinity=any

--- a/ops/terraform/staging.tfvars
+++ b/ops/terraform/staging.tfvars
@@ -12,3 +12,4 @@ protect_resources      = true
 auto_subnets           = true
 ingress_cidrs          = ["0.0.0.0/0"]
 ssh_access_cidrs       = ["0.0.0.0/0"]
+num_gpu_machines       = 0

--- a/ops/terraform/variables.tf
+++ b/ops/terraform/variables.tf
@@ -8,14 +8,14 @@ variable "bacalhau_port" {
 # IMPORTANT - only use this for test clusters or stress test clusters
 # it will result in node0 having an unsafe private key
 variable "bacalhau_unsafe_cluster" {
-  type = bool
+  type    = bool
   default = false
 }
 # connect to a known node0 id
 # this is used for long lived clusters that have already been bootstrapped
 # and the node0 id is derived from a persisted known private key
 variable "bacalhau_connect_node0" {
-  type = string
+  type    = string
   default = ""
 }
 variable "ipfs_version" {
@@ -34,7 +34,7 @@ variable "volume_size_gb" {
   type = number
 }
 variable "boot_disk_size_gb" {
-  type = number
+  type    = number
   default = 10
 }
 // should we add delete protection to public ip addresses and disks?
@@ -71,6 +71,32 @@ variable "ssh_access_cidrs" {
 // on the node's persistent data disk. This is useful for initialising stuff
 // like API keys that shouldn't go in the public repo.
 variable "honeycomb_api_key" {
-  type = string
+  type    = string
   default = ""
+}
+
+
+// Out of a total of var.instance_count machines, how many do you want to be GPU machines?
+// I chose this, rather than making a new pool of machines, to maintain configuration parity
+variable "num_gpu_machines" {
+  type    = number
+  default = 0
+}
+
+// Number of GPUs attached to each machine
+variable "num_gpus_per_machine" {
+  type    = number
+  default = 1
+}
+
+// The sku of the GPU
+variable "gpu_type" {
+  type    = string
+  default = "nvidia-tesla-t4"
+}
+
+// The machine type to attach the GPU to. Unfortunately not all machines support attaching GPUs. I suggest using the UI to figure this out.
+variable "gpu_machine_type" {
+  type    = string
+  default = "n1-standard-4"
 }


### PR DESCRIPTION
Note that this code is only enabled when the variable num_gpu_machines > 0. In this PR, all environments are set to 0.

This is because we have to move the production cluster to `europe-west4-a`, where they have GPUs. I don't want to do that yet, because it's complicated by long-lasting IP addresses and disks.

So in summary, when someone wants to migrate the production cluster to `europe-west4-a`, they only need to set `num_gpu_machines=1` and it will magically work!

Note I have not tested in other regions, you need to make sure T4's and quotas are available.

Part of #423