### PR TITLE
Build Bacalhau under CGO

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,9 +96,10 @@ jobs:
             - run:
                 name: Run go mod tidy check diff
                 command: make modtidy check-diff
+
       - run:
           name: Build
-          command: GO111MODULE=on make build
+          command: make build
 
       - when:
           condition:
@@ -147,6 +148,24 @@ jobs:
                   echo "$GOOGLE_CLOUD_STORAGE_BACALHAU_CICD_RW" | base64 --decode > ~/.boto
                   mv unittests.xml "${TEST_RESULTS_FILENAME}"
                   gsutil cp "$TEST_RESULTS_FILENAME" "gs://$GCS_TEST_RESULTS_BUCKET"
+
+      - run:
+          name: Build tarball
+          command: |
+            echo "$PRIVATE_PEM_B64" | base64 --decode > /tmp/private.pem
+            echo "$PUBLIC_PEM_B64" | base64 --decode > /tmp/public.pem
+            export PRIVATE_KEY_PASSPHRASE="$(echo $PRIVATE_KEY_PASSPHRASE_B64 | base64 --decode)"
+            rm dist/.keep           # Need to remove this file so it's not persisted to github
+            make build-bacalhau-tgz
+            source /tmp/packagevars # Created during `make build-bacalhau-tgz`
+            cp $ARTIFACT_DIR/*.tar.gz dist/
+            cp $ARTIFACT_DIR/*.sha256 dist/
+
+      - persist_to_workspace:
+          root: dist/
+          paths:
+              - "*.tar.gz"
+              - "*.sha256"
 
   # deploy:
   #   docker:
@@ -232,40 +251,8 @@ jobs:
   release:
     executor: linux
     steps:
-      - checkout
-      - run:
-          name: Build tarballs
-          command: |
-            GOOS=linux GOARCH=amd64 make build
-            GOOS=linux GOARCH=arm64 make build
-            GOOS=darwin GOARCH=amd64 make build
-            GOOS=darwin GOARCH=arm64 make build
-            GOOS=windows GOARCH=amd64 make build
-            echo "$PRIVATE_PEM_B64" | base64 --decode > /tmp/private.pem
-            echo "$PUBLIC_PEM_B64" | base64 --decode > /tmp/public.pem
-            export PRIVATE_KEY_PASSPHRASE="$(echo $PRIVATE_KEY_PASSPHRASE_B64 | base64 --decode)"
-            rm dist/.keep           # Need to remove this file so it's not persisted to github
-            GOOS=linux GOARCH=amd64 make build-bacalhau-tgz
-            source /tmp/packagevars # Created during `make build-bacalhau-tgz`
-            cp $ARTIFACT_DIR/*.tar.gz dist/
-            cp $ARTIFACT_DIR/*.sha256 dist/
-            GOOS=linux GOARCH=arm64 make build-bacalhau-tgz
-            source /tmp/packagevars
-            cp $ARTIFACT_DIR/*.tar.gz dist/
-            cp $ARTIFACT_DIR/*.sha256 dist/
-            GOOS=darwin GOARCH=amd64 make build-bacalhau-tgz
-            source /tmp/packagevars
-            cp $ARTIFACT_DIR/*.tar.gz dist/
-            cp $ARTIFACT_DIR/*.sha256 dist/
-            GOOS=darwin GOARCH=arm64 make build-bacalhau-tgz
-            source /tmp/packagevars
-            cp $ARTIFACT_DIR/*.tar.gz dist/
-            cp $ARTIFACT_DIR/*.sha256 dist/
-            GOOS=windows GOARCH=amd64 make build-bacalhau-tgz
-            source /tmp/packagevars
-            cp $ARTIFACT_DIR/*.tar.gz dist/
-            cp $ARTIFACT_DIR/*.sha256 dist/
-            find dist/
+      - attach_workspace:
+          at: dist/
       - run:
           name: Install gh
           command: |
@@ -393,8 +380,17 @@ workflows:
             <<: *filters_main_only
   tags_only: # This workflow will only run on tags (specifically starting with 'v.') and will not run on branches
     jobs:
-      - release:
-          name: release-all-binaries
+      - build:
+          name: build-<< matrix.target_os >>-<< matrix.target_arch >>
+          matrix:
+            parameters:
+              target_os: ["linux", "darwin", "windows"]
+              target_arch: ["amd64", "arm64"]
+              run_tests: [false]
+            exclude:
+              - target_os: "windows"
+                target_arch: "arm64"
+                run_tests: false
           filters: &filters_tags_only
             branches:
               ignore: /.*/ # don't run on any branches - only tags
@@ -402,6 +398,12 @@ workflows:
               # only run on tags that look like release tags e.g. v0.1.2 or
               # v0.1.3alpha19 (actually v0.1.3anything...)
               only: /^v([0-9]+).([0-9]+).([0-9]+).*$/
+      - release:
+          name: release-all-binaries
+          requires:
+              - build
+          filters:
+            <<: *filters_tags_only
       - update_ops:
           name: update-terraform-files
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,19 @@ jobs:
                   brew install go@$BREW_GO_VERSION
                   echo "export PATH='/usr/local/opt/go@$BREW_GO_VERSION/bin:$PATH'" >> ~/.bash_profile
 
+      - when:
+          condition:
+            and:
+              - equal: ["linux", << parameters.target_os >>]
+              - not:
+                  equal: ["amd64", << parameters.target_arch >>]
+          steps:
+            - run:
+                name: Install cross-compilation toolchain
+                command: |
+                  source "compile/linux/${GOOS}_${GOARCH}.env"
+                  sudo apt-get install -y $PACKAGES
+
       - run:
           name: Install IPFS
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,11 +22,9 @@ jobs:
     environment:
       GOVER: 1.18.3
       IPFS_VERSION: v0.12.2
-      GOLANGCILINT: v1.49.0
       GOPROXY: https://proxy.golang.org
       GOOS: << parameters.target_os >>
       GOARCH: << parameters.target_arch >>
-      CGO: 0
       GCS_TEST_RESULTS_BUCKET: bacalhau-global-storage/test-results
     working_directory: ~/repo
     executor: << parameters.target_os >>
@@ -65,37 +63,6 @@ jobs:
             curl -s -L -O "https://dist.ipfs.tech/go-ipfs/${IPFS_VERSION}/go-ipfs_${IPFS_VERSION}_${IPFS_BUILD}.${IPFS_EXT:-tar.gz}"
             tar -xvzf "go-ipfs_${IPFS_VERSION}_${IPFS_BUILD}.${IPFS_EXT:-tar.gz}"
             ${EXEC:-sudo bash} ./go-ipfs/install.sh
-
-      - when:
-          condition:
-            and:
-              - equal: ["linux", << parameters.target_os >>]
-              - equal: ["amd64", << parameters.target_arch >>]
-          steps:
-            - run:
-                name: Install golangci-lint
-                command: |
-                  echo "Installing GOLANGCILINT: ${GOLANGCILINT}"
-                  # binary will be /usr/local/go/bin/bin/golangci-lint
-                  # For some reason, .circlerc (I don't know where this file is generated) reports `go env GOPATH` as '/home/circleci/.go_workspace:/usr/local/go_workspace' (with the colon)
-                  # This breaks normal pathing. So just installing in ./bin/
-                  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | BINDIR=${HOME}/bin sh -s ${GOLANGCILINT}
-                  golangci-lint version
-
-            - run:
-                name: Run linter
-                command: |
-                  make lint
-
-      - when:
-          condition:
-            and:
-              - equal: ["linux", << parameters.target_os >>]
-              - equal: ["amd64", << parameters.target_arch >>]
-          steps:
-            - run:
-                name: Run go mod tidy check diff
-                command: make modtidy check-diff
 
       - run:
           name: Build
@@ -144,7 +111,7 @@ jobs:
                     export TEST_RESULTS_FILENAME="<<pipeline.git.branch>>-$DATETIME-$SHA.xml"
                   fi
                   # Credentials for project: bacalhau-cicd
-                  # Account: 
+                  # Account:
                   echo "$GOOGLE_CLOUD_STORAGE_BACALHAU_CICD_RW" | base64 --decode > ~/.boto
                   mv unittests.xml "${TEST_RESULTS_FILENAME}"
                   gsutil cp "$TEST_RESULTS_FILENAME" "gs://$GCS_TEST_RESULTS_BUCKET"
@@ -166,6 +133,36 @@ jobs:
           paths:
               - "*.tar.gz"
               - "*.sha256"
+
+  lint:
+    parallelism: 1
+    environment:
+      GOVER: 1.18.3
+      GOLANGCILINT: v1.49.0
+      GOPROXY: https://proxy.golang.org
+    working_directory: ~/repo
+    executor: linux
+    steps:
+      - checkout
+
+      - run:
+          name: Install golangci-lint
+          command: |
+            echo "Installing GOLANGCILINT: ${GOLANGCILINT}"
+            # binary will be /usr/local/go/bin/bin/golangci-lint
+            # For some reason, .circlerc (I don't know where this file is generated) reports `go env GOPATH` as '/home/circleci/.go_workspace:/usr/local/go_workspace' (with the colon)
+            # This breaks normal pathing. So just installing in ./bin/
+            curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | BINDIR=${HOME}/bin sh -s ${GOLANGCILINT}
+            golangci-lint version
+
+      - run:
+          name: Run linter
+          command: |
+            make lint
+
+      - run:
+          name: Run go mod tidy check diff
+          command: make modtidy check-diff
 
   # deploy:
   #   docker:
@@ -305,6 +302,14 @@ orbs:
 # Invoke jobs via workflows
 # See: https://circleci.com/docs/2.0/configuration-reference/#workflows
 workflows:
+  lint:
+    jobs:
+      - lint:
+          name: Run linters and static checkers
+          filters:
+            tags:
+              ignore: /.*/
+
   dev_branches: # This workflow will run on all branches except 'main' and will not run on tags
     jobs:
       - build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,11 +3,14 @@
 version: 2.1
 
 executors:
-  linux: &linux
+  linux:
     machine:
       image: ubuntu-2204:2022.07.1
       resource_class: xlarge
-  darwin: *linux
+  darwin:
+    macos:
+      xcode: 13.4.1
+    resource_class: large
   windows:
     machine:
       image: windows-server-2022-gui:current
@@ -43,15 +46,28 @@ jobs:
             equal: ["windows", << parameters.target_os >>]
           steps:
             - run:
-                name: Install GNU Make
+                name: Install GNU Make and GCC
                 command: |
-                  choco install -y make
+                  choco install -y make mingw
                 shell: powershell.exe
             - run:
                 name: Downgrade Golang
                 command: |
                   choco install golang -y --allow-downgrade --version $Env:GOVER
                 shell: powershell.exe
+
+      - when:
+          condition:
+            equal: ["darwin", << parameters.target_os >>]
+          steps:
+            - run:
+                name: Install golang
+                environment:
+                  HOMEBREW_NO_AUTO_UPDATE: 1
+                command: |
+                  export BREW_GO_VERSION=$(echo $GOVER | grep -Eo '^\d\.\d+')
+                  brew install go@$BREW_GO_VERSION
+                  echo "export PATH='/usr/local/opt/go@$BREW_GO_VERSION/bin:$PATH'" >> ~/.bash_profile
 
       - run:
           name: Install IPFS
@@ -71,18 +87,12 @@ jobs:
       - when:
           condition:
             and:
-              - or:
-                  - equal: ["linux", << parameters.target_os >>]
-                  - equal: ["windows", << parameters.target_os >>]
               - equal: ["amd64", << parameters.target_arch >>]
               - equal: [true, << parameters.run_tests >>]
           steps:
             - run:
                 name: Test
                 command: |
-                  echo "---------------------------------------"
-                  docker version
-                  echo "---------------------------------------"
                   export GOBIN=${HOME}/bin
                   export PATH=$GOBIN:$PATH
                   go install gotest.tools/gotestsum@latest
@@ -124,9 +134,6 @@ jobs:
             export PRIVATE_KEY_PASSPHRASE="$(echo $PRIVATE_KEY_PASSPHRASE_B64 | base64 --decode)"
             rm dist/.keep           # Need to remove this file so it's not persisted to github
             make build-bacalhau-tgz
-            source /tmp/packagevars # Created during `make build-bacalhau-tgz`
-            cp $ARTIFACT_DIR/*.tar.gz dist/
-            cp $ARTIFACT_DIR/*.sha256 dist/
 
       - persist_to_workspace:
           root: dist/

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,15 @@ define BUILD_FLAGS
 -X github.com/filecoin-project/bacalhau/pkg/version.GOARCH=$(GOARCH)
 endef
 
+# If we are cross-compiling, bring in the appropriate compilers
+ifneq ($(GOOS)_$(GOARCH),$(OS)_$(ARCH))
+compile/${OS}/$(GOOS)_$(GOARCH).env:
+	$(info No compilation method for ${GOOS}_${GOARCH} on host ${OS})
+
+include compile/${OS}/${GOOS}_${GOARCH}.env
+export CC
+endif
+
 all: build
 
 # Run go fmt against code

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ endif
 # Env Variables
 export GO111MODULE = on
 export GO = go
-export CGO = 0
+export CGO_ENABLED = 1
 export PYTHON = python3
 export PRECOMMIT = poetry run pre-commit
 
@@ -62,15 +62,17 @@ endef
 all: build
 
 # Run go fmt against code
+.PHONY: fmt
 fmt:
-	@${GO} fmt ./cmd/...
-	@${GO} fmt ./pkg/...
+	${GO} fmt ./cmd/...
+	${GO} fmt ./pkg/...
 
 
 # Run go vet against code
+.PHONY: vet
 vet:
-	@${GO} vet ./cmd/...
-	@${GO} vet ./pkg/...
+	${GO} vet ./cmd/...
+	${GO} vet ./pkg/...
 
 
 ## Run all pre-commit hooks
@@ -96,7 +98,7 @@ build-dev: build
 ################################################################################
 .PHONY: build-bacalhau
 build-bacalhau: fmt vet
-	CGO_ENABLED=${CGO} GOOS=${GOOS} GOARCH=${GOARCH} GO111MODULE=${GO111MODULE} ${GO} build -gcflags '-N -l' -ldflags "${BUILD_FLAGS}" -o ${BINARY_PATH} main.go
+	${GO} build -gcflags '-N -l' -ldflags "${BUILD_FLAGS}" -o ${BINARY_PATH} main.go
 
 ################################################################################
 # Target: build-docker-images
@@ -252,7 +254,6 @@ check-diff:
 ################################################################################
 .PHONY: test-and-report
 test-and-report: build-bacalhau
-	CGO_ENABLED=${CGO} \
 		gotestsum \
 			--jsonfile ${TEST_OUTPUT_FILE_PREFIX}_unit.json \
 			--junitfile unittests.xml \
@@ -264,7 +265,7 @@ test-and-report: build-bacalhau
 
 .PHONY: generate
 generate:
-	CGO_ENABLED=0 GOARCH=$(shell go env GOARCH) GO111MODULE=${GO111MODULE} ${GO} generate -gcflags '-N -l' -ldflags "-X main.VERSION=$(TAG)" ./...
+	${GO} generate -gcflags '-N -l' -ldflags "-X main.VERSION=$(TAG)" ./...
 	echo "[OK] Files added to pipeline template directory!"
 
 .PHONY: security

--- a/cmd/bacalhau/docker_run_test.go
+++ b/cmd/bacalhau/docker_run_test.go
@@ -1,4 +1,4 @@
-//go:build !(windows && unit)
+//go:build !(unit && (windows || darwin))
 
 package bacalhau
 

--- a/compile/README
+++ b/compile/README
@@ -1,0 +1,19 @@
+This directory contains data used by the Makefile and CI system to allow
+cross-compilation under CGO.
+
+Each directory spcifies a host OS and each file within the directory specifies a
+target that can be cross-compiled using that host OS. Each file can optionally
+specify:
+
+PACKAGES – list of packages to be installed by the host-specific package manager
+           prior to do this cross-compilation.
+
+CC – compiler that should be used to do the cross-compilation, which should be
+     on the PATH.
+
+Not specifying these just means that cross-compilation is possible with the
+default toolchain. (For example, on Apple platforms the native tools can compile
+for both amd64 and arm64 targets.)
+
+Note that files only need to exist to enable *cross*-compilation – when
+compiling for the same platform as the host, these files are not checked.

--- a/compile/linux/linux_amd64.env
+++ b/compile/linux/linux_amd64.env
@@ -1,0 +1,2 @@
+PACKAGES='gcc-x86-64-linux-gnu libc-dev-amd64-cross'
+CC=x86_64-linux-gnu-gcc

--- a/compile/linux/linux_arm64.env
+++ b/compile/linux/linux_arm64.env
@@ -1,0 +1,2 @@
+PACKAGES='gcc-aarch64-linux-gnu libc-dev-arm64-cross'
+CC=aarch64-linux-gnu-gcc

--- a/compile/linux/windows_amd64.env
+++ b/compile/linux/windows_amd64.env
@@ -1,0 +1,2 @@
+PACKAGES=gcc-mingw-w64-x86-64
+CC=x86_64-w64-mingw32-gcc

--- a/pkg/test/computenode/jobselection_test.go
+++ b/pkg/test/computenode/jobselection_test.go
@@ -1,3 +1,5 @@
+//go:build !(unit && (windows || darwin))
+
 package computenode
 
 import (

--- a/pkg/test/computenode/resourcelimits_test.go
+++ b/pkg/test/computenode/resourcelimits_test.go
@@ -1,5 +1,4 @@
-//go:build !windows
-// +build !windows
+//go:build !windows && !(unit && darwin)
 
 package computenode
 

--- a/pkg/test/computenode/runjob_test.go
+++ b/pkg/test/computenode/runjob_test.go
@@ -1,4 +1,4 @@
-//go:build !(windows && unit)
+//go:build !(unit && (windows || darwin))
 
 package computenode
 

--- a/pkg/test/devstack/combodriver_test.go
+++ b/pkg/test/devstack/combodriver_test.go
@@ -1,4 +1,4 @@
-//go:build !(windows && unit)
+//go:build !(unit && (windows || darwin))
 
 package devstack
 

--- a/pkg/test/devstack/concurrency_test.go
+++ b/pkg/test/devstack/concurrency_test.go
@@ -1,4 +1,4 @@
-//go:build !(windows && unit)
+//go:build !(unit && (windows || darwin))
 
 package devstack
 

--- a/pkg/test/devstack/devstack_test.go
+++ b/pkg/test/devstack/devstack_test.go
@@ -1,4 +1,4 @@
-//go:build !(windows && unit)
+//go:build !(unit && (windows || darwin))
 
 package devstack
 

--- a/pkg/test/devstack/min_bids_test.go
+++ b/pkg/test/devstack/min_bids_test.go
@@ -1,4 +1,4 @@
-//go:build !(windows && unit)
+//go:build !(unit && (windows || darwin))
 
 package devstack
 

--- a/pkg/test/devstack/multiple_cid_test.go
+++ b/pkg/test/devstack/multiple_cid_test.go
@@ -1,4 +1,4 @@
-//go:build !(windows && unit)
+//go:build !(unit && (windows || darwin))
 
 package devstack
 

--- a/pkg/test/devstack/pythonwasm_test.go
+++ b/pkg/test/devstack/pythonwasm_test.go
@@ -1,4 +1,4 @@
-//go:build !(windows && unit)
+//go:build !(unit && (windows || darwin))
 
 package devstack
 

--- a/pkg/test/devstack/sharding_test.go
+++ b/pkg/test/devstack/sharding_test.go
@@ -1,4 +1,4 @@
-//go:build !(windows && unit)
+//go:build !(unit && (windows || darwin))
 
 package devstack
 

--- a/pkg/test/executor/docker_executor_test.go
+++ b/pkg/test/executor/docker_executor_test.go
@@ -1,4 +1,4 @@
-//go:build !(windows && unit)
+//go:build !(unit && (windows || darwin))
 
 package docker
 


### PR DESCRIPTION
This set of commits allows us to build Bacalhau under CGO, both locally and in CI. This necessitates lots of change to how we use CI because cross-compilation is limited for Darwin platforms, requires specific toolchains on Linux platforms, and now requires C compilers on Windows platforms.

Included are some quality of life improvements to our CI config, including splitting out linting steps (so they happen in parallel and hence jobs are faster overall) and simplification of generating our release tarballs. 

By itself this is somewhat irrelevant, but the important change is this now allows us to use libraries that have C extensions. This will be necessary to get any native WASM interrogation and execution working.