### PR TITLE
611 make list work well

### DIFF
--- a/cmd/bacalhau/describe.go
+++ b/cmd/bacalhau/describe.go
@@ -147,49 +147,49 @@ var describeCmd = &cobra.Command{
 			return nil
 		}
 
-		jobState, err := GetAPIClient().GetJobState(ctx, j.ID)
+		jobState, err := GetAPIClient().GetJobState(ctx, j.Job.ID)
 		if err != nil {
-			log.Error().Msgf("Failure retrieving job states '%s': %s", j.ID, err)
+			log.Error().Msgf("Failure retrieving job states '%s': %s", j.Job.ID, err)
 			return err
 		}
 
-		jobEvents, err := GetAPIClient().GetEvents(ctx, j.ID)
+		jobEvents, err := GetAPIClient().GetEvents(ctx, j.Job.ID)
 		if err != nil {
-			log.Error().Msgf("Failure retrieving job events '%s': %s", j.ID, err)
+			log.Error().Msgf("Failure retrieving job events '%s': %s", j.Job.ID, err)
 			return err
 		}
 
-		localEvents, err := GetAPIClient().GetLocalEvents(ctx, j.ID)
+		localEvents, err := GetAPIClient().GetLocalEvents(ctx, j.Job.ID)
 		if err != nil {
-			log.Error().Msgf("Failure retrieving job events '%s': %s", j.ID, err)
+			log.Error().Msgf("Failure retrieving job events '%s': %s", j.Job.ID, err)
 			return err
 		}
 
 		jobDockerDesc := jobSpecDockerDescription{}
-		jobDockerDesc.Image = j.Spec.Docker.Image
-		jobDockerDesc.Entrypoint = j.Spec.Docker.Entrypoint
-		jobDockerDesc.Env = j.Spec.Docker.Env
+		jobDockerDesc.Image = j.Job.Spec.Docker.Image
+		jobDockerDesc.Entrypoint = j.Job.Spec.Docker.Entrypoint
+		jobDockerDesc.Env = j.Job.Spec.Docker.Env
 
-		jobDockerDesc.CPU = j.Spec.Resources.CPU
-		jobDockerDesc.Memory = j.Spec.Resources.Memory
+		jobDockerDesc.CPU = j.Job.Spec.Resources.CPU
+		jobDockerDesc.Memory = j.Job.Spec.Resources.Memory
 
 		jobSpecDesc := jobSpecDescription{}
-		jobSpecDesc.Engine = j.Spec.Engine.String()
+		jobSpecDesc.Engine = j.Job.Spec.Engine.String()
 
 		jobDealDesc := jobDealDescription{}
-		jobDealDesc.Concurrency = j.Deal.Concurrency
-		jobDealDesc.Confidence = j.Deal.Confidence
+		jobDealDesc.Concurrency = j.Job.Deal.Concurrency
+		jobDealDesc.Confidence = j.Job.Deal.Confidence
 
-		jobSpecDesc.Verifier = j.Spec.Verifier.String()
+		jobSpecDesc.Verifier = j.Job.Spec.Verifier.String()
 		jobSpecDesc.Docker = jobDockerDesc
 
 		jobDesc := jobDescription{}
-		jobDesc.ID = j.ID
-		jobDesc.ClientID = j.ClientID
-		jobDesc.RequesterNodeID = j.RequesterNodeID
+		jobDesc.ID = j.Job.ID
+		jobDesc.ClientID = j.Job.ClientID
+		jobDesc.RequesterNodeID = j.Job.RequesterNodeID
 		jobDesc.Spec = jobSpecDesc
-		jobDesc.Deal = j.Deal
-		jobDesc.CreatedAt = j.CreatedAt
+		jobDesc.Deal = j.Job.Deal
+		jobDesc.CreatedAt = j.Job.CreatedAt
 		jobDesc.Events = []eventDescription{}
 
 		shardDescriptions := map[int]shardStateDescription{}
@@ -251,7 +251,7 @@ var describeCmd = &cobra.Command{
 
 		bytes, err := yaml.Marshal(jobDesc)
 		if err != nil {
-			log.Error().Msgf("Failure marshaling job description '%s': %s", j.ID, err)
+			log.Error().Msgf("Failure marshaling job description '%s': %s", j.Job.ID, err)
 			return err
 		}
 

--- a/cmd/bacalhau/describe_test.go
+++ b/cmd/bacalhau/describe_test.go
@@ -125,7 +125,7 @@ func (suite *DescribeSuite) TestDescribeJob() {
 				// Short job id
 				_, out, err = ExecuteTestCobraCommand(suite.T(), suite.rootCmd, "describe",
 					"--api-host", host,
-					submittedJob.ID[0:6],
+					submittedJob.ID[0:8],
 					"--api-port", port,
 				)
 

--- a/cmd/bacalhau/docker_run_test.go
+++ b/cmd/bacalhau/docker_run_test.go
@@ -12,14 +12,12 @@ import (
 	"net/url"
 	"os"
 	"strconv"
-	"time"
-
-	"github.com/filecoin-project/bacalhau/pkg/devstack"
-
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/filecoin-project/bacalhau/pkg/computenode"
+	"github.com/filecoin-project/bacalhau/pkg/devstack"
 	"github.com/filecoin-project/bacalhau/pkg/publicapi"
 	"github.com/filecoin-project/bacalhau/pkg/system"
 	devstack_tests "github.com/filecoin-project/bacalhau/pkg/test/devstack"

--- a/cmd/bacalhau/docker_run_test.go
+++ b/cmd/bacalhau/docker_run_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	crand "crypto/rand"
 	"fmt"
-	"github.com/filecoin-project/bacalhau/pkg/devstack"
 	"io"
 	"io/ioutil"
 	"math/big"
@@ -14,6 +13,8 @@ import (
 	"os"
 	"strconv"
 	"time"
+
+	"github.com/filecoin-project/bacalhau/pkg/devstack"
 
 	"strings"
 	"testing"
@@ -141,7 +142,7 @@ func (suite *DockerRunSuite) TestRun_GPURequests() {
 				o := logBuf.String()
 				require.Contains(suite.T(), o, tc.errString, "Did not find expected error message in error string.\nExpected: %s\nActual: %s", tc.errString, o)
 			}
-			require.Equal(suite.T(), tc.numGPUs, job.Spec.Resources.GPU, "Expected %d GPUs, but got %d", tc.numGPUs, job.Spec.Resources.GPU)
+			require.Equal(suite.T(), tc.numGPUs, job.Job.Spec.Resources.GPU, "Expected %d GPUs, but got %d", tc.numGPUs, job.Job.Spec.Resources.GPU)
 		}()
 	}
 }
@@ -254,12 +255,12 @@ func (suite *DockerRunSuite) TestRun_SubmitInputs() {
 				require.NoError(suite.T(), err)
 				require.NotNil(suite.T(), job, "Failed to get job with ID: %s", out)
 
-				require.Equal(suite.T(), len(tcids.inputVolumes), len(job.Spec.Inputs), "Number of job inputs != # of test inputs .")
+				require.Equal(suite.T(), len(tcids.inputVolumes), len(job.Job.Spec.Inputs), "Number of job inputs != # of test inputs .")
 
 				// Need to do the below because ordering is not guaranteed
 				for _, tcidIV := range tcids.inputVolumes {
 					testCIDinJobInputs := false
-					for _, jobInput := range job.Spec.Inputs {
+					for _, jobInput := range job.Job.Spec.Inputs {
 						if tcidIV.cid == jobInput.Cid {
 							testCIDinJobInputs = true
 							testPath := "/inputs"
@@ -334,12 +335,12 @@ func (suite *DockerRunSuite) TestRun_SubmitUrlInputs() {
 				require.NoError(suite.T(), err)
 				require.NotNil(suite.T(), job, "Failed to get job with ID: %s", out)
 
-				require.Equal(suite.T(), len(turls.inputURLs), len(job.Spec.Inputs), "Number of job urls != # of test urls.")
+				require.Equal(suite.T(), len(turls.inputURLs), len(job.Job.Spec.Inputs), "Number of job urls != # of test urls.")
 
 				// Need to do the below because ordering is not guaranteed
 				for _, turlIU := range turls.inputURLs {
 					testURLinJobInputs := false
-					for _, jobInput := range job.Spec.Inputs {
+					for _, jobInput := range job.Job.Spec.Inputs {
 						if turlIU.url == jobInput.URL {
 							testURLinJobInputs = true
 							testPath := "/app2"
@@ -425,13 +426,13 @@ func (suite *DockerRunSuite) TestRun_SubmitOutputs() {
 				require.NoError(suite.T(), err)
 				require.NotNil(suite.T(), job, "Failed to get job with ID: %s", out)
 
-				require.Equal(suite.T(), tcids.correctLength, len(job.Spec.Outputs), "Number of job outputs != correct number.")
+				require.Equal(suite.T(), tcids.correctLength, len(job.Job.Spec.Outputs), "Number of job outputs != correct number.")
 
 				// Need to do the below because ordering is not guaranteed
 				for _, tcidOV := range tcids.outputVolumes {
 					testNameinJobOutputs := false
 					testPathinJobOutputs := false
-					for _, jobOutput := range job.Spec.Outputs {
+					for _, jobOutput := range job.Job.Spec.Outputs {
 						if tcidOV.name == "" {
 							if jobOutput.Name == "outputs" {
 								testNameinJobOutputs = true
@@ -488,10 +489,10 @@ func (suite *DockerRunSuite) TestRun_CreatedAt() {
 			j, _, err := c.Get(ctx, strings.TrimSpace(out))
 			require.NoError(suite.T(), err)
 			require.NotNil(suite.T(), j, "Failed to get job with ID: %s", out)
-			require.LessOrEqual(suite.T(), j.CreatedAt, time.Now(), "Created at time is not less than or equal to now.")
+			require.LessOrEqual(suite.T(), j.Job.CreatedAt, time.Now(), "Created at time is not less than or equal to now.")
 
 			oldStartTime, _ := time.Parse(time.RFC3339, "2021-01-01T01:01:01+00:00")
-			require.GreaterOrEqual(suite.T(), j.CreatedAt, oldStartTime, "Created at time is not greater or equal to 2022-01-01.")
+			require.GreaterOrEqual(suite.T(), j.Job.CreatedAt, oldStartTime, "Created at time is not greater or equal to 2022-01-01.")
 		}()
 
 	}
@@ -578,8 +579,8 @@ Actual length: %d
 
 Expected Annotations: %+v
 Actual Annotations: %+v
-`, labelTest.Name, len(labelTest.Annotations), len(testJob.Spec.Annotations), labelTest.Annotations, testJob.Spec.Annotations)
-					require.Equal(suite.T(), labelTest.CorrectLength, len(testJob.Spec.Annotations), msg)
+`, labelTest.Name, len(labelTest.Annotations), len(testJob.Job.Spec.Annotations), labelTest.Annotations, testJob.Job.Spec.Annotations)
+					require.Equal(suite.T(), labelTest.CorrectLength, len(testJob.Job.Spec.Annotations), msg)
 				}
 			}
 		}()
@@ -679,7 +680,7 @@ func (suite *DockerRunSuite) TestRun_SubmitWorkdir() {
 				require.NoError(suite.T(), err, "Error submitting job.")
 				job, _, err := c.Get(ctx, strings.TrimSpace(out))
 				require.NotNil(suite.T(), job, "Failed to get job with ID: %s", out)
-				require.Equal(suite.T(), tc.workdir, job.Spec.Docker.WorkingDir, "Job workdir != test workdir.")
+				require.Equal(suite.T(), tc.workdir, job.Job.Spec.Docker.WorkingDir, "Job workdir != test workdir.")
 				require.NoError(suite.T(), err, "Error in running command.")
 			}
 		}()

--- a/cmd/bacalhau/get.go
+++ b/cmd/bacalhau/get.go
@@ -77,7 +77,7 @@ var getCmd = &cobra.Command{
 			return err
 		}
 
-		results, err := GetAPIClient().GetResults(ctx, j.ID)
+		results, err := GetAPIClient().GetResults(ctx, j.Job.ID)
 		if err != nil {
 			return err
 		}
@@ -85,7 +85,7 @@ var getCmd = &cobra.Command{
 		err = ipfs.DownloadJob(
 			ctx,
 			cm,
-			j,
+			j.Job,
 			results,
 			OG.IPFSDownloadSettings,
 		)

--- a/cmd/bacalhau/get_test.go
+++ b/cmd/bacalhau/get_test.go
@@ -104,7 +104,7 @@ func (suite *GetSuite) TestGetJob() {
 				"--api-host", host,
 				"--api-port", port,
 				"--output-dir", outputDirWithID,
-				submittedJob.ID[0:6],
+				submittedJob.ID[0:8],
 			)
 			require.NoError(suite.T(), err, "Error in getting short job: %+v", err)
 

--- a/cmd/bacalhau/list.go
+++ b/cmd/bacalhau/list.go
@@ -76,7 +76,7 @@ func init() { //nolint:gochecknoinits // Using init in cobra command is idomatic
 		`The output format for the list of jobs (json or text)`,
 	)
 	listCmd.PersistentFlags().BoolVar(&OL.SortReverse, "reverse", OL.SortReverse,
-		`reverse order of table - for time sorting, this will be newest first. Use '--reverse=false' to sort oldest first.`)
+		`reverse order of table - for time sorting, this will be newest first. Use '--reverse=false' to sort oldest first (single quotes are required).`)
 
 	listCmd.PersistentFlags().Var(&OL.SortBy, "sort-by",
 		`sort by field, defaults to creation time, with newest first [Allowed "id", "created_at"].`)
@@ -91,7 +91,7 @@ func init() { //nolint:gochecknoinits // Using init in cobra command is idomatic
 	)
 	listCmd.PersistentFlags().BoolVar(
 		&OL.ReturnAll, "all", OL.ReturnAll,
-		`Fetch all jobs from the network (default is filter those that belong to the user). This may take a long time, please use with caution.`,
+		`Fetch all jobs from the network (default is to filter those belonging to the user). This option may take a long time to return, please use with caution.`,
 	)
 }
 

--- a/cmd/bacalhau/list.go
+++ b/cmd/bacalhau/list.go
@@ -140,7 +140,7 @@ var listCmd = &cobra.Command{
 
 		log.Debug().Msgf("Table filter flag set to: %s", OL.IDFilter)
 		log.Debug().Msgf("Table limit flag set to: %d", OL.MaxJobs)
-		log.Debug().Msgf("Table output format flag set to: %d", OL.OutputFormat)
+		log.Debug().Msgf("Table output format flag set to: %s", OL.OutputFormat)
 		log.Debug().Msgf("Table reverse flag set to: %t", OL.SortReverse)
 		log.Debug().Msgf("Found return all flag: %t", OL.ReturnAll)
 		log.Debug().Msgf("Found sort flag: %s", OL.SortBy)

--- a/cmd/bacalhau/list.go
+++ b/cmd/bacalhau/list.go
@@ -149,7 +149,7 @@ var listCmd = &cobra.Command{
 			return err
 		}
 
-		if OL.OutputFormat == "json" {
+		if OL.OutputFormat == JSONFormat {
 			msgBytes, err := json.MarshalIndent(jobs, "", "    ")
 			if err != nil {
 				return err
@@ -208,18 +208,6 @@ var listCmd = &cobra.Command{
 
 			tw.Render()
 		}
-
-		// if OL.OutputFormat == JSONFormat {
-		// 	msgBytes, err := json.MarshalIndent(jobs, "", "    ")
-		// 	if err != nil {
-		// 		return err
-		// 	}
-
-		// 	cmd.Printf("%s\n", msgBytes)
-		// 	return nil
-		// } else {
-		// 	tw.Render()
-		// }
 
 		return nil
 	},

--- a/cmd/bacalhau/list_test.go
+++ b/cmd/bacalhau/list_test.go
@@ -51,7 +51,7 @@ func (suite *ListSuite) TearDownAllSuite() {
 }
 
 type listResponse struct {
-	Jobs map[string]model.Job `json:"jobs"`
+	JobsWithInfo []model.JobWithInfo `json:"jobs"`
 }
 
 func (suite *ListSuite) TestList_NumberOfJobs() {
@@ -154,11 +154,11 @@ func (suite *ListSuite) TestList_IdFilter() {
 
 	// parse response
 	response := listResponse{}
-	err = json.Unmarshal([]byte(out), &response.Jobs)
+	err = json.Unmarshal([]byte(out), &response.JobsWithInfo)
 	require.NoError(suite.T(), err)
 
-	require.Contains(suite.T(), response.Jobs, jobLongIds[0], "The filtered job id was not found in the response")
-	require.Equal(suite.T(), 1, len(response.Jobs), "The list of jobs is not strictly filtered to the requested job id")
+	require.Contains(suite.T(), response.JobsWithInfo, jobLongIds[0], "The filtered job id was not found in the response")
+	require.Equal(suite.T(), 1, len(response.JobsWithInfo), "The list of jobs is not strictly filtered to the requested job id")
 }
 
 func (suite *ListSuite) TestList_SortFlags() {

--- a/cmd/bacalhau/list_test.go
+++ b/cmd/bacalhau/list_test.go
@@ -156,7 +156,7 @@ func (suite *ListSuite) TestList_IdFilter() {
 	response := listResponse{}
 	err = json.Unmarshal([]byte(out), &response.Jobs)
 	require.NoError(suite.T(), err)
-	
+
 	require.Contains(suite.T(), response.Jobs, jobLongIds[0], "The filtered job id was not found in the response")
 	require.Equal(suite.T(), 1, len(response.Jobs), "The list of jobs is not strictly filtered to the requested job id")
 }

--- a/go.work.sum
+++ b/go.work.sum
@@ -37,6 +37,9 @@ github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsK
 github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/slack-go/slack v0.11.3 h1:GN7revxEMax4amCc3El9a+9SGnjmBvSUobs0QnO6ZO8=
 github.com/slack-go/slack v0.11.3/go.mod h1:hlGi5oXA+Gt+yWTPP0plCdRKmjsDxecdHxYQdlMQKOw=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
+github.com/xeipuuv/gojsonschema v0.0.0-20180618132009-1d523034197f h1:mvXjJIHRZyhNuGassLTcXTwjiWq7NmjdavZsUnmFybQ=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.opentelemetry.io/contrib v0.20.0 h1:ubFQUn0VCZ0gPwIoJfBJVpeBlyRMxu8Mm/huKWYd9p0=
 go.opentelemetry.io/otel/exporters/otlp v0.20.0 h1:PTNgq9MRmQqqJY0REVbZFvwkYOA85vbdQU/nVfxDyqg=

--- a/ops/aws/canary/lambda/pkg/scenarios/list.go
+++ b/ops/aws/canary/lambda/pkg/scenarios/list.go
@@ -3,6 +3,7 @@ package scenarios
 import (
 	"context"
 	"fmt"
+
 	"github.com/filecoin-project/bacalhau/cmd/bacalhau"
 )
 
@@ -11,14 +12,14 @@ func List(ctx context.Context) error {
 	// scenario to mimic the behavior of bacalhau cli.
 	client := bacalhau.GetAPIClient()
 
-	jobs, err := client.List(ctx)
+	jobs, err := client.List(ctx, "", 10, false, "created_at", true)
 	if err != nil {
 		return err
 	}
 
 	count := 0
 	for _, j := range jobs {
-		fmt.Printf("Job: %s\n", j.ID)
+		fmt.Printf("Job: %s\n", j.Job.ID)
 		count++
 		if count > 10 {
 			break

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -131,7 +131,7 @@ func (ctrl *Controller) GetJobState(ctx context.Context, id string) (model.JobSt
 	return ctrl.localdb.GetJobState(ctx, id)
 }
 
-func (ctrl *Controller) GetJobs(ctx context.Context, query localdb.JobQuery) ([]model.Job, error) {	
+func (ctrl *Controller) GetJobs(ctx context.Context, query localdb.JobQuery) ([]model.Job, error) {
 	return ctrl.localdb.GetJobs(ctx, query)
 }
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -131,7 +131,7 @@ func (ctrl *Controller) GetJobState(ctx context.Context, id string) (model.JobSt
 	return ctrl.localdb.GetJobState(ctx, id)
 }
 
-func (ctrl *Controller) GetJobs(ctx context.Context, query localdb.JobQuery) ([]model.Job, error) {
+func (ctrl *Controller) GetJobs(ctx context.Context, query localdb.JobQuery) ([]model.Job, error) {	
 	return ctrl.localdb.GetJobs(ctx, query)
 }
 

--- a/pkg/job/util.go
+++ b/pkg/job/util.go
@@ -117,9 +117,7 @@ func buildJobOutputs(outputVolumes []string) ([]model.StorageSpec, error) {
 	return returnOutputVolumes, nil
 }
 
-func ShortID(outputWide bool, id string) string {
-	if outputWide {
-		return id
-	}
+// Shortens a Job ID e.g. `c42603b4-b418-4827-a9ca-d5a43338f2fe` to `c42603b4`
+func ShortID(id string) string {
 	return id[:8]
 }

--- a/pkg/job/util.go
+++ b/pkg/job/util.go
@@ -116,3 +116,10 @@ func buildJobOutputs(outputVolumes []string) ([]model.StorageSpec, error) {
 
 	return returnOutputVolumes, nil
 }
+
+func ShortID(outputWide bool, id string) string {
+	if outputWide {
+		return id
+	}
+	return id[:8]
+}

--- a/pkg/localdb/inmemory/inmemory.go
+++ b/pkg/localdb/inmemory/inmemory.go
@@ -171,7 +171,6 @@ func (d *InMemoryDatastore) AddJob(ctx context.Context, job model.Job) error {
 
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
-	// log.Debug().Msgf("jobs in datastore: %v", d.jobs)
 	existingJob, ok := d.jobs[job.ID]
 	if ok {
 		if len(job.RequesterPublicKey) > 0 {

--- a/pkg/localdb/inmemory/inmemory.go
+++ b/pkg/localdb/inmemory/inmemory.go
@@ -47,10 +47,10 @@ func (d *InMemoryDatastore) GetJob(ctx context.Context, id string) (model.Job, e
 	defer d.mtx.RUnlock()
 
 	// support for short job IDs
-	if jobutils.ShortID(false, id) == id {
+	if jobutils.ShortID(id) == id {
 		// passed in a short id, need to resolve the long id first
 		for k := range d.jobs {
-			if jobutils.ShortID(false, k) == id {
+			if jobutils.ShortID(k) == id {
 				id = k
 				break
 			}

--- a/pkg/localdb/inmemory/inmemory.go
+++ b/pkg/localdb/inmemory/inmemory.go
@@ -46,7 +46,7 @@ func (d *InMemoryDatastore) GetJob(ctx context.Context, id string) (model.Job, e
 	d.mtx.RLock()
 	defer d.mtx.RUnlock()
 
-	// support short job IDs
+	// support for short job IDs
 	if jobutils.ShortID(false, id) == id {
 		// passed in a short id, need to resolve the long id first
 		for k := range d.jobs {
@@ -134,14 +134,12 @@ func (d *InMemoryDatastore) GetJobs(ctx context.Context, query localdb.JobQuery)
 			}
 		}
 
-		// TODO @enricorotundo add span
-
 		// sort results
 		log.Debug().Msgf("sorting by %s", query.SortBy)
 		sort.Slice(result, func(i, j int) bool {
 			switch query.SortBy {
 			case "id":
-				// are IDs lexically sortable?
+				// what does it mean to sort by ID?
 				return result[i].ID < result[j].ID
 			case "created_at":
 				return result[i].CreatedAt.UTC().Unix() < result[j].CreatedAt.UTC().Unix()

--- a/pkg/localdb/inmemory/inmemory_test.go
+++ b/pkg/localdb/inmemory/inmemory_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestInMemoryDataStore(t *testing.T) {
 
-	jobId := "123"
+	jobId := "12345678" // short ID is 8 chars long
 	nodeId := "456"
 	shardIndex := 1
 

--- a/pkg/localdb/types.go
+++ b/pkg/localdb/types.go
@@ -7,7 +7,12 @@ import (
 )
 
 type JobQuery struct {
-	ID string `json:"id"`
+	ID        string `json:"id"`
+	ClientID  string `json:"clientID"`
+	Limit     int    `json:"limit"`
+	ReturnAll bool   `json:"return_all"`
+	SortBy      string `json:"sort_by"`
+	SortReverse bool   `json:"sort_reverse"`
 }
 
 // A LocalDB will persist jobs and their state to the underlying storage.

--- a/pkg/localdb/types.go
+++ b/pkg/localdb/types.go
@@ -7,10 +7,10 @@ import (
 )
 
 type JobQuery struct {
-	ID        string `json:"id"`
-	ClientID  string `json:"clientID"`
-	Limit     int    `json:"limit"`
-	ReturnAll bool   `json:"return_all"`
+	ID          string `json:"id"`
+	ClientID    string `json:"clientID"`
+	Limit       int    `json:"limit"`
+	ReturnAll   bool   `json:"return_all"`
 	SortBy      string `json:"sort_by"`
 	SortReverse bool   `json:"sort_reverse"`
 }

--- a/pkg/model/job.go
+++ b/pkg/model/job.go
@@ -74,16 +74,18 @@ type JobShardingConfig struct {
 // generally be in different states on different nodes - one node may be
 // ignoring a job as its bid was rejected, while another node may be
 // submitting results for the job to the requester node.
+// 
 // Each node will produce an array of JobShardState one for each shard
 // (jobs without a sharding config will still have sharded job
 // states - just with a shard count of 1). Any code that is determining
-// the current "state" of a job must look at both
-// the ShardCount of the JobExecutionPlan and the
-// collection of JobShardState to determine the current state.
-
-// JobState itself is not mutable - the JobExecutionPlan and
+// the current "state" of a job must look at both:
+// 
+// 		* the ShardCount of the JobExecutionPlan
+//		* the collection of JobShardState to determine the current state
+// 
+// Note: JobState itself is not mutable - the JobExecutionPlan and
 // JobShardState are updatable and the JobState is queried by the rest
-// of the system
+// of the system.
 type JobState struct {
 	Nodes map[string]JobNodeState `json:"nodes"`
 }

--- a/pkg/model/job.go
+++ b/pkg/model/job.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-// Job contains data about a job in the bacalhau network.
+// Job contains data about a job request in the bacalhau network.
 type Job struct {
 	// The unique global ID of this job in the bacalhau network.
 	ID string `json:"id"`
@@ -31,6 +31,12 @@ type Job struct {
 
 	// Time the job was submitted to the bacalhau network.
 	CreatedAt time.Time `json:"created_at"`
+}
+
+// JobWithInfo is the job request + the result of attempting to run it on the network
+type JobWithInfo struct {
+	Job      Job      `json:"job"`
+	JobState JobState `json:"job_state"`
 }
 
 // JobShard contains data about a job shard in the bacalhau network.
@@ -74,15 +80,15 @@ type JobShardingConfig struct {
 // generally be in different states on different nodes - one node may be
 // ignoring a job as its bid was rejected, while another node may be
 // submitting results for the job to the requester node.
-// 
+//
 // Each node will produce an array of JobShardState one for each shard
 // (jobs without a sharding config will still have sharded job
 // states - just with a shard count of 1). Any code that is determining
 // the current "state" of a job must look at both:
-// 
+//
 // 		* the ShardCount of the JobExecutionPlan
 //		* the collection of JobShardState to determine the current state
-// 
+//
 // Note: JobState itself is not mutable - the JobExecutionPlan and
 // JobShardState are updatable and the JobState is queried by the rest
 // of the system.

--- a/pkg/publicapi/client.go
+++ b/pkg/publicapi/client.go
@@ -64,7 +64,6 @@ func (apiClient *APIClient) Alive(ctx context.Context) (bool, error) {
 }
 
 // List returns the list of jobs in the node's transport.
-// func (apiClient *APIClient) List(ctx context.Context, idFilter string, maxJobs int, returnAll bool, sortBy string, sortReverse bool) (map[string]model.Job, error) {
 func (apiClient *APIClient) List(ctx context.Context, idFilter string, maxJobs int, returnAll bool, sortBy string, sortReverse bool) ([]model.JobWithInfo, error) {
 	ctx, span := system.GetTracer().Start(ctx, "pkg/publicapi.List")
 	defer span.End()

--- a/pkg/publicapi/client_test.go
+++ b/pkg/publicapi/client_test.go
@@ -30,5 +30,5 @@ func TestGet(t *testing.T) {
 	job2, ok, err := c.Get(ctx, job.ID)
 	require.NoError(t, err)
 	require.True(t, ok)
-	require.Equal(t, job2.ID, job.ID)
+	require.Equal(t, job2.Job.ID, job.ID)
 }

--- a/pkg/publicapi/endpoints_list.go
+++ b/pkg/publicapi/endpoints_list.go
@@ -36,6 +36,7 @@ func (apiServer *APIServer) list(res http.ResponseWriter, req *http.Request) {
 	}
 	unMarshallSpan.End()
 
+	// get Jobs
 	getJobsCtx, getJobsSpan := t.Start(ctx, "gettingjobs")
 	list, err := apiServer.Controller.GetJobs(getJobsCtx, localdb.JobQuery{
 		ClientID:    listReq.ClientID,
@@ -51,11 +52,11 @@ func (apiServer *APIServer) list(res http.ResponseWriter, req *http.Request) {
 	}
 	getJobsSpan.End()
 
-	// TODO @enricorotundo: add job state info here
-	// TODO @enricorotundo: create ctx and span for this block
+	// get JobStates
+	getJobStateCtx, getJobStateSpan := t.Start(ctx, "gettingjobstates")
 	jobsWithInfo := []model.JobWithInfo{}
 	for i := range list {
-		jobState, err := apiServer.Controller.GetJobState(ctx, list[i].ID)
+		jobState, err := apiServer.Controller.GetJobState(getJobStateCtx, list[i].ID)
 		if err != nil {
 			log.Error().Msgf("error getting job state: %s", err)
 		}
@@ -64,6 +65,7 @@ func (apiServer *APIServer) list(res http.ResponseWriter, req *http.Request) {
 			JobState: jobState,
 		})
 	}
+	getJobStateSpan.End()
 
 	_, marshallSpan := t.Start(ctx, "marshallingresponse")
 	res.WriteHeader(http.StatusOK)

--- a/pkg/publicapi/server_test.go
+++ b/pkg/publicapi/server_test.go
@@ -48,7 +48,7 @@ func (suite *ServerSuite) TestList() {
 	defer cm.Cleanup()
 
 	// Should have no jobs initially:
-	jobs, err := c.List(ctx)
+	jobs, err := c.List(ctx, "", 10, true, "created_at", true)
 	require.NoError(suite.T(), err)
 	require.Empty(suite.T(), jobs)
 
@@ -59,7 +59,7 @@ func (suite *ServerSuite) TestList() {
 	require.NoError(suite.T(), err)
 
 	// Should now have one job:
-	jobs, err = c.List(ctx)
+	jobs, err = c.List(ctx, "", 10, true, "created_at", true)
 	require.NoError(suite.T(), err)
 	require.Len(suite.T(), jobs, 1)
 }


### PR DESCRIPTION
This PR fixes #611 and #452.

## Highlights

- Tinier client, now makes only 1 call to server that (always) returns a sorted, filtered job list.
- Changed List endpoint return type `map[string]model.Job` -> `[]model.JobWithInfo`. Basically `JobWithInfo` embeds `Job` and `JobState`. All references to List have been updated to handle the new return type.
- `JobQuery` in localdb includes new options for fine-grained querying e.g. ClientID, Limit, SortBy, etc.

See https://github.com/filecoin-project/bacalhau/issues/611 for a detailed check-list.

## Notes for reviewers

Major changes involve the following files:

* cmd/bacalhau/list.go
* pkg/localdb/inmemory/inmemory.go
* pkg/localdb/types.go
* pkg/publicapi/client.go
* pkg/publicapi/endpoints_list.go

## Limitations

- Results are not paginated (not implemented). It'll be required once localdb has persistence (https://github.com/filecoin-project/bacalhau/issues/663) and `list --all` will get slow.