### PR TITLE
wait flags

### DIFF
--- a/cmd/bacalhau/utils.go
+++ b/cmd/bacalhau/utils.go
@@ -234,7 +234,7 @@ type RunTimeSettings struct {
 func NewRunTimeSettings() *RunTimeSettings {
 	return &RunTimeSettings{
 		AutoDownloadResults:   false,
-		WaitForJobToFinish:    false,
+		WaitForJobToFinish:    true,
 		WaitForJobTimeoutSecs: DefaultDockerRunWaitSeconds,
 		IPFSGetTimeOut:        10,
 		IsLocal:               false,
@@ -299,9 +299,19 @@ func ExecuteJob(ctx context.Context,
 		return err
 	}
 
+	// if we are in --wait=false - print the id then exit
+	// because all code after this point is related to
+	// "wait for the job to finish" (via WaitAndPrintResultsToUser)
+	if !runtimeSettings.WaitForJobToFinish {
+		cmd.Print(j.ID + "\n")
+		return nil
+	}
+
+	// if we are in --id-only mode - print the id
 	if idOnly {
 		cmd.Print(j.ID + "\n")
 	}
+
 	// if we are only printing the id, set the rest of the output to "quiet",
 	// i.e. don't print
 	quiet := idOnly


### PR DESCRIPTION
default --wait to true and short circuit the `WaitAndPrintResultsToUser` function if the user requests --wait=false

in the case of not waiting - we print the job id so the user has a reference for the job that was just submitted

here is output of the various combinations:

### `wait=true` && `id-only==false`

```
kai@xwing:~/projects/protocol-labs/bacalhau$ time bacalhau docker run ubuntu -- bash -c "sleep 10 && echo hello"
Job successfully submitted. Job ID: c4b15b1c-fbd8-4af8-9de8-44f76a27498e
Checking job status... (Enter Ctrl+C to exit at any time, your job will continue running):

               Creating job for submission ... done ✅
               Finding node(s) for the job ... done ✅
                     Node accepted the job ... done ✅
           Job finished, verifying results ... done ✅
              Results accepted, publishing ... done ✅
                                          
Results CID: QmZrk6BqwovihA4EVwGmTkqru6eCbXqXjr6cDMJS8WSwEY
Job Results By Node:
Node Qmf1cAxM:
  Shard 0:
    Status: Completed
    Container Exit Code: 0
    Stdout:
      hello
    Stderr: <NONE>

To download the results, execute:
  bacalhau get c4b15b1c-fbd8-4af8-9de8-44f76a27498e

To get more details about the run, execute:
  bacalhau describe c4b15b1c-fbd8-4af8-9de8-44f76a27498e

real    0m12.258s
user    0m0.561s
sys     0m0.075s
```

### `wait=true` && `id-only==true`

```
kai@xwing:~/projects/protocol-labs/bacalhau$ time bacalhau docker run --id-only ubuntu -- bash -c "sleep 10 && echo hello"
c6232373-d9f0-440a-84db-34545d8cc226

real    0m12.299s
user    0m0.608s
sys     0m0.061s
```
 
### `wait=false` && `id-only==true`

```
kai@xwing:~/projects/protocol-labs/bacalhau$ time bacalhau docker run --id-only --wait=false ubuntu -- bash -c "sleep 10 && echo hello"
f43a001c-1dea-4fbb-bb9c-4dc0c4737f4c

real    0m0.184s
user    0m0.217s
sys     0m0.032s
```

### `wait=false` && `id-only==false`

```
kai@xwing:~/projects/protocol-labs/bacalhau$ time bacalhau docker run --wait=false ubuntu -- bash -c "sleep 10 && echo hello"
1ee96031-5e96-44a3-b138-0c3cf6d99cb6

real    0m0.229s
user    0m0.301s
sys     0m0.030s
```