### PR TITLE
add test that combines an IPFS input with a URL

### DIFF
--- a/pkg/test/devstack/multiple_cid_test.go
+++ b/pkg/test/devstack/multiple_cid_test.go
@@ -255,3 +255,107 @@ func (suite *MultipleCIDSuite) TestMultipleURLs() {
 
 	require.Equal(suite.T(), files["/file1.txt"]+files["/file2.txt"], string(stdout))
 }
+
+func (suite *MultipleCIDSuite) TestIPFSURLCombo() {
+	URLContent := "Common sense is like deodorant. The people who need it most never use it.\n"
+	IPFSContent := "Truth hurts. Maybe not as much as jumping on a bicycle with a seat missing, but it hurts.\n"
+
+	ctx := context.Background()
+
+	stack, cm := SetupTest(
+		ctx,
+		suite.T(),
+		1,
+		0,
+		computenode.ComputeNodeConfig{
+			JobSelectionPolicy: computenode.JobSelectionPolicy{
+				Locality: computenode.Anywhere,
+			},
+		},
+	)
+	defer TeardownTest(stack, cm)
+
+	t := system.GetTracer()
+	ctx, rootSpan := system.NewRootSpan(ctx, t, "pkg/test/devstack/multiple_cid_test/testmultipleurls")
+	defer rootSpan.End()
+	cm.RegisterCallback(system.CleanupTraceProvider)
+
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(URLContent))
+	}))
+	defer svr.Close()
+
+	cid, err := devstack.AddTextToNodes(ctx, []byte(IPFSContent), devstack.ToIPFSClients(stack.Nodes[:1])...)
+	require.NoError(suite.T(), err)
+
+	apiUri := stack.Nodes[0].APIServer.GetURI()
+	apiClient := publicapi.NewAPIClient(apiUri)
+
+	j := &model.Job{}
+	j.Spec = model.Spec{
+		Engine:    model.EngineDocker,
+		Verifier:  model.VerifierNoop,
+		Publisher: model.PublisherIpfs,
+		Docker: model.JobSpecDocker{
+			Image: "ubuntu",
+			Entrypoint: []string{
+				"bash", "-c",
+				"cat /inputs/hello-url.txt && cat /inputs/hello-ipfs.txt",
+			},
+		},
+	}
+	j.Spec.Inputs = []model.StorageSpec{
+		{
+			StorageSource: model.StorageSourceURLDownload,
+			URL:           svr.URL,
+			Path:          "/inputs/hello-url.txt",
+		},
+		{
+			StorageSource: model.StorageSourceIPFS,
+			CID:           cid,
+			Path:          "/inputs/hello-ipfs.txt",
+		},
+	}
+	j.Deal = model.Deal{Concurrency: 1}
+
+	submittedJob, err := apiClient.Submit(ctx, j, nil)
+	require.NoError(suite.T(), err)
+
+	resolver := apiClient.GetJobStateResolver()
+
+	err = resolver.Wait(
+		ctx,
+		submittedJob.ID,
+		1,
+		job.WaitThrowErrors([]model.JobStateType{
+			model.JobStateCancelled,
+			model.JobStateError,
+		}),
+		job.WaitForJobStates(map[model.JobStateType]int{
+			model.JobStateCompleted: 1,
+		}),
+	)
+	require.NoError(suite.T(), err)
+
+	shards, err := resolver.GetShards(ctx, submittedJob.ID)
+	require.NoError(suite.T(), err)
+
+	shard := shards[0]
+
+	node, err := stack.GetNode(ctx, shard.NodeID)
+	require.NoError(suite.T(), err)
+
+	outputDir, err := ioutil.TempDir("", "bacalhau-ipfs-multiple-url-test")
+	require.NoError(suite.T(), err)
+	require.NotEmpty(suite.T(), shard.PublishedResult.CID)
+
+	outputPath := filepath.Join(outputDir, shard.PublishedResult.CID)
+	err = node.IPFSClient.Get(ctx, shard.PublishedResult.CID, outputPath)
+	require.NoError(suite.T(), err)
+
+	stdout, err := os.ReadFile(fmt.Sprintf("%s/stdout", outputPath))
+	require.NoError(suite.T(), err)
+
+	require.Equal(suite.T(), URLContent+IPFSContent, string(stdout))
+}


### PR DESCRIPTION
the underlying reason causing #533 was fixed [PR #805](https://github.com/filecoin-project/bacalhau/pull/805) - this PR adds a test for combining an IPFS cid with a URL