### PR TITLE
#673 Native Windows support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,16 @@
 version: 2.1
 
 executors:
-  linux:
+  linux: &linux
     machine:
       image: ubuntu-2204:2022.07.1
-    resource_class: xlarge
+      resource_class: xlarge
+  darwin: *linux
+  windows:
+    machine:
+      image: windows-server-2022-gui:current
+      resource_class: windows.xlarge
+      shell: bash.exe
 
 # Define a job to be invoked later in a workflow.
 # See: https://circleci.com/docs/2.0/configuration-reference/#jobs
@@ -23,7 +29,7 @@ jobs:
       CGO: 0
       GCS_TEST_RESULTS_BUCKET: bacalhau-global-storage/test-results
     working_directory: ~/repo
-    executor: linux
+    executor: << parameters.target_os >>
     parameters:
       target_arch:
         type: string
@@ -34,14 +40,31 @@ jobs:
     steps:
       - checkout
 
+      - when:
+          condition:
+            equal: ["windows", << parameters.target_os >>]
+          steps:
+            - run:
+                name: Install GNU Make
+                command: |
+                  choco install -y make
+                shell: powershell.exe
+            - run:
+                name: Downgrade Golang
+                command: |
+                  choco install golang -y --allow-downgrade --version $Env:GOVER
+                shell: powershell.exe
+
       - run:
           name: Install IPFS
           command: |
             echo "Installing IPFS_VERSION: $IPFS_VERSION"
             export IPFS_BUILD="$GOOS-$GOARCH"
-            curl -s -L -O "https://dist.ipfs.tech/go-ipfs/${IPFS_VERSION}/go-ipfs_${IPFS_VERSION}_${IPFS_BUILD}.tar.gz"
-            tar -xvzf "go-ipfs_${IPFS_VERSION}_${IPFS_BUILD}.tar.gz"
-            sudo bash ./go-ipfs/install.sh
+            if [ "${GOOS}" = "windows" ]; then export IPFS_EXT=zip; fi
+            if [ "${GOOS}" = "windows" ]; then export EXEC=bash; fi
+            curl -s -L -O "https://dist.ipfs.tech/go-ipfs/${IPFS_VERSION}/go-ipfs_${IPFS_VERSION}_${IPFS_BUILD}.${IPFS_EXT:-tar.gz}"
+            tar -xvzf "go-ipfs_${IPFS_VERSION}_${IPFS_BUILD}.${IPFS_EXT:-tar.gz}"
+            ${EXEC:-sudo bash} ./go-ipfs/install.sh
 
       - when:
           condition:
@@ -80,7 +103,9 @@ jobs:
       - when:
           condition:
             and:
-              - equal: ["linux", << parameters.target_os >>]
+              - or:
+                - equal: ["linux", << parameters.target_os >>]
+                - equal: ["windows", << parameters.target_os >>]
               - equal: ["amd64", << parameters.target_arch >>]
               - equal: [true, << parameters.run_tests >>]
           steps:
@@ -90,9 +115,19 @@ jobs:
                   echo "---------------------------------------"
                   docker version
                   echo "---------------------------------------"
+                  export GOBIN=${HOME}/bin
+                  export PATH=$GOBIN:$PATH
                   go install gotest.tools/gotestsum@latest
                   make test-and-report
                 no_output_timeout: 20m
+
+      - when:
+          condition:
+            and:
+              - equal: ["linux", << parameters.target_os >>]
+              - equal: ["amd64", << parameters.target_arch >>]
+              - equal: [true, << parameters.run_tests >>]
+          steps:
             - run:
                 name: Upload results
                 command: |
@@ -205,6 +240,7 @@ jobs:
             GOOS=linux GOARCH=arm64 make build
             GOOS=darwin GOARCH=amd64 make build
             GOOS=darwin GOARCH=arm64 make build
+            GOOS=windows GOARCH=amd64 make build
             echo "$PRIVATE_PEM_B64" | base64 --decode > /tmp/private.pem
             echo "$PUBLIC_PEM_B64" | base64 --decode > /tmp/public.pem
             export PRIVATE_KEY_PASSPHRASE="$(echo $PRIVATE_KEY_PASSPHRASE_B64 | base64 --decode)"
@@ -222,6 +258,10 @@ jobs:
             cp $ARTIFACT_DIR/*.tar.gz dist/
             cp $ARTIFACT_DIR/*.sha256 dist/
             GOOS=darwin GOARCH=arm64 make build-bacalhau-tgz
+            source /tmp/packagevars
+            cp $ARTIFACT_DIR/*.tar.gz dist/
+            cp $ARTIFACT_DIR/*.sha256 dist/
+            GOOS=windows GOARCH=amd64 make build-bacalhau-tgz
             source /tmp/packagevars
             cp $ARTIFACT_DIR/*.tar.gz dist/
             cp $ARTIFACT_DIR/*.sha256 dist/
@@ -284,12 +324,13 @@ workflows:
           name: build-<< matrix.target_os >>-<< matrix.target_arch >>
           matrix:
             parameters:
-              target_os: ["linux", "darwin"]
+              target_os: ["linux", "darwin", "windows"]
               target_arch: ["amd64", "arm64"]
               run_tests: [true]
             exclude:
-              - target_os: "linux"
+              - target_os: "windows"
                 target_arch: "arm64"
+                run_tests: true
           filters:
             &filters_dev_branches # this yaml anchor is setting these values to "filters_dev_branches"
             branches:
@@ -319,9 +360,13 @@ workflows:
           name: build-<< matrix.target_os >>-<< matrix.target_arch >>
           matrix:
             parameters:
-              target_os: ["linux", "darwin"]
+              target_os: ["linux", "darwin", "windows"]
               target_arch: ["amd64", "arm64"]
               run_tests: [true]
+            exclude:
+              - target_os: "windows"
+                target_arch: "arm64"
+                run_tests: true
           filters:
             &filters_main_only # this yaml anchor is setting these values to "filters_main_only"
             branches:

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ temperature_sensor_data.csv
 temperature_sensor_data.csv.bz2
 .ipynb_checkpoints
 __debug_bin
+__debug_bin.exe
 .terraform/*
 ops/terraform/*.out
 ops/terraform/.terraform.lock.hcl

--- a/cmd/bacalhau/devstack.go
+++ b/cmd/bacalhau/devstack.go
@@ -3,6 +3,7 @@ package bacalhau
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 
 	"github.com/filecoin-project/bacalhau/pkg/computenode"
@@ -92,8 +93,8 @@ var devstackCmd = &cobra.Command{
 		ctx, cancel := system.WithSignalShutdown(ctx)
 		defer cancel()
 
-		portFileName := "/tmp/bacalhau-devstack.port"
-		pidFileName := "/tmp/bacalhau-devstack.pid"
+		portFileName := filepath.Join(os.TempDir(), "bacalhau-devstack.port")
+		pidFileName := filepath.Join(os.TempDir(), "bacalhau-devstack.pid")
 
 		if _, ignore := os.LookupEnv("IGNORE_PID_AND_PORT_FILES"); !ignore {
 			_, err := os.Stat(portFileName)

--- a/cmd/bacalhau/docker_run_test.go
+++ b/cmd/bacalhau/docker_run_test.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strconv"
 
 	"github.com/filecoin-project/bacalhau/pkg/devstack"
@@ -755,7 +756,7 @@ func (suite *DockerRunSuite) TestRun_ExplodeVideos() {
 	require.NoError(suite.T(), err)
 	for _, video := range videos {
 		err = os.WriteFile(
-			fmt.Sprintf("%s/%s", dirPath, video),
+			filepath.Join(dirPath, video),
 			[]byte(fmt.Sprintf("hello %s", video)),
 			0644,
 		)

--- a/cmd/bacalhau/docker_run_test.go
+++ b/cmd/bacalhau/docker_run_test.go
@@ -1,3 +1,5 @@
+//go:build !(windows && unit)
+
 package bacalhau
 
 import (

--- a/cmd/bacalhau/get_test.go
+++ b/cmd/bacalhau/get_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -109,7 +110,7 @@ func (suite *GetSuite) TestGetJob() {
 			)
 			require.Error(suite.T(), err, "Submitting a get request with no id should error.")
 
-			outputDirWithID := fmt.Sprintf("%s/%s", outputDir, submittedJobID)
+			outputDirWithID := filepath.Join(outputDir, submittedJobID)
 			os.Mkdir(outputDirWithID, util.OS_ALL_RWX)
 
 			// Job Id at the end

--- a/go.mod
+++ b/go.mod
@@ -278,6 +278,7 @@ require (
 	github.com/prometheus/statsd_exporter v0.21.0 // indirect
 	github.com/raulk/clock v1.1.0 // indirect
 	github.com/raulk/go-watchdog v1.2.0 // indirect
+	github.com/ricochet2200/go-disk-usage/du v0.0.0-20210707232629-ac9918953285
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rs/cors v1.7.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1596,6 +1596,8 @@ github.com/raulk/go-watchdog v1.2.0 h1:konN75pw2BMmZ+AfuAm5rtFsWcJpKF3m02rKituuX
 github.com/raulk/go-watchdog v1.2.0/go.mod h1:lzSbAl5sh4rtI8tYHU01BWIDzgzqaQLj6RcA1i4mlqI=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
+github.com/ricochet2200/go-disk-usage/du v0.0.0-20210707232629-ac9918953285 h1:d54EL9l+XteliUfUCGsEwwuk65dmmxX85VXF+9T6+50=
+github.com/ricochet2200/go-disk-usage/du v0.0.0-20210707232629-ac9918953285/go.mod h1:fxIDly1xtudczrZeOOlfaUvd2OPb2qZAPuWdU2BsBTk=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=

--- a/pkg/capacitymanager/utils.go
+++ b/pkg/capacitymanager/utils.go
@@ -8,13 +8,13 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"syscall"
 
 	"github.com/BTBurke/k8sresource"
 	"github.com/c2h5oh/datasize"
 	"github.com/filecoin-project/bacalhau/pkg/config"
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/pbnjay/memory"
+	"github.com/ricochet2200/go-disk-usage/du"
 )
 
 // NvidiaCLI is the path to the Nvidia helper binary
@@ -88,12 +88,11 @@ func ParseResourceUsageConfig(usage model.ResourceUsageConfig) model.ResourceUsa
 // get free disk space for storage path
 // returns bytes
 func getFreeDiskSpace(path string) (uint64, error) {
-	fs := syscall.Statfs_t{}
-	err := syscall.Statfs(path, &fs)
-	if err != nil {
-		return 0, err
+	usage := du.NewDiskUsage(path)
+	if usage == nil {
+		return 0, fmt.Errorf("getFreeDiskSpace: unable to get disk space for path %s", path)
 	}
-	return fs.Bfree * uint64(fs.Bsize), nil
+	return usage.Free(), nil
 }
 
 // numSystemGPUs wraps nvidia-container-cli to get the number of GPUs

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/filecoin-project/bacalhau/pkg/storage/util"
@@ -119,7 +120,7 @@ func GetPrivateKey(keyName string) (crypto.PrivKey, error) {
 
 	// We include the port in the filename so that in devstack multiple nodes
 	// running on the same host get different identities
-	privKeyPath := fmt.Sprintf("%s/%s", configPath, keyName)
+	privKeyPath := filepath.Join(configPath, keyName)
 
 	if _, err := os.Stat(privKeyPath); errors.Is(err, os.ErrNotExist) {
 		// Private key does not exist - create and write it

--- a/pkg/devstack/devstack.go
+++ b/pkg/devstack/devstack.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path"
 	"runtime"
 	"runtime/pprof"
 	"strconv"
@@ -221,7 +222,7 @@ func NewDevStack(
 
 	log.Trace().Msg("============= STARTING PROFILING ============")
 	// devstack always records a cpu profile, it will be generally useful.
-	cpuprofile := "/tmp/bacalhau-devstack-cpu.prof"
+	cpuprofile := path.Join(os.TempDir(), "bacalhau-devstack-cpu.prof")
 	f, err := os.Create(cpuprofile)
 	if err != nil {
 		log.Fatal().Msgf("could not create CPU profile: %s", err) //nolint:gocritic

--- a/pkg/executor/docker/executor.go
+++ b/pkg/executor/docker/executor.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"runtime/debug"
 
 	"github.com/pkg/errors"
@@ -186,7 +187,7 @@ func (e *Executor) RunShard(
 			return &model.RunCommandResult{ErrorMsg: err.Error()}, err
 		}
 
-		srcd := fmt.Sprintf("%s/%s", jobResultsDir, output.Name)
+		srcd := filepath.Join(jobResultsDir, output.Name)
 		err = os.Mkdir(srcd, util.OS_ALL_R|util.OS_ALL_X|util.OS_USER_W)
 		if err != nil {
 			return &model.RunCommandResult{ErrorMsg: err.Error()}, err

--- a/pkg/publicapi/server_test.go
+++ b/pkg/publicapi/server_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/filecoin-project/bacalhau/pkg/types"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -53,7 +52,7 @@ func (suite *ServerSuite) TestList() {
 	require.Empty(suite.T(), jobs)
 
 	// Submit a random job to the node:
-	j := MakeGenericJob()
+	j := MakeNoopJob()
 
 	_, err = c.Submit(ctx, j, nil)
 	require.NoError(suite.T(), err)
@@ -98,26 +97,6 @@ func (suite *ServerSuite) TestVarz() {
 	err := json.Unmarshal(rawVarZBody, &varZ)
 	require.NoError(suite.T(), err, "Error unmarshalling /varz data.")
 
-}
-
-func makeJob() (*model.JobSpec, *model.JobDeal) {
-	jobSpec := model.JobSpec{
-		Engine:   model.EngineDocker,
-		Verifier: model.VerifierNoop,
-		Docker: model.JobSpecDocker{
-			Image: "ubuntu:latest",
-			Entrypoint: []string{
-				"cat",
-				"/data/file.txt",
-			},
-		},
-	}
-
-	jobDeal := model.JobDeal{
-		Concurrency: 1,
-	}
-
-	return &jobSpec, &jobDeal
 }
 
 func testEndpoint(t *testing.T, endpoint string, contentToCheck string) []byte {

--- a/pkg/publicapi/util.go
+++ b/pkg/publicapi/util.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os/exec"
 	"strconv"
-	"syscall"
 	"testing"
 	"time"
 
@@ -22,6 +21,7 @@ import (
 	verifier_utils "github.com/filecoin-project/bacalhau/pkg/verifier/util"
 	"github.com/google/uuid"
 	"github.com/phayes/freeport"
+	"github.com/ricochet2200/go-disk-usage/du"
 	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/require"
 )
@@ -123,14 +123,13 @@ func waitForHealthy(ctx context.Context, c *APIClient) error {
 
 // Function to get disk usage of path/disk
 func MountUsage(path string) (disk types.MountStatus) {
-	fs := syscall.Statfs_t{}
-	err := syscall.Statfs(path, &fs)
-	if err != nil {
+	usage := du.NewDiskUsage(path)
+	if usage == nil {
 		return
 	}
-	disk.All = fs.Blocks * uint64(fs.Bsize)
-	disk.Free = fs.Bfree * uint64(fs.Bsize)
-	disk.Used = disk.All - disk.Free
+	disk.All = usage.Size()
+	disk.Free = usage.Free()
+	disk.Used = usage.Used()
 	return
 }
 

--- a/pkg/publisher/filecoin_lotus/mock.go
+++ b/pkg/publisher/filecoin_lotus/mock.go
@@ -1,0 +1,5 @@
+//go:build !windows
+
+package filecoinlotus
+
+const MockLotusExecutable string = "../../../testdata/mocks/lotus.sh"

--- a/pkg/publisher/filecoin_lotus/mock_windows.go
+++ b/pkg/publisher/filecoin_lotus/mock_windows.go
@@ -1,0 +1,3 @@
+package filecoinlotus
+
+const MockLotusExecutable string = "..\\..\\..\\testdata\\mocks\\lotus.bat"

--- a/pkg/publisher/filecoin_lotus/publisher_test.go
+++ b/pkg/publisher/filecoin_lotus/publisher_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -59,7 +60,7 @@ func (suite *FilecoinPublisherSuite) SetupTest() {
 	)
 	tempDir, setupErr = ioutil.TempDir("", "bacalhau-filecoin-lotus-test")
 	require.NoError(suite.T(), setupErr)
-	os.Setenv("LOTUS_LOGFILE", fmt.Sprintf("%s/logs.txt", tempDir))
+	os.Setenv("LOTUS_LOGFILE", filepath.Join(tempDir, "logs.txt"))
 	os.Setenv("LOTUS_TEST_CONTENT_CID", TestContentCid)
 	os.Setenv("LOTUS_TEST_DEAL_CID", TestDealCid)
 	driver, setupErr = NewFilecoinLotusPublisher(cm, resolver, FilecoinLotusPublisherConfig{
@@ -82,7 +83,7 @@ func (suite *FilecoinPublisherSuite) TestIsInstalled() {
 	installed, err := driver.IsInstalled(ctx)
 	require.NoError(suite.T(), err)
 	require.True(suite.T(), installed)
-	dat, err := os.ReadFile(fmt.Sprintf("%s/logs.txt", tempDir))
+	dat, err := os.ReadFile(filepath.Join(tempDir, "logs.txt"))
 	require.NoError(suite.T(), err)
 	require.Equal(suite.T(), "command: version\n0.0.1\n", string(dat))
 }
@@ -91,7 +92,7 @@ func (suite *FilecoinPublisherSuite) TestPublishShardResult() {
 	tmpDirPrefix := "bacalhau-filecoin-lotus-test"
 	resultsDir, err := ioutil.TempDir("", tmpDirPrefix)
 	require.NoError(suite.T(), err)
-	err = os.WriteFile(fmt.Sprintf("%s/file.txt", resultsDir), []byte("hello"), 0644)
+	err = os.WriteFile(filepath.Join(resultsDir, "file.txt"), []byte("hello"), 0644)
 	require.NoError(suite.T(), err)
 	publishResult, err := driver.PublishShardResult(ctx, model.JobShard{
 		Job: &model.Job{
@@ -100,7 +101,7 @@ func (suite *FilecoinPublisherSuite) TestPublishShardResult() {
 	}, TestHostId, resultsDir)
 	require.NoError(suite.T(), err)
 
-	commandLogs, err := os.ReadFile(fmt.Sprintf("%s/logs.txt", tempDir))
+	commandLogs, err := os.ReadFile(filepath.Join(tempDir, "logs.txt"))
 	require.NoError(suite.T(), err)
 
 	require.Equal(suite.T(), fmt.Sprintf("job-%s-shard-%d-host-%s", TestJobId, 0, TestHostId), publishResult.Name)

--- a/pkg/publisher/filecoin_lotus/publisher_test.go
+++ b/pkg/publisher/filecoin_lotus/publisher_test.go
@@ -64,7 +64,7 @@ func (suite *FilecoinPublisherSuite) SetupTest() {
 	os.Setenv("LOTUS_TEST_CONTENT_CID", TestContentCid)
 	os.Setenv("LOTUS_TEST_DEAL_CID", TestDealCid)
 	driver, setupErr = NewFilecoinLotusPublisher(cm, resolver, FilecoinLotusPublisherConfig{
-		ExecutablePath:  "../../../testdata/mocks/lotus.sh",
+		ExecutablePath:  MockLotusExecutable,
 		MinerAddress:    TestMinerAddress,
 		StoragePrice:    TestStoragePrice,
 		StorageDuration: TestStorageDuration,

--- a/pkg/storage/filecoin_unsealed/storage_test.go
+++ b/pkg/storage/filecoin_unsealed/storage_test.go
@@ -2,9 +2,9 @@ package filecoinunsealed
 
 import (
 	"context"
-	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 
 	_ "github.com/filecoin-project/bacalhau/pkg/logger"
@@ -24,7 +24,7 @@ type FilecoinUnsealedSuite struct {
 }
 
 func (suite *FilecoinUnsealedSuite) prepareCid(cid string) model.StorageSpec {
-	folderPath := fmt.Sprintf("%s/%s", tempDir, cid)
+	folderPath := filepath.Join(tempDir, cid)
 	err := os.MkdirAll(folderPath, os.ModePerm)
 	require.NoError(suite.T(), err)
 	return model.StorageSpec{
@@ -52,7 +52,7 @@ func (suite *FilecoinUnsealedSuite) SetupTest() {
 	ctx = context.Background()
 	tempDir, setupErr = ioutil.TempDir("", "bacalhau-filecoin-unsealed-test")
 	require.NoError(suite.T(), setupErr)
-	driver, setupErr = NewStorageProvider(cm, fmt.Sprintf("%s/{{.Cid}}", tempDir))
+	driver, setupErr = NewStorageProvider(cm, filepath.Join(tempDir, "{{.Cid}}"))
 	require.NoError(suite.T(), setupErr)
 }
 
@@ -85,7 +85,7 @@ func (suite *FilecoinUnsealedSuite) TestGetVolumeSize() {
 	cid := "123"
 	fileContents := "hello world"
 	spec := suite.prepareCid(cid)
-	filePath := fmt.Sprintf("%s/%s", spec.Path, "file")
+	filePath := filepath.Join(spec.Path, "file")
 	err := os.WriteFile(filePath, []byte(fileContents), 0644)
 	require.NoError(suite.T(), err)
 	volumeSize, err := driver.GetVolumeSize(ctx, spec)

--- a/pkg/storage/ipfs_apicopy/storage.go
+++ b/pkg/storage/ipfs_apicopy/storage.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/filecoin-project/bacalhau/pkg/config"
@@ -106,10 +108,7 @@ func (dockerIPFS *StorageProvider) PrepareStorage(ctx context.Context, storageSp
 
 //nolint:lll // Exception to the long rule
 func (dockerIPFS *StorageProvider) CleanupStorage(ctx context.Context, storageSpec model.StorageSpec, volume storage.StorageVolume) error {
-	_, err := system.UnsafeForUserCodeRunCommand("rm", []string{
-		"-rf", fmt.Sprintf("%s/%s", dockerIPFS.LocalDir, storageSpec.Cid),
-	})
-	return err
+	return os.RemoveAll(filepath.Join(dockerIPFS.LocalDir, storageSpec.Cid))
 }
 
 func (dockerIPFS *StorageProvider) Upload(ctx context.Context, localPath string) (model.StorageSpec, error) {
@@ -157,7 +156,7 @@ func (dockerIPFS *StorageProvider) Explode(ctx context.Context, spec model.Stora
 }
 
 func (dockerIPFS *StorageProvider) copyFile(ctx context.Context, storageSpec model.StorageSpec) (storage.StorageVolume, error) {
-	outputPath := fmt.Sprintf("%s/%s", dockerIPFS.LocalDir, storageSpec.Cid)
+	outputPath := filepath.Join(dockerIPFS.LocalDir, storageSpec.Cid)
 
 	// If the output path already exists, we already have the data, as
 	// ipfsClient.Get(...) renames the result path atomically after it has

--- a/pkg/system/cleanup.go
+++ b/pkg/system/cleanup.go
@@ -2,6 +2,7 @@ package system
 
 import (
 	"os"
+	"path"
 	"runtime"
 	"runtime/pprof"
 	"time"
@@ -61,7 +62,7 @@ func (cm *CleanupManager) Cleanup() {
 	// stop profiling now, just before we clean up, if we're profiling.
 	log.Trace().Msg("============= STOPPING PROFILING ============")
 	pprof.StopCPUProfile()
-	memprofile := "/tmp/bacalhau-devstack-mem.prof"
+	memprofile := path.Join(os.TempDir(), "bacalhau-devstack-mem.prof")
 	f, err := os.Create(memprofile)
 	if err != nil {
 		log.Fatal().Msgf("could not create memory profile: %s", err)

--- a/pkg/system/script_checker.go
+++ b/pkg/system/script_checker.go
@@ -2,7 +2,6 @@ package system
 
 import (
 	"fmt"
-	"path/filepath"
 	"strings"
 
 	"github.com/rs/zerolog/log"
@@ -60,7 +59,11 @@ func SanitizeImageAndEntrypoint(jobEntrypoint []string) (returnMessages []string
 // Function for validating the workdir of a docker command.
 func ValidateWorkingDir(jobWorkingDir string) error {
 	if jobWorkingDir != "" {
-		if !filepath.IsAbs(jobWorkingDir) {
+		if !strings.HasPrefix(jobWorkingDir, "/") {
+			// This mirrors the implementation at path/filepath/path_unix.go#L13 which
+			// we reuse here to get cross-platform working dir detection. This is
+			// necessary (rather than using IsAbs()) because clients may be running on
+			// Windows/Plan9 but we want to check inside Docker (linux).
 			return fmt.Errorf("workdir must be an absolute path. Passed in: %s", jobWorkingDir)
 		}
 	}

--- a/pkg/system/utils.go
+++ b/pkg/system/utils.go
@@ -410,25 +410,6 @@ func PathExists(path string) (bool, error) {
 	return false, err
 }
 
-func RepeatedCharactersBashCommandToStdout(num int) string {
-	return repeatedCharactersBashCommand(num, false)
-}
-
-func RepeatedCharactersBashCommandToStderr(num int) string {
-	return repeatedCharactersBashCommand(num, true)
-}
-
-// Repeats '=' num times. toStderr true == stderr, false == stdout
-func repeatedCharactersBashCommand(num int, toStderr bool) string {
-	toStderrString := ""
-
-	// If going to stderr, we need to use the special bash command to write to stderr
-	if toStderr {
-		toStderrString = "| cat 1>&2"
-	}
-	return fmt.Sprintf(`for i in $(seq 1 %d) ; do echo -n "="; done %s`, num, toStderrString)
-}
-
 // TODO: #233 Replace when we move to go1.18
 // https://stackoverflow.com/questions/27516387/what-is-the-correct-way-to-find-the-min-between-two-integers-in-go
 func Min(a, b int) int {

--- a/pkg/test/computenode/resourcelimits_test.go
+++ b/pkg/test/computenode/resourcelimits_test.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 package computenode
 
 import (

--- a/pkg/test/computenode/runjob_test.go
+++ b/pkg/test/computenode/runjob_test.go
@@ -1,3 +1,5 @@
+//go:build !(windows && unit)
+
 package computenode
 
 import (

--- a/pkg/test/devstack/combodriver_test.go
+++ b/pkg/test/devstack/combodriver_test.go
@@ -62,10 +62,10 @@ func (suite *ComboDriverSuite) TestComboDriver() {
 		cid := "apples"
 		basePath, err := os.MkdirTemp("", "combo-driver-test")
 		require.NoError(suite.T(), err)
-		filePath := fmt.Sprintf("%s/file.txt", basePath)
+		filePath := filepath.Join(basePath, "file.txt")
 		if unsealedMode {
-			os.MkdirAll(fmt.Sprintf("%s/%s", basePath, cid), os.ModePerm)
-			filePath = fmt.Sprintf("%s/%s/file.txt", basePath, cid)
+			os.MkdirAll(filepath.Join(basePath, cid), os.ModePerm)
+			filePath = filepath.Join(basePath, cid, "file.txt")
 		}
 		err = os.WriteFile(
 			filePath,

--- a/pkg/test/devstack/combodriver_test.go
+++ b/pkg/test/devstack/combodriver_test.go
@@ -1,3 +1,5 @@
+//go:build !(windows && unit)
+
 package devstack
 
 import (

--- a/pkg/test/devstack/concurrency_test.go
+++ b/pkg/test/devstack/concurrency_test.go
@@ -1,3 +1,5 @@
+//go:build !(windows && unit)
+
 package devstack
 
 import (

--- a/pkg/test/devstack/devstack_test.go
+++ b/pkg/test/devstack/devstack_test.go
@@ -1,3 +1,5 @@
+//go:build !(windows && unit)
+
 package devstack
 
 import (

--- a/pkg/test/devstack/min_bids_test.go
+++ b/pkg/test/devstack/min_bids_test.go
@@ -1,3 +1,5 @@
+//go:build !(windows && unit)
+
 package devstack
 
 import (

--- a/pkg/test/devstack/pythonwasm_test.go
+++ b/pkg/test/devstack/pythonwasm_test.go
@@ -1,3 +1,5 @@
+//go:build !(windows && unit)
+
 package devstack
 
 import (

--- a/pkg/test/devstack/sharding_test.go
+++ b/pkg/test/devstack/sharding_test.go
@@ -5,12 +5,9 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sort"
-	"strconv"
 	"strings"
-	"syscall"
 	"testing"
 
 	"github.com/filecoin-project/bacalhau/pkg/computenode"
@@ -157,25 +154,10 @@ func (suite *ShardingSuite) TestExplodeCid() {
 }
 
 func (suite *ShardingSuite) TestEndToEnd() {
-	ulimitValue := 0
+	shouldRun, err := shouldRunShardingTest()
+	require.NoError(suite.T(), err)
 
-	if _, err := exec.LookPath("ulimit"); err == nil {
-		// Test to see how many files can be open on this system...
-		cmd := exec.Command("ulimit", "-n")
-		out, err := cmd.Output()
-		require.NoError(suite.T(), err)
-
-		ulimitValue, err = strconv.Atoi(strings.TrimSpace(string(out)))
-		require.NoError(suite.T(), err)
-	} else {
-		var rLimit syscall.Rlimit
-		err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)
-		require.NoError(suite.T(), err)
-		ulimitValue, err = strconv.Atoi(fmt.Sprint(rLimit.Cur))
-		require.NoError(suite.T(), err)
-	}
-
-	if ulimitValue <= 512 {
+	if !shouldRun {
 		suite.T().Skip("Skipping sharding end to end test because the ulimit value is too low.")
 	}
 

--- a/pkg/test/devstack/sharding_test.go
+++ b/pkg/test/devstack/sharding_test.go
@@ -420,7 +420,7 @@ func (suite *ShardingSuite) TestExplodeVideos() {
 	require.NoError(suite.T(), err)
 	for _, video := range videos {
 		err = os.WriteFile(
-			fmt.Sprintf("%s/%s", dirPath, video),
+			filepath.Join(dirPath, video),
 			[]byte(fmt.Sprintf("hello %s", video)),
 			0644,
 		)

--- a/pkg/test/devstack/sharding_test.go
+++ b/pkg/test/devstack/sharding_test.go
@@ -1,3 +1,5 @@
+//go:build !(windows && unit)
+
 package devstack
 
 import (

--- a/pkg/test/devstack/util_ulimit.go
+++ b/pkg/test/devstack/util_ulimit.go
@@ -1,0 +1,43 @@
+//go:build !windows
+
+package devstack
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+const minimumOpenFiles int = 512
+
+func shouldRunShardingTest() (bool, error) { //nolint:unused
+	ulimitValue := 0
+
+	if _, err := exec.LookPath("ulimit"); err == nil {
+		// Test to see how many files can be open on this system...
+		cmd := exec.Command("ulimit", "-n")
+		out, err := cmd.Output()
+		if err != nil {
+			return false, err
+		}
+
+		ulimitValue, err = strconv.Atoi(strings.TrimSpace(string(out)))
+		if err != nil {
+			return false, err
+		}
+	} else {
+		var rLimit syscall.Rlimit
+		err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)
+		if err != nil {
+			return false, err
+		}
+		ulimitValue, err = strconv.Atoi(fmt.Sprint(rLimit.Cur))
+		if err != nil {
+			return false, err
+		}
+	}
+
+	return ulimitValue > minimumOpenFiles, nil
+}

--- a/pkg/test/devstack/util_ulimit_windows.go
+++ b/pkg/test/devstack/util_ulimit_windows.go
@@ -1,0 +1,5 @@
+package devstack
+
+func shouldRunShardingTest() (bool, error) { //nolint:unused
+	return true, nil
+}

--- a/pkg/test/executor/docker_executor_test.go
+++ b/pkg/test/executor/docker_executor_test.go
@@ -1,3 +1,5 @@
+//go:build !(windows && unit)
+
 package docker
 
 import (

--- a/pkg/test/scenario/utils.go
+++ b/pkg/test/scenario/utils.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/filecoin-project/bacalhau/pkg/ipfs"
@@ -141,7 +142,7 @@ func singleFileGetData(
 	resultsDir string,
 	filePath string,
 ) ([]byte, error) {
-	outputFile := fmt.Sprintf("%s/%s", resultsDir, filePath)
+	outputFile := filepath.Join(resultsDir, filePath)
 	return os.ReadFile(outputFile)
 }
 

--- a/testdata/mocks/lotus.bat
+++ b/testdata/mocks/lotus.bat
@@ -1,0 +1,3 @@
+@echo on
+CD /D "%~dp0"
+powershell .\lotus.ps1 %*

--- a/testdata/mocks/lotus.ps1
+++ b/testdata/mocks/lotus.ps1
@@ -1,0 +1,5 @@
+$logfile = $Env:LOTUS_LOGFILE.split("\")
+$logfile[0] = "/" + $logfile[0].replace(":", "").toLower()
+$ENV:LOTUS_LOGFILE = $logfile -join "/"
+
+sh .\lotus.sh $args


### PR DESCRIPTION
This branch adds support for native Windows builds to Bacalhau.

What does that mean? Well, it is now possible to check out, build, test and release the entire repository [natively on Windows](https://app.circleci.com/pipelines/github/filecoin-project/bacalhau/1176/workflows/37e3fe08-b863-43de-be89-30fefacd1c69/jobs/5869) (i.e. not through WSL), including running the client and devstack. Windows builds will be included in future releases.

### Things that don't work
There are some constraints that need to be documented:

- Docker resource limits don't work on Windows (because they have to applied differently based on WSL or Hyper-V type hosts)
- ARM64 builds are not supported because IPFS doesn't produce `windows-arm64` builds.
- Tests that use Docker don't work on CircleCI, but do work locally (because you can't run Linux-based containers on Windows hosts in CircleCI) – some of this work has been about removing Docker as the default way to run jobs where it's not necessary.

### Things we'll need to do differently if we merge this
Writing for cross-platform requires us to behave a little differently (all good ways really):

- Make more use of noop jobs to avoid using Docker if we're not actually testing Docker.
- Using e.g `filepath.Join` instead of sprintf-style path manipulations.
- Less shelling out to coreutil commands – so more using golang library functions where appropriate, and no `sudo`.
- Judicious use of build tags when adding new POSIX-only features (like FUSE?).

As per [this discussion](https://filecoinproject.slack.com/archives/C02RLM3JHUY/p1662976230450479), I'm open to not merging this because we don't want those behavioural changes. The top of this branch has Windows-specific stuff, the bottom half has general stuff that would be good to merge anyway for code hygiene and tech debt, so if we don't want to commit to Windows then we can just strip off the top of the branch.