### PR TITLE
Stop calling controlLoopBidOnJobs outside of the ticker

### DIFF
--- a/pkg/computenode/computenode.go
+++ b/pkg/computenode/computenode.go
@@ -24,7 +24,7 @@ import (
 
 const DefaultJobCPU = "100m"
 const DefaultJobMemory = "100Mb"
-const ControlLoopIntervalMinutes = 10
+const ControlLoopIntervalMillis = 10
 const DelayBeforeBidMillisecondRange = 100
 
 type ComputeNodeConfig struct {
@@ -140,11 +140,7 @@ func constructComputeNode(
 */
 
 func (node *ComputeNode) controlLoopSetup(cm *system.CleanupManager) {
-	// this won't hurt our throughput becauase we are calling
-	// controlLoopBidOnJobs right away as soon as a created event is
-	// seen or a job has finished
-
-	ticker := time.NewTicker(time.Minute * ControlLoopIntervalMinutes)
+	ticker := time.NewTicker(time.Millisecond * ControlLoopIntervalMillis)
 	ctx, cancelFunction := context.WithCancel(context.Background())
 
 	cm.RegisterCallback(func() error {
@@ -155,7 +151,7 @@ func (node *ComputeNode) controlLoopSetup(cm *system.CleanupManager) {
 	for {
 		select {
 		case <-ticker.C:
-			node.controlLoopBidOnJobs("tick")
+			node.controlLoopBidOnJobs()
 		case <-ctx.Done():
 			ticker.Stop()
 			return
@@ -170,13 +166,11 @@ func (node *ComputeNode) controlLoopSetup(cm *system.CleanupManager) {
 //   - if there is enough in the remaining then bid
 //   - add each bid on job to the "projected resources"
 //   - repeat until project resources >= total resources or no more jobs in queue
-func (node *ComputeNode) controlLoopBidOnJobs(debug string) {
-	log.Debug().Msgf("[%s] starting controlLoopBidOnJobs because %s, acq lock", node.id[:8], debug)
+func (node *ComputeNode) controlLoopBidOnJobs() {
 	node.bidMu.Lock()
 	defer node.bidMu.Unlock()
 	bidJobIds := node.capacityManager.GetNextItems()
 
-	log.Debug().Msgf("len(bidJobIds)=%d", len(bidJobIds))
 	for _, flatID := range bidJobIds {
 		jobID, shardIndex, err := capacitymanager.ExplodeShardID(flatID)
 		if err != nil {

--- a/pkg/computenode/computenode.go
+++ b/pkg/computenode/computenode.go
@@ -24,7 +24,7 @@ import (
 
 const DefaultJobCPU = "100m"
 const DefaultJobMemory = "100Mb"
-const ControlLoopIntervalMillis = 10
+const ControlLoopIntervalMillis = 100
 const DelayBeforeBidMillisecondRange = 100
 
 type ComputeNodeConfig struct {

--- a/pkg/computenode/shard_fsm.go
+++ b/pkg/computenode/shard_fsm.go
@@ -294,9 +294,6 @@ func (m *shardStateMachine) transitionedTo(newState shardStateType) {
 func enqueuedState(m *shardStateMachine) StateFn {
 	m.transitionedTo(shardEnqueued)
 
-	// trigger the bidding loop as soon as the shard state is updated to enqueued.
-	go m.node.controlLoopBidOnJobs("job enqueud")
-
 	for {
 		req := <-m.req
 		switch req.action {
@@ -438,9 +435,5 @@ func errorState(m *shardStateMachine) StateFn {
 // we always reach this state, whether the job completed successfully or due to a failure.
 func completedState(m *shardStateMachine) StateFn {
 	m.transitionedTo(shardCompleted)
-
-	// once we've finished this shard - let's see if we should
-	// bid on another shard or if we've finished the job
-	go m.node.controlLoopBidOnJobs("job completed")
 	return nil
 }


### PR DESCRIPTION
We have a bimodal behaviour on how compute nodes trigger the job bidding loop:
1. We have a periodic job that runs every 10 minutes
2. We trigger the loop when a bid is rejected as capacity is released
3. We trigger the loop when a job is completed 

These are over optimizations in our aim to bid for a job as soon as possible, but it adds extra complexity and can make debugging issues more challenging.

The proposal here is to only trigger the loop inside the periodic job, and reduce the ticks from 10 minutes to 100ms. I ran benchmarks using 3, 100 and 200 nodes and I didn't see any degradation. In contrary, I am getting less deviated numbers across retries with this change, but I don't have metrics to explain why