### PR TITLE
fix --id-only --wait

### DIFF
--- a/cmd/bacalhau/run_python.go
+++ b/cmd/bacalhau/run_python.go
@@ -256,7 +256,7 @@ func SubmitLanguageJob(cmd *cobra.Command, ctx context.Context, language, versio
 		Fatal(fmt.Sprintf("Error submitting job: %s", err), 1)
 	}
 
-	err = PrintResultsToUser(ctx, returnedJob)
+	err = WaitAndPrintResultsToUser(ctx, returnedJob, false)
 	if err != nil {
 		Fatal(fmt.Sprintf("Error submitting job: %s", err), 1)
 	}

--- a/cmd/bacalhau/utils.go
+++ b/cmd/bacalhau/utils.go
@@ -300,11 +300,11 @@ func ExecuteJob(ctx context.Context,
 	}
 
 	if idOnly {
-		cmd.Print(j.ID)
+		cmd.Print(j.ID + "\n")
 	}
 	// if we are only printing the id, set the rest of the output to "quiet",
 	// i.e. don't print
-	quiet := !idOnly
+	quiet := idOnly
 	err = WaitAndPrintResultsToUser(ctx, j, quiet)
 	if err != nil {
 		if err.Error() == PrintoutCanceledButRunningNormally {
@@ -379,7 +379,9 @@ To get more details about the run, execute:
 	if resultsCID != "" {
 		resultsCID = fmt.Sprintf("Results CID: %s\n", resultsCID)
 	}
-	RootCmd.Print(fmt.Sprintf(printOut, resultsCID))
+	if !quiet {
+		RootCmd.Print(fmt.Sprintf(printOut, resultsCID))
+	}
 
 	if runtimeSettings.AutoDownloadResults {
 		results, err := getResults(ctx, apiClient, j)


### PR DESCRIPTION
Still wait for a job to finish in the case that we set --id-only and --wait together, but otherwise silence the output

Fixes #848 