### PR TITLE
430 feat support working directory w argument for docker run

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,7 +28,7 @@ linters-settings:
       - wrapperFunc
       - hugeParam
   gocyclo:
-    min-complexity: 15
+    min-complexity: 18
   goimports:
     local-prefixes: github.com/golangci/golangci-lint
   gomnd:

--- a/cmd/bacalhau/apply.go
+++ b/cmd/bacalhau/apply.go
@@ -23,6 +23,7 @@ var jobfConcurrency int
 var jobfInputUrls []string
 var jobfInputVolumes []string
 var jobfOutputVolumes []string
+var jobfWorkingDir string
 var jobTags []string
 
 func init() { // nolint:gochecknoinits
@@ -125,8 +126,15 @@ var applyCmd = &cobra.Command{
 
 		verifierType, err := verifier.ParseVerifierType(jobspec.VerifierName)
 		if err != nil {
-			cmd.Printf("Error parsing engine type: %s", err)
+			cmd.Printf("Error parsing verifier type: %s", err)
 			return err
+		}
+
+		if len(jobfWorkingDir) > 0 {
+			err = system.ValidateWorkingDir(jobfWorkingDir)
+			if err != nil {
+				return err
+			}
 		}
 
 		spec, deal, err := job.ConstructDockerJob(
@@ -143,6 +151,7 @@ var applyCmd = &cobra.Command{
 			jobImage,
 			jobfConcurrency,
 			jobTags,
+			jobfWorkingDir,
 		)
 		if err != nil {
 			return err

--- a/cmd/bacalhau/docker_run.go
+++ b/cmd/bacalhau/docker_run.go
@@ -346,7 +346,7 @@ func init() { // nolint:gochecknoinits // Using init in cobra command is idomati
 
 	dockerRunCmd.PersistentFlags().StringVarP(
 		&jobWorkingDir, "workdir", "w", "",
-		`Working directory inside the container. Overrides the WORKDIR shipped with the image.`,
+		`Working directory inside the container. Overrides the working directory shipped with the image (e.g. via WORKDIR in Dockerfile).`,
 	)
 
 	dockerRunCmd.PersistentFlags().StringSliceVarP(&jobLabels,

--- a/cmd/bacalhau/docker_run.go
+++ b/cmd/bacalhau/docker_run.go
@@ -35,6 +35,7 @@ var jobIpfsGetTimeOut int
 var jobCPU string
 var jobMemory string
 var jobGPU string
+var jobWorkingDir string
 var skipSyntaxChecking bool
 var waitForJobToFinishAndPrintOutput bool
 var jobLabels []string
@@ -343,13 +344,18 @@ func init() { // nolint:gochecknoinits // Using init in cobra command is idomati
 		`Skip having 'shellchecker' verify syntax of the command`,
 	)
 
+	dockerRunCmd.PersistentFlags().StringVarP(
+		&jobWorkingDir, "workdir", "w", "",
+		`Working directory inside the container. Overrides the WORKDIR shipped with the image.`,
+	)
+
 	dockerRunCmd.PersistentFlags().StringSliceVarP(&jobLabels,
 		"labels", "l", []string{},
 		`List of labels for the job. Enter multiple in the format '-l a -l 2'. All characters not matching /a-zA-Z0-9_:|-/ and all emojis will be stripped.`, // nolint:lll // Documentation, ok if long.
 	)
 
-	dockerRunCmd.PersistentFlags().BoolVarP(
-		&waitForJobToFinishAndPrintOutput, "wait", "w", false,
+	dockerRunCmd.PersistentFlags().BoolVar(
+		&waitForJobToFinishAndPrintOutput, "wait", false,
 		`Wait For Job To Finish And Print Output`,
 	)
 
@@ -394,6 +400,7 @@ var dockerRunCmd = &cobra.Command{
 		skipSyntaxChecking = false
 		waitForJobToFinishAndPrintOutput = false
 		jobIpfsGetTimeOut = 10
+		jobWorkingDir = ""
 	},
 	RunE: func(cmd *cobra.Command, cmdArgs []string) error { // nolintunparam // incorrect that cmd is unused.
 		ctx := context.Background()
@@ -427,6 +434,13 @@ var dockerRunCmd = &cobra.Command{
 			log.Warn().Msgf("Found the following possible errors in arguments: %+v", sanitizationMsgs)
 		}
 
+		if len(jobWorkingDir) > 0 {
+			err = system.ValidateWorkingDir(jobWorkingDir)
+			if err != nil {
+				return err
+			}
+		}
+
 		spec, deal, err := pjob.ConstructDockerJob(
 			engineType,
 			verifierType,
@@ -441,6 +455,7 @@ var dockerRunCmd = &cobra.Command{
 			jobImage,
 			jobConcurrency,
 			jobLabels,
+			jobWorkingDir,
 		)
 
 		if err != nil {

--- a/cmd/bacalhau/docker_run_test.go
+++ b/cmd/bacalhau/docker_run_test.go
@@ -612,3 +612,52 @@ func (suite *DockerRunSuite) TestRun_EdgeCaseCLI() {
 		}()
 	}
 }
+
+func (suite *DockerRunSuite) TestRun_SubmitWorkdir() {
+	tests := []struct {
+		workdir    string
+		error_code int
+	}{
+		{workdir: "", error_code: 0},
+		{workdir: "/", error_code: 0},
+		{workdir: "./mydir", error_code: 1},
+		{workdir: "../mydir", error_code: 1},
+		{workdir: "http://foo.com", error_code: 1},
+		{workdir: "/foo//", error_code: 0}, // double forward slash is allowed in unix
+		{workdir: "/foo//bar", error_code: 0},
+	}
+
+	// TODO reset all cli variables
+	jobWorkingDir = ""
+	jobOutputVolumes = []string{}
+
+	for _, tc := range tests {
+		func() {
+			ctx := context.Background()
+			c, cm := publicapi.SetupTests(suite.T())
+			defer cm.Cleanup()
+
+			parsedBasedURI, _ := url.Parse(c.BaseURI)
+			host, port, _ := net.SplitHostPort(parsedBasedURI.Host)
+			flagsArray := []string{"docker", "run",
+				"--api-host", host,
+				"--api-port", port}
+			flagsArray = append(flagsArray, "-w", tc.workdir)
+			flagsArray = append(flagsArray, "ubuntu pwd")
+
+			_, out, err := ExecuteTestCobraCommand(suite.T(), suite.rootCmd,
+				flagsArray...,
+			)
+
+			if tc.error_code != 0 {
+				require.Error(suite.T(), err)
+			} else {
+				require.NoError(suite.T(), err, "Error submitting job.")
+				job, _, err := c.Get(ctx, strings.TrimSpace(out))
+				require.NotNil(suite.T(), job, "Failed to get job with ID: %s", out)
+				require.Equal(suite.T(), tc.workdir, job.Spec.Docker.WorkingDir, "Job workdir != test workdir.")
+				require.NoError(suite.T(), err, "Error in running command.")
+			}
+		}()
+	}
+}

--- a/pkg/executor/docker/executor.go
+++ b/pkg/executor/docker/executor.go
@@ -219,6 +219,7 @@ func (e *Executor) RunJob(ctx context.Context, j executor.Job) (string, error) {
 		Entrypoint:      j.Spec.Docker.Entrypoint,
 		Labels:          e.jobContainerLabels(j),
 		NetworkDisabled: true,
+		WorkingDir:      j.Spec.Docker.WorkingDir,
 	}
 
 	log.Trace().Msgf("Container: %+v %+v", containerConfig, mounts)

--- a/pkg/executor/types.go
+++ b/pkg/executor/types.go
@@ -94,6 +94,8 @@ type JobSpecDocker struct {
 	Entrypoint []string `json:"entrypoint" yaml:"entrypoint"`
 	// a map of env to run the container with
 	Env []string `json:"env" yaml:"env"`
+	// working directory inside the container
+	WorkingDir string `json:"workdir" yaml:"workdir"`
 }
 
 // for language style executors (can target docker or wasm)

--- a/pkg/job/job.go
+++ b/pkg/job/job.go
@@ -111,9 +111,9 @@ func ConstructDockerJob( //nolint:funlen
 		if err != nil {
 			log.Error().Msg(err.Error())
 			return executor.JobSpec{}, executor.JobDeal{}, err
-		}	
+		}
 	}
-	
+
 	spec := executor.JobSpec{
 		Engine:   engine,
 		Verifier: v,

--- a/pkg/job/job.go
+++ b/pkg/job/job.go
@@ -10,6 +10,7 @@ import (
 	"github.com/filecoin-project/bacalhau/pkg/executor"
 	"github.com/filecoin-project/bacalhau/pkg/storage"
 	"github.com/filecoin-project/bacalhau/pkg/storage/url/urldownload"
+	"github.com/filecoin-project/bacalhau/pkg/system"
 	"github.com/filecoin-project/bacalhau/pkg/verifier"
 	"github.com/rs/zerolog/log"
 )
@@ -26,6 +27,7 @@ func ConstructDockerJob( //nolint:funlen
 	image string,
 	concurrency int,
 	annotations []string,
+	workingDir string,
 ) (executor.JobSpec, executor.JobDeal, error) {
 	if concurrency <= 0 {
 		return executor.JobSpec{}, executor.JobDeal{}, fmt.Errorf("concurrency must be >= 1")
@@ -104,6 +106,14 @@ func ConstructDockerJob( //nolint:funlen
 			strings.Join(unSafeAnnotations, ", "))
 	}
 
+	if len(workingDir) > 0 {
+		err := system.ValidateWorkingDir(workingDir)
+		if err != nil {
+			log.Error().Msg(err.Error())
+			return executor.JobSpec{}, executor.JobDeal{}, err
+		}	
+	}
+	
 	spec := executor.JobSpec{
 		Engine:   engine,
 		Verifier: v,
@@ -117,6 +127,11 @@ func ConstructDockerJob( //nolint:funlen
 		Inputs:      jobInputs,
 		Outputs:     jobOutputs,
 		Annotations: jobAnnotations,
+	}
+
+	// override working dir if provided
+	if len(workingDir) > 0 {
+		spec.Docker.WorkingDir = workingDir
 	}
 
 	deal := executor.JobDeal{

--- a/pkg/system/script_checker.go
+++ b/pkg/system/script_checker.go
@@ -1,6 +1,8 @@
 package system
 
 import (
+	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/rs/zerolog/log"
@@ -53,4 +55,14 @@ func SanitizeImageAndEntrypoint(jobEntrypoint []string) (returnMessages []string
 	}
 
 	return returnMessages, errorIsFatal
+}
+
+// Function for validating the workdir of a docker command.
+func ValidateWorkingDir(jobWorkingDir string) error {
+	if jobWorkingDir != "" {
+		if !filepath.IsAbs(jobWorkingDir) {
+			return fmt.Errorf("workdir must be an absolute path. Passed in: %s", jobWorkingDir)
+		}
+	}
+	return nil
 }

--- a/pkg/system/script_checker_test.go
+++ b/pkg/system/script_checker_test.go
@@ -65,6 +65,32 @@ func (suite *SystemScriptCheckerSuite) TestSubmitSyntaxErrors() {
 	}
 }
 
+func TestValidateWorkingDir(t *testing.T) {
+	tests := map[string]struct {
+		path       string
+		error_code int
+	}{
+		"good_path": {path: "/", error_code: 0},
+		"good_path_full": {path: "/project/", error_code: 0},
+		"relative_path":  {path: "../foo", error_code: 1},
+		"relative_path_2":  {path: "./foo", error_code: 1},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// t.Parallel()
+
+			err := ValidateWorkingDir(tc.path)
+
+			if tc.error_code != 0 {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err, "Error in running command.")
+			}
+		})
+	}
+}
+
 // https://github.com/koalaman/shellcheck
 var (
 	GOOD_PYTHON       = `python3 -c "time.sleep(10); %s"`

--- a/pkg/test/computenode/resourcelimits_test.go
+++ b/pkg/test/computenode/resourcelimits_test.go
@@ -260,6 +260,7 @@ func (suite *ComputeNodeResourceLimitsSuite) TestTotalResourceLimits() {
 				"",
 				1,
 				[]string{},
+				"",
 			)
 
 			require.NoError(suite.T(), err)


### PR DESCRIPTION
Try it out with devstack:

### Default workdir (no flag)

```
LOG_LEVEL=debug go run . --api-port=$BACALHAU_API_PORT_0 --api-host=localhost docker run ubuntu pwd
ipfs --api /ip4/127.0.0.1/tcp/${BACALHAU_IPFS_API_PORT_0} cat $RESULT_PATH/stdout
```

prints: `/` in fact `docker run --rm ubuntu pwd` ---> prints `/`

### Pass custom workdir

```
LOG_LEVEL=debug go run . --api-port=$BACALHAU_API_PORT_0 --api-host=localhost -w /app docker run ubuntu pwd
ipfs --api /ip4/127.0.0.1/tcp/${BACALHAU_IPFS_API_PORT_0} cat $RESULT_PATH/stdout
```

prints: `/app`

### Invalid workdir

```
LOG_LEVEL=debug go run . --api-port=$BACALHAU_API_PORT_0 --api-host=localhost -w ../app docker run ubuntu pwd
```

prints: `[...] Error: workdir must be an absolute path. Passed in: ../app [...]`

### WORKDIR set in Dockerfile (from public image)

```
LOG_LEVEL=debug go run . --api-port=$BACALHAU_API_PORT_0 --api-host=localhost docker run harsp/workdir pwd
ipfs --api /ip4/127.0.0.1/tcp/${BACALHAU_IPFS_API_PORT_0} cat $RESULT_PATH/stdout
```

Prints: `/newtemp` that's correct: https://github.com/harshapjingade/Docker/blob/6d5f797985c55a02097b1dc902fd26a92d70f34a/workdir/Dockerfile#L3