### PR TITLE
586 multiple urls

### DIFF
--- a/pkg/test/devstack/multiple_cid_test.go
+++ b/pkg/test/devstack/multiple_cid_test.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -142,4 +144,114 @@ func (suite *MultipleCIDSuite) TestMultipleCIDs() {
 	// check that the stdout string containts the text hello-cid-1.txt and hello-cid-2.txt
 	require.Contains(suite.T(), string(stdout), "hello-cid-1.txt")
 	require.Contains(suite.T(), string(stdout), "hello-cid-2.txt")
+}
+
+func (suite *MultipleCIDSuite) TestMultipleURLs() {
+
+	files := map[string]string{
+		"/file1.txt": "Before you marry a person, you should first make them use a computer with slow Internet to see who they really are.\n",
+		"/file2.txt": "I walk around like everything’s fine, but deep down, inside my shoe, my sock is sliding off.\n",
+	}
+
+	ctx := context.Background()
+
+	stack, cm := SetupTest(
+		ctx,
+		suite.T(),
+		1,
+		0,
+		computenode.ComputeNodeConfig{
+			JobSelectionPolicy: computenode.JobSelectionPolicy{
+				Locality: computenode.Anywhere,
+			},
+		},
+	)
+	defer TeardownTest(stack, cm)
+
+	t := system.GetTracer()
+	ctx, rootSpan := system.NewRootSpan(ctx, t, "pkg/test/devstack/multiple_cid_test/testmultipleurls")
+	defer rootSpan.End()
+	cm.RegisterCallback(system.CleanupTraceProvider)
+
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		content, ok := files[r.URL.Path]
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte("not found"))
+		} else {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(content))
+		}
+	}))
+	defer svr.Close()
+
+	apiUri := stack.Nodes[0].APIServer.GetURI()
+	apiClient := publicapi.NewAPIClient(apiUri)
+
+	j := &model.Job{}
+	j.Spec = model.Spec{
+		Engine:    model.EngineDocker,
+		Verifier:  model.VerifierNoop,
+		Publisher: model.PublisherIpfs,
+		Docker: model.JobSpecDocker{
+			Image: "ubuntu",
+			Entrypoint: []string{
+				"bash", "-c",
+				"cat /inputs/hello-url-1.txt && cat /inputs/hello-url-2.txt",
+			},
+		},
+	}
+	j.Spec.Inputs = []model.StorageSpec{
+		{
+			StorageSource: model.StorageSourceURLDownload,
+			URL:           fmt.Sprintf("%s/file1.txt", svr.URL),
+			Path:          "/inputs/hello-url-1.txt",
+		},
+		{
+			StorageSource: model.StorageSourceURLDownload,
+			URL:           fmt.Sprintf("%s/file2.txt", svr.URL),
+			Path:          "/inputs/hello-url-2.txt",
+		},
+	}
+	j.Deal = model.Deal{Concurrency: 1}
+
+	submittedJob, err := apiClient.Submit(ctx, j, nil)
+	require.NoError(suite.T(), err)
+
+	resolver := apiClient.GetJobStateResolver()
+
+	err = resolver.Wait(
+		ctx,
+		submittedJob.ID,
+		1,
+		job.WaitThrowErrors([]model.JobStateType{
+			model.JobStateCancelled,
+			model.JobStateError,
+		}),
+		job.WaitForJobStates(map[model.JobStateType]int{
+			model.JobStateCompleted: 1,
+		}),
+	)
+	require.NoError(suite.T(), err)
+
+	shards, err := resolver.GetShards(ctx, submittedJob.ID)
+	require.NoError(suite.T(), err)
+
+	shard := shards[0]
+
+	node, err := stack.GetNode(ctx, shard.NodeID)
+	require.NoError(suite.T(), err)
+
+	outputDir, err := ioutil.TempDir("", "bacalhau-ipfs-multiple-url-test")
+	require.NoError(suite.T(), err)
+	require.NotEmpty(suite.T(), shard.PublishedResult.CID)
+
+	outputPath := filepath.Join(outputDir, shard.PublishedResult.CID)
+	err = node.IPFSClient.Get(ctx, shard.PublishedResult.CID, outputPath)
+	require.NoError(suite.T(), err)
+
+	stdout, err := os.ReadFile(fmt.Sprintf("%s/stdout", outputPath))
+	require.NoError(suite.T(), err)
+
+	require.Equal(suite.T(), files["/file1.txt"]+files["/file2.txt"], string(stdout))
 }

--- a/pkg/test/devstack/multiple_cid_test.go
+++ b/pkg/test/devstack/multiple_cid_test.go
@@ -1,3 +1,5 @@
+//go:build !(windows && unit)
+
 package devstack
 
 import (

--- a/pkg/test/devstack/utils.go
+++ b/pkg/test/devstack/utils.go
@@ -42,7 +42,7 @@ func SetupTest(
 		NumberOfBadActors: badActors,
 	}
 
-	stack, err := devstack.NewStandardDevStack(ctx, cm, options, computenode.NewDefaultComputeNodeConfig())
+	stack, err := devstack.NewStandardDevStack(ctx, cm, options, config)
 	require.NoError(t, err)
 
 	// important to give the pubsub network time to connect


### PR DESCRIPTION
 * add test for using multuple `-u` flags from CLI perspective
 * add test for run a real job that downloads multiples urls from a real http server and merges them into the results
 * fix a bug where we were ignoring the compute node config we were passing in