### PR TITLE
Build statically on Linux to avoid libc versioning issues.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,6 +154,9 @@ jobs:
               - "*.tar.gz"
               - "*.sha256"
 
+      - store_artifacts:
+          path: dist/
+
   lint:
     parallelism: 1
     environment:

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,14 @@ define BUILD_FLAGS
 -X github.com/filecoin-project/bacalhau/pkg/version.GOARCH=$(GOARCH)
 endef
 
+define STATIC_BUILD_FLAGS
+-linkmode=external -extldflags '-static'
+endef
+
+ifeq (${GOOS},linux)
+BUILD_FLAGS += ${STATIC_BUILD_FLAGS}
+endif
+
 # If we are cross-compiling, bring in the appropriate compilers
 ifneq ($(GOOS)_$(GOARCH),$(OS)_$(ARCH))
 compile/${OS}/$(GOOS)_$(GOARCH).env:


### PR DESCRIPTION
Now that we are building with CGO, our previously static binaries now dynamically link against the libc version of whatever machine they were built on. As a number of users have older libc versions (because they use older LTS versions of e.g. Ubuntu) our tool no longer works there.

This commit updates our build process to output static binaries on Linux. This isn't possible on Darwin (thanks again, Apple!) and whilst it should be possible on Windows, it will probably require different flags and so we can do this later as there isn't such an urgent need for it.

Resolves #850, should also help towards #851. 