### PR TITLE
Add a newline after `bacalhau describe <id>`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ stdout
 unittests.xml
 output_dir
 experimental/*
+.idea/

--- a/cmd/bacalhau/utils.go
+++ b/cmd/bacalhau/utils.go
@@ -393,7 +393,7 @@ func PrintReturnedJobIDToUser(j *model.Job) error {
 
 	RootCmd.Printf("Job ID: %s\n\n", j.ID)
 	RootCmd.Println("To get the status of the job, run:")
-	RootCmd.Printf("  bacalhau describe %s", j.ID)
+	RootCmd.Printf("  bacalhau describe %s\n", j.ID)
 	return nil
 }
 


### PR DESCRIPTION
Add a newline after the `bacalhau describe` message to avoid any further messages from being concatenated with the job ID, such as error messages about the job being executed or logs of the content being downloaded.

Also add JetBrains IDEs to gitignore.