### PR TITLE
Add RunOutput to describe cmd

### DIFF
--- a/cmd/bacalhau/describe.go
+++ b/cmd/bacalhau/describe.go
@@ -70,11 +70,12 @@ type localEventDescription struct {
 }
 
 type shardNodeStateDescription struct {
-	Node     string `yaml:"Node"`
-	State    string `yaml:"State"`
-	Status   string `yaml:"Status"`
-	Verified bool   `yaml:"Verified"`
-	ResultID string `yaml:"ResultID"`
+	Node      string                  `yaml:"Node"`
+	State     string                  `yaml:"State"`
+	Status    string                  `yaml:"Status"`
+	Verified  bool                    `yaml:"Verified"`
+	ResultID  string                  `yaml:"ResultID"`
+	RunOutput *model.RunCommandResult `yaml:"RunOutput"`
 }
 
 type shardStateDescription struct {
@@ -203,11 +204,12 @@ var describeCmd = &cobra.Command{
 				}
 			}
 			shardDescription.Nodes = append(shardDescription.Nodes, shardNodeStateDescription{
-				Node:     shard.NodeID,
-				State:    shard.State.String(),
-				Status:   shard.Status,
-				Verified: shard.VerificationResult.Result,
-				ResultID: shard.PublishedResult.Cid,
+				Node:      shard.NodeID,
+				State:     shard.State.String(),
+				Status:    shard.Status,
+				Verified:  shard.VerificationResult.Result,
+				ResultID:  shard.PublishedResult.Cid,
+				RunOutput: shard.RunOutput,
 			})
 			shardDescriptions[shard.ShardIndex] = shardDescription
 		}

--- a/pkg/computenode/computenode.go
+++ b/pkg/computenode/computenode.go
@@ -571,7 +571,7 @@ func (n *ComputeNode) RunShardExecution(ctx context.Context, shard model.JobShar
 	// check that we have the executor to run this job
 	e, err := n.getExecutor(ctx, shard.Job.Spec.Engine)
 	if err != nil {
-		return &model.RunCommandResult{Error: err}, err
+		return &model.RunCommandResult{ErrorMsg: err.Error()}, err
 	}
 	return e.RunShard(ctx, shard, resultFolder)
 }
@@ -582,12 +582,12 @@ func (n *ComputeNode) RunShard(ctx context.Context, shard model.JobShard) ([]byt
 
 	verifier, err := n.getVerifier(ctx, shard.Job.Spec.Verifier)
 	if err != nil {
-		runOutput.Error = err
+		runOutput.ErrorMsg = err.Error()
 		return shardProposal, runOutput, err
 	}
 	resultFolder, err := verifier.GetShardResultPath(ctx, shard)
 	if err != nil {
-		runOutput.Error = err
+		runOutput.ErrorMsg = err.Error()
 		return shardProposal, runOutput, err
 	}
 
@@ -611,7 +611,9 @@ func (n *ComputeNode) RunShard(ctx context.Context, shard model.JobShard) ([]byt
 	// we don't pass the results off to the verifier
 	if err == nil {
 		shardProposal, err = verifier.GetShardProposal(ctx, shard, resultFolder)
-		runOutput.Error = err
+		if err != nil {
+			runOutput.ErrorMsg = err.Error()
+		}
 	}
 
 	return shardProposal, runOutput, err

--- a/pkg/computenode/shard_fsm.go
+++ b/pkg/computenode/shard_fsm.go
@@ -205,11 +205,14 @@ type shardStateMachine struct {
 	mu      sync.Mutex
 	req     chan shardStateRequest
 
-	currentState   shardStateType
-	previousState  shardStateType
+	currentState  shardStateType
+	previousState shardStateType
+
+	runOutput      *model.RunCommandResult
 	resultProposal []byte
-	bidSent        bool
 	errorMsg       string
+
+	bidSent bool
 }
 
 func (m *shardStateMachineManager) newStateMachine(
@@ -358,11 +361,8 @@ func runningState(ctx context.Context, m *shardStateMachine) StateFn {
 	// we get a "proposal" from this method which is not the results
 	// but what the compute node verifier wants to pass to the requester
 	// node verifier
-
-	// Need to do something with RunOutput
-	// proposal, runOutput, err := m.node.RunShard(ctx, m.Shard)
-
-	proposal, _, err := m.node.RunShard(ctx, m.Shard)
+	proposal, runOutput, err := m.node.RunShard(ctx, m.Shard)
+	m.runOutput = runOutput
 	if err == nil {
 		m.resultProposal = proposal
 		return publishingToVerifierState
@@ -387,6 +387,7 @@ func publishingToVerifierState(ctx context.Context, m *shardStateMachine) StateF
 		m.Shard.Index,
 		fmt.Sprintf("Got results proposal of length: %d", len(m.resultProposal)),
 		m.resultProposal,
+		m.runOutput,
 	)
 
 	if err != nil {
@@ -455,6 +456,7 @@ func errorState(ctx context.Context, m *shardStateMachine) StateFn {
 			m.Shard.Job.ID,
 			m.Shard.Index,
 			errMessage,
+			m.runOutput,
 		)
 		if err != nil {
 			log.Error().Msgf("%s failed to report error of job due to %s",

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -373,6 +373,7 @@ func (ctrl *Controller) ShardExecutionFinished(
 	shardIndex int,
 	status string,
 	proposal []byte,
+	runOutput *model.RunCommandResult,
 ) error {
 	jobCtx := ctrl.getJobNodeContext(ctx, jobID)
 	ctrl.addJobLifecycleEvent(jobCtx, jobID, "write_ShardExecutionFinished")
@@ -380,6 +381,7 @@ func (ctrl *Controller) ShardExecutionFinished(
 	ev.Status = status
 	ev.VerificationProposal = proposal
 	ev.ShardIndex = shardIndex
+	ev.RunOutput = runOutput
 	return ctrl.writeEvent(jobCtx, ev)
 }
 
@@ -402,12 +404,14 @@ func (ctrl *Controller) ShardError(
 	jobID string,
 	shardIndex int,
 	status string,
+	runOutput *model.RunCommandResult,
 ) error {
 	jobCtx := ctrl.getJobNodeContext(ctx, jobID)
 	ctrl.addJobLifecycleEvent(jobCtx, jobID, "write_ShardError")
 	ev := ctrl.constructEvent(jobID, model.JobEventError)
 	ev.Status = status
 	ev.ShardIndex = shardIndex
+	ev.RunOutput = runOutput
 	return ctrl.writeEvent(jobCtx, ev)
 }
 
@@ -548,6 +552,7 @@ func (ctrl *Controller) mutateDatastore(ctx context.Context, ev model.JobEvent) 
 				VerificationProposal: ev.VerificationProposal,
 				VerificationResult:   ev.VerificationResult,
 				PublishedResult:      ev.PublishedResult,
+				RunOutput:            ev.RunOutput,
 			},
 		)
 		if err != nil {

--- a/pkg/executor/language/executor.go
+++ b/pkg/executor/language/executor.go
@@ -52,7 +52,7 @@ func (e *Executor) RunShard(
 ) (*model.RunCommandResult, error) {
 	if shard.Job.Spec.Language.Language != "python" && shard.Job.Spec.Language.LanguageVersion != "3.10" {
 		err := fmt.Errorf("only python 3.10 is supported")
-		return &model.RunCommandResult{Error: err}, err
+		return &model.RunCommandResult{ErrorMsg: err.Error()}, err
 	}
 
 	if shard.Job.Spec.Language.Deterministic {
@@ -64,7 +64,7 @@ func (e *Executor) RunShard(
 		log.Debug().Msgf("running arbitrary python 3.10")
 		err := fmt.Errorf("arbitrary python not supported yet")
 		// TODO: Instantiate a docker with python:3.10 image
-		return &model.RunCommandResult{Error: err}, err
+		return &model.RunCommandResult{ErrorMsg: err.Error()}, err
 	}
 }
 

--- a/pkg/ipfs/downloader.go
+++ b/pkg/ipfs/downloader.go
@@ -194,12 +194,12 @@ func moveResults(ctx context.Context,
 		}
 		log.Info().Msgf("Combining shard from output volume '%s' to final location: '%s'", outputVolume.Name, finalOutputDirAbs)
 
-		r := system.UnsafeForUserCodeRunCommand("bash", []string{
+		_, err = system.UnsafeForUserCodeRunCommand("bash", []string{
 			"-c",
 			fmt.Sprintf("find %s -name '*' -type f -exec mv -f {} %s \\;", volumeSourceDir, volumeOutputDir),
 		})
-		if r.Error != nil {
-			return r.Error
+		if err != nil {
+			return err
 		}
 	}
 
@@ -224,7 +224,7 @@ func catStdFiles(ctx context.Context,
 		"stdout",
 		"stderr",
 	} {
-		r := system.UnsafeForUserCodeRunCommand("bash", []string{
+		_, err := system.UnsafeForUserCodeRunCommand("bash", []string{
 			"-c",
 			fmt.Sprintf(
 				"cat %s >> %s",
@@ -232,8 +232,8 @@ func catStdFiles(ctx context.Context,
 				filepath.Join(finalOutputDirAbs, filename),
 			),
 		})
-		if r.Error != nil {
-			return r.Error
+		if err != nil {
+			return err
 		}
 	}
 	return nil
@@ -251,12 +251,12 @@ func moveStdFiles(ctx context.Context,
 		"stderr",
 		"exitCode",
 	} {
-		r := system.UnsafeForUserCodeRunCommand("mv", []string{
+		_, err = system.UnsafeForUserCodeRunCommand("mv", []string{
 			filepath.Join(shardDownloadDir, filename),
 			shardOutputDir,
 		})
-		if r.Error != nil {
-			return r.Error
+		if err != nil {
+			return err
 		}
 	}
 	return nil

--- a/pkg/localdb/inmemory/inmemory.go
+++ b/pkg/localdb/inmemory/inmemory.go
@@ -249,6 +249,10 @@ func (d *InMemoryDatastore) UpdateShardState(
 		shardSate.Status = update.Status
 	}
 
+	if update.RunOutput != nil {
+		shardSate.RunOutput = update.RunOutput
+	}
+
 	if len(update.VerificationProposal) != 0 {
 		shardSate.VerificationProposal = update.VerificationProposal
 	}

--- a/pkg/model/command.go
+++ b/pkg/model/command.go
@@ -1,23 +1,23 @@
 package model
 
 type RunCommandResult struct {
-	// stdout of the run.
-	STDOUT string `json:"stdout"`
+	// stdout of the run. Yaml provided for `describe` output
+	STDOUT string `json:"stdout" yaml:"Stdout"`
 
 	// bool describing if stdout was truncated
-	StdoutTruncated bool `json:"stdouttruncated"`
+	StdoutTruncated bool `json:"stdouttruncated" yaml:"StdoutTruncated"`
 
 	// stderr of the run.
-	STDERR string `json:"stderr"`
+	STDERR string `json:"stderr" yaml:"Stderr"`
 
 	// bool describing if stderr was truncated
-	StderrTruncated bool `json:"stderrtruncated"`
+	StderrTruncated bool `json:"stderrtruncated" yaml:"StderrTruncated"`
 
 	// exit code of the run.
-	ExitCode int `json:"exitCode"`
+	ExitCode int `json:"exitCode" yaml:"ExitCode"`
 
 	// Runner error
-	Error error `json:"runnerError"`
+	ErrorMsg string `json:"runnerError" yaml:"RunnerError"`
 }
 
 func NewRunCommandResult() *RunCommandResult {

--- a/pkg/model/job.go
+++ b/pkg/model/job.go
@@ -106,6 +106,7 @@ type JobShardState struct {
 	VerificationProposal []byte             `json:"verification_proposal"`
 	VerificationResult   VerificationResult `json:"verification_result"`
 	PublishedResult      StorageSpec        `json:"published_results"`
+	RunOutput            *RunCommandResult  `json:"run_output"`
 }
 
 // The deal the client has made with the bacalhau network.
@@ -235,6 +236,7 @@ type JobEvent struct {
 	// this is only defined in "update_deal" events
 	JobDeal              JobDeal            `json:"job_deal"`
 	Status               string             `json:"status"`
+	RunOutput            *RunCommandResult  `json:"run_output"`
 	VerificationProposal []byte             `json:"verification_proposal"`
 	VerificationResult   VerificationResult `json:"verification_result"`
 	PublishedResult      StorageSpec        `json:"published_results"`

--- a/pkg/requesternode/requesternode.go
+++ b/pkg/requesternode/requesternode.go
@@ -140,6 +140,7 @@ func (node *RequesterNode) subscriptionEventShardExecutionComplete(
 			job.ID,
 			jobEvent.ShardIndex,
 			err.Error(),
+			nil,
 		)
 		if err != nil {
 			log.Debug().Msgf("ErrorShard failed: %s", err.Error())

--- a/pkg/storage/ipfs_apicopy/storage.go
+++ b/pkg/storage/ipfs_apicopy/storage.go
@@ -106,10 +106,10 @@ func (dockerIPFS *StorageProvider) PrepareStorage(ctx context.Context, storageSp
 
 //nolint:lll // Exception to the long rule
 func (dockerIPFS *StorageProvider) CleanupStorage(ctx context.Context, storageSpec model.StorageSpec, volume storage.StorageVolume) error {
-	r := system.UnsafeForUserCodeRunCommand("rm", []string{
+	_, err := system.UnsafeForUserCodeRunCommand("rm", []string{
 		"-rf", fmt.Sprintf("%s/%s", dockerIPFS.LocalDir, storageSpec.Cid),
 	})
-	return r.Error
+	return err
 }
 
 func (dockerIPFS *StorageProvider) Upload(ctx context.Context, localPath string) (model.StorageSpec, error) {

--- a/pkg/storage/ipfs_fusedocker/storage.go
+++ b/pkg/storage/ipfs_fusedocker/storage.go
@@ -384,11 +384,11 @@ func (sp *StorageProvider) canSeeFuseMount(ctx context.Context, cid string) bool
 	if err != nil {
 		return false
 	}
-	r := system.UnsafeForUserCodeRunCommand("sudo", []string{
+	_, err = system.UnsafeForUserCodeRunCommand("sudo", []string{
 		"timeout", "1s", "ls", "-la",
 		testMountPath,
 	})
-	return r.Error == nil
+	return err == nil
 }
 
 func cleanupStorageDriver(ctx context.Context, storageHandler *StorageProvider) error {
@@ -435,19 +435,19 @@ func createMountDir() (string, error) {
 }
 
 func cleanupMountDir(mountDir string) error {
-	r := system.UnsafeForUserCodeRunCommand("sudo", []string{
+	_, err := system.UnsafeForUserCodeRunCommand("sudo", []string{
 		"umount",
 		fmt.Sprintf("%s/data", mountDir),
 	})
-	if r.Error != nil {
-		return r.Error
+	if err != nil {
+		return err
 	}
-	r = system.UnsafeForUserCodeRunCommand("sudo", []string{
+	_, err = system.UnsafeForUserCodeRunCommand("sudo", []string{
 		"umount",
 		fmt.Sprintf("%s/ipns", mountDir),
 	})
-	if r.Error != nil {
-		return r.Error
+	if err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/storage/url/urldownload/storage.go
+++ b/pkg/storage/url/urldownload/storage.go
@@ -101,10 +101,14 @@ func (sp *StorageProvider) CleanupStorage(
 	pathToCleanup := filepath.Dir(volume.Source)
 	log.Debug().Msgf("Cleaning up: %s", pathToCleanup)
 
-	r := system.UnsafeForUserCodeRunCommand("rm", []string{
+	_, err := system.UnsafeForUserCodeRunCommand("rm", []string{
 		"-rf", pathToCleanup,
 	})
-	return r.Error
+
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // we don't "upload" anything to a URL

--- a/pkg/system/tracer.go
+++ b/pkg/system/tracer.go
@@ -298,12 +298,12 @@ func AddNodeIDFromBaggageToSpan(ctx context.Context, span oteltrace.Span) {
 
 func AddAttributeToSpanFromBaggage(ctx context.Context, span oteltrace.Span, name string) {
 	b := baggage.FromContext(ctx)
-	log.Debug().Msgf("adding %s from baggage to span as attribute: %+v", name, b)
+	log.Trace().Msgf("adding %s from baggage to span as attribute: %+v", name, b)
 	m := b.Member(name)
 	if m.Value() != "" {
 		span.SetAttributes(attribute.String(name, m.Value()))
 	} else {
-		log.Debug().Msgf("no value found for baggage key %s", name)
+		log.Trace().Msgf("no value found for baggage key %s", name)
 		if log.Trace().Enabled() {
 			debug.PrintStack()
 		}

--- a/pkg/system/utils.go
+++ b/pkg/system/utils.go
@@ -214,21 +214,20 @@ func runCommandResultsToDisk(command string, args []string,
 	return r, err
 }
 
-func readProcessOutputFromFile(f *os.File, maxVariableReturnLengthInBytes int) (string, bool, error) {
+func readProcessOutputFromFile(f *os.File, maxVariableReturnLengthInBytes int) (output string, isTruncated bool, err error) {
 	log.Trace().Msgf("Reading from file: %s", f.Name())
-	isTruncated := false
 
 	// start by resetting the file seek position
-	_, err := f.Seek(0, io.SeekStart)
+	_, err = f.Seek(0, io.SeekStart)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error seeking to beginning of file: %s", f.Name())
 		return "", isTruncated, err
 	}
 
-	_, err := f.Seek(0, 0) // reset to zero
+	_, err = f.Seek(0, 0) // reset to zero
 	if err != nil {
 		log.Error().Err(err).Msgf("Error seeking to beginning of file: %s", f.Name())
-		return "", err
+		return "", isTruncated, err
 	}
 
 	fileStat, err := f.Stat()

--- a/pkg/system/waiters.go
+++ b/pkg/system/waiters.go
@@ -32,14 +32,14 @@ func WaitForFileSudo(path string, maxAttempts int, delay time.Duration) error {
 		MaxAttempts: maxAttempts,
 		Delay:       delay,
 		Handler: func() (bool, error) {
-			r := UnsafeForUserCodeRunCommand("sudo", []string{
+			r, err := UnsafeForUserCodeRunCommand("sudo", []string{
 				"ls", "-la",
 				path,
 			})
 
-			fmt.Printf("AFTER CHECK: %s %+v\n", r.STDOUT, r.Error)
-			if r.Error != nil {
-				return false, r.Error
+			fmt.Printf("AFTER CHECK: %s %+v\n", r.STDOUT, err)
+			if err != nil {
+				return false, err
 			}
 			return true, nil
 		},

--- a/pkg/test/computenode/runjob_test.go
+++ b/pkg/test/computenode/runjob_test.go
@@ -72,7 +72,7 @@ func (suite *ComputeNodeRunJobSuite) TestRunJob() {
 	}
 	runnerOutput, err := computeNode.RunShardExecution(ctx, shard, result)
 	require.NoError(suite.T(), err)
-	require.Equal(suite.T(), runnerOutput.Error, err)
+	require.Empty(suite.T(), runnerOutput.ErrorMsg)
 
 	stdoutPath := fmt.Sprintf("%s/stdout", result)
 	require.FileExists(suite.T(), stdoutPath, "The stdout file exists")
@@ -103,5 +103,5 @@ func (suite *ComputeNodeRunJobSuite) TestEmptySpec() {
 	}
 	runnerOutput, err := computeNode.RunShardExecution(ctx, shard, "")
 	require.Error(suite.T(), err)
-	require.Equal(suite.T(), runnerOutput.Error, err)
+	require.Equal(suite.T(), runnerOutput.ErrorMsg, err.Error())
 }

--- a/pkg/test/computenode/utils.go
+++ b/pkg/test/computenode/utils.go
@@ -83,7 +83,7 @@ func RunJobGetStdout(
 	}
 	runnerOutput, err := computeNode.RunShardExecution(ctx, shard, result)
 	require.NoError(t, err)
-	require.Equal(t, runnerOutput.ErrorMsg, err.Error())
+	require.Empty(t, runnerOutput.ErrorMsg)
 
 	stdoutPath := fmt.Sprintf("%s/stdout", result)
 	require.DirExists(t, result, "The job result folder exists")

--- a/pkg/test/computenode/utils.go
+++ b/pkg/test/computenode/utils.go
@@ -83,7 +83,7 @@ func RunJobGetStdout(
 	}
 	runnerOutput, err := computeNode.RunShardExecution(ctx, shard, result)
 	require.NoError(t, err)
-	require.Equal(t, runnerOutput.Error, err)
+	require.Equal(t, runnerOutput.ErrorMsg, err.Error())
 
 	stdoutPath := fmt.Sprintf("%s/stdout", result)
 	require.DirExists(t, result, "The job result folder exists")

--- a/pkg/test/devstack/utils.go
+++ b/pkg/test/devstack/utils.go
@@ -168,10 +168,13 @@ func RunDeterministicVerifierTest( //nolint:funlen
 					if nodeConfig.IsBadActor {
 						runOutput.STDOUT = fmt.Sprintf("i am bad and deserve to fail %d", shard.Index)
 					}
-					runOutput.Error = os.WriteFile(fmt.Sprintf("%s/stdout", resultsDir), []byte(runOutput.STDOUT), 0600) //nolint:gomnd
+					err := os.WriteFile(fmt.Sprintf("%s/stdout", resultsDir), []byte(runOutput.STDOUT), 0600) //nolint:gomnd
+					if err != nil {
+						runOutput.ErrorMsg = err.Error()
+					}
 
 					// Adding explicit error for consistency in function signatures
-					return runOutput, runOutput.Error
+					return runOutput, err
 				},
 			},
 		})

--- a/pkg/test/executor/docker_executor_test.go
+++ b/pkg/test/executor/docker_executor_test.go
@@ -106,8 +106,8 @@ func dockerExecutorStorageTest(
 		require.NoError(t, err)
 
 		runnerOutput, err := dockerExecutor.RunShard(ctx, shard, resultsDirectory)
-		require.NoError(t, runnerOutput.Error)
-		require.Equal(t, runnerOutput.Error, err)
+		require.NoError(t, err)
+		require.Empty(t, runnerOutput.ErrorMsg)
 
 		err = testCase.ResultsChecker(resultsDirectory)
 		require.NoError(t, err)

--- a/pkg/test/ipfs/ipfs_host_storage_test.go
+++ b/pkg/test/ipfs/ipfs_host_storage_test.go
@@ -120,7 +120,7 @@ func runFileTest(t *testing.T, engine model.StorageSourceType, getStorageDriver 
 	// 	"cat",
 	// 	volume.Source,
 	// })
-	r := system.UnsafeForUserCodeRunCommand("cat", []string{
+	r, err := system.UnsafeForUserCodeRunCommand("cat", []string{
 		volume.Source,
 	})
 	require.NoError(t, err)
@@ -181,7 +181,7 @@ func runFolderTest(t *testing.T, engine model.StorageSourceType, getStorageDrive
 	// 	"cat",
 	// 	fmt.Sprintf("%s/file.txt", volume.Source),
 	// })
-	r := system.UnsafeForUserCodeRunCommand("cat", []string{
+	r, err := system.UnsafeForUserCodeRunCommand("cat", []string{
 		fmt.Sprintf("%s/file.txt", volume.Source),
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
Few other things I had to do for this change to work:
1. had to change `RunCommandResult.Error` of type `error` to `RunCommandResult.ErrorMsg` of type `string` due to failing to un/marshal error types
2. Reset stdout and stderr files's cursors as we were reading from the end of the files and returning blank output

### Sample output not Truncated 
```
→ bacalhau_local docker run ubuntu echo Hello World --wait | xargs bacalhau_local describe
Id: 1b172d6b-b799-4c08-9404-495c87d09bd9
ClientID: 6c873b593515cfe5c6d3a7ccad987b12d2c1b872607c84468cd038bcb5c3cf65
RequesterNodeId: QmXwbRDdRVJEturtw3yTLJXxM6fWiv7tdLAUdEh3cPr6kj
Spec:
    Engine: Docker
    Verifier: Noop
    Docker:
        Image: ubuntu
        Entrypoint Command:
            - echo
            - Hello
            - World
        Submitted Env Variables: []
        CPU Allocated: ""
        Memory Allocated: ""
        Inputs: []
        Outputs: []
        Annotations: []
    Deployment:
        Concurrency: 0
        Confidence: 0
        Assigned Nodes: []
Deal:
    concurrency: 1
    confidence: 0
    minbids: 0
Shards:
    - ShardIndex: 0
      Nodes:
        - Node: QmXP2bRVZxFfz79Qm1MrU2FquvoLYxWX8ALxhW55HiuMR3
          State: Completed
          Status: 'Got results proposal of length: 0'
          Verified: true
          ResultID: QmYnaUZLWmbRTJzpx6kgxoAVT3ZAmhqWY6qWZm33v8PjNm
          RunOutput:
            Stdout: Hello World
            StdoutTruncated: false
            Stderr: ""
            StderrTruncated: false
            ExitCode: 0
            RunnerError: ""
Start Time: 2022-09-21T14:36:44.424138-07:00
```

### Sample Output Truncated:
```
→ bacalhau_local docker run ubuntu printf 'A%.0s' {1..3000} --wait | xargs bacalhau_local describe
...
...
we are printing the whole input, we should also trim it
...
...
Deal:
    concurrency: 1
    confidence: 0
    minbids: 0
Shards:
    - ShardIndex: 0
      Nodes:
        - Node: QmXpbWMxiHqomdcA54XRf1jGTDpUT4iWCx4g49n6ovX3bF
          State: Completed
          Status: 'Got results proposal of length: 0'
          Verified: true
          ResultID: QmdvoQLuhYTqJtKTicDG3WBPPbWsvd1NwYG3EAi4bAmHAa
          RunOutput:
            Stdout: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
            StdoutTruncated: true
            Stderr: ""
            StderrTruncated: false
            ExitCode: 0
            RunnerError: ""
Start Time: 2022-09-21T14:37:56.772455-07:00
```

### Sample Output with an Error:
```
→ bacalhau_local docker run ubuntu dummy_command
→ bacalhau_local describe 25fa036c-b706-4a9d-9e32-55aa84f137a8
Id: 25fa036c-b706-4a9d-9e32-55aa84f137a8
ClientID: 6c873b593515cfe5c6d3a7ccad987b12d2c1b872607c84468cd038bcb5c3cf65
RequesterNodeId: QmXwbRDdRVJEturtw3yTLJXxM6fWiv7tdLAUdEh3cPr6kj
Spec:
    Engine: Docker
    Verifier: Noop
    Docker:
        Image: ubuntu
        Entrypoint Command:
            - dummy_command
        Submitted Env Variables: []
        CPU Allocated: ""
        Memory Allocated: ""
        Inputs: []
        Outputs: []
        Annotations: []
    Deployment:
        Concurrency: 0
        Confidence: 0
        Assigned Nodes: []
Deal:
    concurrency: 1
    confidence: 0
    minbids: 0
Shards:
    - ShardIndex: 0
      Nodes:
        - Node: QmXwbRDdRVJEturtw3yTLJXxM6fWiv7tdLAUdEh3cPr6kj
          State: Error
          Status: '[QmXwbRDd] shard: 25fa036c-b706-4a9d-9e32-55aa84f137a8:0 at state: Error error completing job due to Error response from daemon: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "dummy_command": executable file not found in $PATH: unknown'
          Verified: false
          ResultID: ""
          RunOutput:
            Stdout: ""
            StdoutTruncated: false
            Stderr: ""
            StderrTruncated: false
            ExitCode: 0
            RunnerError: 'failed to start container: Error response from daemon: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "dummy_command": executable file not found in $PATH: unknown'
Start Time: 2022-09-21T14:39:39.231356-07:00
```