### PR TITLE
Ensure download timeouts are consistent across commands.

### DIFF
--- a/cmd/bacalhau/get.go
+++ b/cmd/bacalhau/get.go
@@ -39,7 +39,7 @@ type GetOptions struct {
 func NewGetOptions() *GetOptions {
 	return &GetOptions{
 		IPFSDownloadSettings: ipfs.IPFSDownloadSettings{
-			TimeoutSecs:    600,
+			TimeoutSecs:    int(ipfs.DefaultIPFSTimeout.Seconds()),
 			OutputDir:      ".",
 			IPFSSwarmAddrs: "",
 		},

--- a/pkg/ipfs/downloader.go
+++ b/pkg/ipfs/downloader.go
@@ -21,9 +21,11 @@ type IPFSDownloadSettings struct {
 	IPFSSwarmAddrs string
 }
 
+const DefaultIPFSTimeout time.Duration = 5 * time.Minute
+
 func NewIPFSDownloadSettings() *IPFSDownloadSettings {
 	return &IPFSDownloadSettings{
-		TimeoutSecs:    10,
+		TimeoutSecs:    int(DefaultIPFSTimeout.Seconds()),
 		OutputDir:      ".",
 		IPFSSwarmAddrs: "",
 	}


### PR DESCRIPTION
We have some issues with commands failing to download the results of a job within the timeout limit, even when it is very large. At the moment this is inconsistent across `get` and `download` commands because the timeouts they use are different.

This commit just unifies those timeouts – there's no reason for them to be different as they are both CLI commands that do the same thing. But we still need to fix the underlying issue of downloads failing.

Resolves #787.