### PR TITLE
Error when no shards found

### DIFF
--- a/pkg/job/sharding.go
+++ b/pkg/job/sharding.go
@@ -197,6 +197,9 @@ func GenerateExecutionPlan(
 	if err != nil {
 		return executor.JobExecutionPlan{}, err
 	}
+	if len(shards) == 0 {
+		return executor.JobExecutionPlan{}, fmt.Errorf("no sharding atoms found for glob pattern %s", config.GlobPattern)
+	}
 	return executor.JobExecutionPlan{
 		TotalShards: len(shards),
 	}, nil

--- a/pkg/job/sharding_test.go
+++ b/pkg/job/sharding_test.go
@@ -46,6 +46,11 @@ func TestApplyGlobPattern(t *testing.T) {
 		"/inputs/Prominent Late Gothic styled architecture.mp4",
 	}
 
+	videoFilesNoSlash := []string{}
+	for _, videoFile := range videoFiles {
+		videoFilesNoSlash = append(videoFilesNoSlash, strings.TrimPrefix(videoFile, "/"))
+	}
+
 	videoResults := []string{
 		"/inputs/Bird flying over the lake.mp4",
 		"/inputs/Calm waves on a rocky sea gulf.mp4",
@@ -112,9 +117,16 @@ func TestApplyGlobPattern(t *testing.T) {
 			videoResults,
 		},
 		{
-			"test without leading slash",
+			"test without leading slash in pattern",
 			videoFiles,
 			"*.mp4",
+			"/inputs",
+			videoResults,
+		},
+		{
+			"test without leading slash in filenames",
+			videoFilesNoSlash,
+			"/*.mp4",
 			"/inputs",
 			videoResults,
 		},

--- a/pkg/job/sharding_test.go
+++ b/pkg/job/sharding_test.go
@@ -39,6 +39,19 @@ func TestApplyGlobPattern(t *testing.T) {
 		"/b/file2.txt",
 	}
 
+	videoFiles := []string{
+		"/inputs",
+		"/inputs/Bird flying over the lake.mp4",
+		"/inputs/Calm waves on a rocky sea gulf.mp4",
+		"/inputs/Prominent Late Gothic styled architecture.mp4",
+	}
+
+	videoResults := []string{
+		"/inputs/Bird flying over the lake.mp4",
+		"/inputs/Calm waves on a rocky sea gulf.mp4",
+		"/inputs/Prominent Late Gothic styled architecture.mp4",
+	}
+
 	testCases := []struct {
 		name     string
 		files    []string
@@ -90,6 +103,20 @@ func TestApplyGlobPattern(t *testing.T) {
 				"/a/file3.txt",
 				"/a/file4.txt",
 			},
+		},
+		{
+			"test with spaces in file names",
+			videoFiles,
+			"/inputs/*.mp4",
+			"",
+			videoResults,
+		},
+		{
+			"test without leading slash",
+			videoFiles,
+			"*.mp4",
+			"/inputs",
+			videoResults,
 		},
 	}
 

--- a/pkg/publicapi/client.go
+++ b/pkg/publicapi/client.go
@@ -280,7 +280,7 @@ func (apiClient *APIClient) post(ctx context.Context, api string, reqData, resDa
 		}
 
 		return fmt.Errorf(
-			"publicapi: received non-200 status: %d", res.StatusCode)
+			"publicapi: received non-200 status: %d %s", res.StatusCode, string(body))
 	}
 
 	if err := json.NewDecoder(res.Body).Decode(resData); err != nil {


### PR DESCRIPTION
Some small improvements to the sharding feature:

 * api server will error if a globbing pattern is provided but not results were found when input volumes were exploded
 * some tweaks to the globbing function to not care if the user fails to prepend `/` to their glob pattern