### PR TITLE
Fix starting transport twice

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -80,7 +80,7 @@ func (ctrl *Controller) Start(ctx context.Context) error {
 		return ctrl.Shutdown(ctx)
 	})
 
-	return ctrl.transport.Start(ctx)
+	return nil
 }
 
 func (ctrl *Controller) Shutdown(ctx context.Context) error {

--- a/pkg/devstack/devstack.go
+++ b/pkg/devstack/devstack.go
@@ -344,6 +344,9 @@ func NewDevStack(
 			if err = ctrl.Start(ctx); err != nil {
 				panic(err) // if controller can't run, devstack should stop
 			}
+			if err = transport.Start(ctx); err != nil {
+				panic(err) // if transport can't run, devstack should stop
+			}
 		}(context.Background())
 
 		log.Debug().Msgf("libp2p server started: %d", libp2pPort)

--- a/pkg/test/computenode/utils.go
+++ b/pkg/test/computenode/utils.go
@@ -121,8 +121,13 @@ func SetupTestNoop(
 		t.Fatal(err)
 	}
 
-	err = ctrl.Start(context.Background())
+	ctx := context.Background()
+	err = ctrl.Start(ctx)
 	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err = transport.Start(ctx); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/test/transport/transport_test.go
+++ b/pkg/test/transport/transport_test.go
@@ -107,7 +107,11 @@ func setupTest(t *testing.T) (
 	)
 	require.NoError(t, err)
 
-	err = ctrl.Start(context.Background())
+	ctx := context.Background()
+	err = ctrl.Start(ctx)
+	require.NoError(t, err)
+
+	err = transport.Start(ctx)
 	require.NoError(t, err)
 
 	return transport, noopExecutor, noopVerifier, ctrl, cm


### PR DESCRIPTION
Currently transport is started twice in the server. First inside [controller.Start()](https://github.com/filecoin-project/bacalhau/blob/main/pkg/controller/controller.go#L71), and second explicitly inside [serve.go](https://github.com/filecoin-project/bacalhau/blob/main/cmd/bacalhau/serve.go#L289) after starting the controller. 

There are two ways to fix this:
1. Only start transport inside the controller and remove it from `serve.go`. The issue here is that any transport subscribers added after starting the controller may lose some events. Besides, transport is a dependency passed to the controller and the controller should not mutate the transport state, including starting it or shutting it down.
2. Remove `transport.Start()` from the controller, and explicitly start the transport wherever needed. This is the approach that I went with in this PR, but I am interested in hearing others thoughts.
