### PR TITLE
Add an option to start Lotus with the devstack

### DIFF
--- a/cmd/bacalhau/devstack.go
+++ b/cmd/bacalhau/devstack.go
@@ -42,6 +42,7 @@ func newDevStackOptions() *devstack.DevStackOptions {
 		Peer:              "",
 		PublicIPFSMode:    false,
 		EstuaryAPIKey:     os.Getenv("ESTUARY_API_KEY"),
+		LocalNetworkLotus: false,
 	}
 }
 
@@ -61,6 +62,10 @@ func init() { //nolint:gochecknoinits // Using init in cobra command is idomatic
 	devstackCmd.PersistentFlags().StringVar(
 		&ODs.Peer, "peer", ODs.Peer,
 		`Connect node 0 to another network node`,
+	)
+	devstackCmd.PersistentFlags().BoolVar(
+		&ODs.LocalNetworkLotus, "lotus-node", ODs.LocalNetworkLotus,
+		"Also start a Lotus FileCoin instance",
 	)
 
 	setupJobSelectionCLIFlags(devstackCmd)
@@ -110,6 +115,10 @@ var devstackCmd = &cobra.Command{
 		computeNodeConfig := computenode.ComputeNodeConfig{
 			JobSelectionPolicy:    getJobSelectionConfig(),
 			CapacityManagerConfig: getCapacityManagerConfig(),
+		}
+
+		if ODs.LocalNetworkLotus {
+			cmd.Println("Note that starting up the Lotus node can take many minutes!")
 		}
 
 		var stack *devstack.DevStack

--- a/cmd/bacalhau/docker_run_test.go
+++ b/cmd/bacalhau/docker_run_test.go
@@ -201,7 +201,7 @@ func (s *DockerRunSuite) TestRun_GenericSubmitWait() {
 	for i, tc := range tests {
 		s.Run(fmt.Sprintf("numberOfJobs:%v", tc.numberOfJobs), func() {
 			ctx := context.Background()
-			devstack, _ := devstack_tests.SetupTest(ctx, s.T(), 1, 0, computenode.ComputeNodeConfig{})
+			devstack, _ := devstack_tests.SetupTest(ctx, s.T(), 1, 0, false, computenode.ComputeNodeConfig{})
 
 			*ODR = *NewDockerRunOptions()
 
@@ -741,6 +741,7 @@ func (s *DockerRunSuite) TestRun_ExplodeVideos() {
 		s.T(),
 		nodeCount,
 		0,
+		false,
 		computenode.NewDefaultComputeNodeConfig(),
 	)
 
@@ -779,14 +780,6 @@ func (s *DockerRunSuite) TestRun_ExplodeVideos() {
 
 	_, _, submitErr := ExecuteTestCobraCommand(s.T(), s.rootCmd, allArgs...)
 	require.NoError(s.T(), submitErr)
-}
-
-type deterministicVerifierTestArgs struct {
-	nodeCount      int
-	badActors      int
-	confidence     int
-	expectedPassed int
-	expectedFailed int
 }
 
 func (s *DockerRunSuite) TestRun_Deterministic_Verifier() {
@@ -973,7 +966,7 @@ func (s *DockerRunSuite) TestRun_BadExecutables() {
 	}
 
 	ctx := context.TODO()
-	stack, _ := devstack_tests.SetupTest(ctx, s.T(), 1, 0, computenode.ComputeNodeConfig{})
+	stack, _ := devstack_tests.SetupTest(ctx, s.T(), 1, 0, false, computenode.ComputeNodeConfig{})
 
 	for name, tc := range tests {
 		*ODR = *NewDockerRunOptions()

--- a/docs/running_locally.md
+++ b/docs/running_locally.md
@@ -1,8 +1,8 @@
 # Running locally with the 'devstack' command
 
-The `devstack` command of bacalhau will start a 3 node cluster alongside isolated ipfs servers.
+The `devstack` command of `bacalhau` will start a 3 node cluster alongside isolated ipfs servers.
 
-This is useful to kick the tires and/or developing on the codebase.  It's also the tool used by some of the tests.
+This is useful to kick the tires and/or developing on the codebase.  It's also the tool used by some tests.
 
 ## Pre-requisites
 
@@ -29,14 +29,16 @@ go build
 ./bin/<YOUR_ARCHITECTURE>/bacalhau devstack
 ```
 
-This will start a 3 node bacalhau cluster connected with libp2p.
+This will start a 3 node Bacalhau cluster connected with libp2p.
 
-Each node has it's own ipfs server isolated using the `IPFS_PATH` environment variable and it's own API RPC server isolated using a random port.
+Each node has its own ipfs server isolated using the `IPFS_PATH` environment variable and its own API RPC server isolated using a random port.
 
 If you would like to make it a bit more predictable and/or ignore errors (such as during CI), you can add the following before your execution:
 ```
 IGNORE_PID_AND_PORT_FILES=true PREDICTABLE_API_PORT=1
 ```
+
+If you wish to also have a [Lotus](https://lotus.filecoin.io/) node to test against, then you can include the `--lotus-node` flag. This will start a Docker container running Lotus against a [local network](https://lotus.filecoin.io/lotus/developers/local-network/), making it easy to test the functionality without any cost concerns. 
 
 Once everything has started up - you will see output like the following:
 

--- a/go.mod
+++ b/go.mod
@@ -111,7 +111,7 @@ require (
 	github.com/dgraph-io/ristretto v0.0.2 // indirect
 	github.com/didip/tollbooth v4.0.2+incompatible
 	github.com/docker/distribution v2.8.1+incompatible // indirect
-	github.com/docker/go-connections v0.4.0 // indirect
+	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/elastic/gosigar v0.14.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,7 @@ require (
 )
 
 require (
+	github.com/filecoin-project/go-jsonrpc v0.1.8
 	github.com/golang/mock v1.6.0
 	github.com/imdario/mergo v0.3.5
 	github.com/invopop/jsonschema v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -300,6 +300,8 @@ github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSw
 github.com/felixge/httpsnoop v1.0.2/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/filecoin-project/go-jsonrpc v0.1.8 h1:uXX/ikAk3Q4f/k8DRd9Zw+fWnfiYb5I+UI1tzlQgHog=
+github.com/filecoin-project/go-jsonrpc v0.1.8/go.mod h1:XBBpuKIMaXIIzeqzO1iucq4GvbF8CxmXRFoezRh+Cx4=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6/go.mod h1:1i71OnUq3iUe1ma7Lr6yG6/rjvM3emb6yoL7xLFzcVQ=
 github.com/flynn/noise v1.0.0 h1:DlTHqmzmvcEiKj+4RYo/imoswx/4r6iBlCMfVtrMXpQ=
@@ -485,6 +487,7 @@ github.com/gopherjs/gopherjs v0.0.0-20190430165422-3e4dfb77656c/go.mod h1:wJfORR
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
@@ -717,6 +720,7 @@ github.com/ipfs/go-log v1.0.5/go.mod h1:j0b8ZoR+7+R99LD9jZ6+AJsrzkPbSXbZfGakb5JP
 github.com/ipfs/go-log/v2 v2.0.2/go.mod h1:O7P1lJt27vWHhOwQmcFEvlmo49ry2VY2+JfBWFaa9+0=
 github.com/ipfs/go-log/v2 v2.0.3/go.mod h1:O7P1lJt27vWHhOwQmcFEvlmo49ry2VY2+JfBWFaa9+0=
 github.com/ipfs/go-log/v2 v2.0.5/go.mod h1:eZs4Xt4ZUJQFM3DlanGhy7TkwwawCZcSByscwkWG+dw=
+github.com/ipfs/go-log/v2 v2.0.8/go.mod h1:eZs4Xt4ZUJQFM3DlanGhy7TkwwawCZcSByscwkWG+dw=
 github.com/ipfs/go-log/v2 v2.1.1/go.mod h1:2v2nsGfZsvvAJz13SyFzf9ObaqwHiHxsPLEHntrv9KM=
 github.com/ipfs/go-log/v2 v2.1.3/go.mod h1:/8d0SH3Su5Ooc31QlL1WysJhvyOTDCjcCZ9Axpmri6g=
 github.com/ipfs/go-log/v2 v2.3.0/go.mod h1:QqGoj30OTpnKaG/LKTGTxoP2mmQtjVMEnK72gynbe/g=

--- a/pkg/devstack/lotus.go
+++ b/pkg/devstack/lotus.go
@@ -1,0 +1,287 @@
+package devstack
+
+import (
+	"archive/tar"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	dockertypes "github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/mount"
+	dockerclient "github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/jsonmessage"
+	"github.com/docker/go-connections/nat"
+	"github.com/filecoin-project/bacalhau/pkg/docker"
+	"github.com/filecoin-project/bacalhau/pkg/system"
+	"github.com/filecoin-project/bacalhau/pkg/util/closer"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"golang.org/x/net/context"
+)
+
+const defaultImage = "ghcr.io/bacalhau-project/lotus-filecoin-image:v0.0.1"
+
+type LotusNode struct {
+	client    *dockerclient.Client
+	image     string
+	container string
+
+	// Port is the port number that Lotus will be listening on
+	Port string
+	// Dir is the directory where files to be uploaded to Lotus should be stored
+	Dir string
+	// Token is actor in the local network with some FIL to do some work
+	Token string
+}
+
+func newLotusNode(ctx context.Context) (*LotusNode, error) {
+	ctx, span := system.GetTracer().Start(ctx, "pkg/devstack.newlotusnode")
+	defer span.End()
+
+	image := defaultImage
+	if e, ok := os.LookupEnv("LOTUS_TEST_IMAGE"); ok {
+		image = e
+	}
+
+	dockerClient, err := docker.NewDockerClient()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := pullImage(ctx, dockerClient, image); err != nil {
+		closer.CloseWithLogOnError("docker", dockerClient)
+		return nil, err
+	}
+
+	return &LotusNode{
+		client: dockerClient,
+		image:  image,
+	}, nil
+}
+
+// start performs the work of actually starting the Lotus container. This is separated from the constructor so the user
+// can cancel and still have the container, which may not be healthy yet, cleaned up via Close.
+func (l *LotusNode) start(ctx context.Context) error {
+	ctx, span := system.GetTracer().Start(ctx, "pkg/devstack.start")
+	defer span.End()
+
+	dir, err := ioutil.TempDir("", "bacalhau-lotus")
+	if err != nil {
+		return err
+	}
+
+	l.Dir = dir
+
+	c, err := l.client.ContainerCreate(ctx, &container.Config{
+		Image: l.image,
+	}, &container.HostConfig{
+		PortBindings: map[nat.Port][]nat.PortBinding{
+			"1234/tcp": {{}},
+		},
+		Mounts: []mount.Mount{
+			// Mount the temp directory at the same place within the container to aviod confusion between paths outside the
+			// container, that the user sees, and paths within the container, that the ClientImport command uses.
+			{
+				Type:     mount.TypeBind,
+				ReadOnly: true,
+				Source:   dir,
+				Target:   dir,
+			},
+		},
+	}, nil, nil, "")
+	if err != nil {
+		return err
+	}
+
+	l.container = c.ID
+
+	log.Debug().
+		Str("image", l.image).
+		Str("dir", l.Dir).
+		Str("containerId", l.container).
+		Msg("Starting Lotus container")
+
+	if err := l.client.ContainerStart(ctx, l.container, dockertypes.ContainerStartOptions{}); err != nil {
+		return err
+	}
+
+	if err := l.waitForLotusToBeHealthy(ctx); err != nil {
+		if err := l.Close(); err != nil { //nolint:govet
+			log.Err(err).Msgf(`Problem occurred when giving up waiting for Lotus to become healthy`)
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (l *LotusNode) waitForLotusToBeHealthy(ctx context.Context) error {
+	ctx, span := system.GetTracer().Start(ctx, "pkg/devstack.waitforlotustobehealthy")
+	defer span.End()
+
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute) //nolint:gomnd
+	defer cancel()
+
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		state, err := l.client.ContainerInspect(ctx, l.container)
+		if err != nil {
+			return err
+		}
+
+		if state.State.Health.Status == dockertypes.Healthy {
+			l.Port = state.NetworkSettings.Ports["1234/tcp"][0].HostPort
+			break
+		}
+
+		e := log.Debug()
+		if len(state.State.Health.Log) != 0 {
+			e = e.Str("last-health-check", strings.TrimSpace(state.State.Health.Log[len(state.State.Health.Log)-1].Output))
+		}
+		e.Msg("Lotus not healthy yet")
+		time.Sleep(5 * time.Second) //nolint:gomnd
+	}
+
+	content, _, err := l.client.CopyFromContainer(ctx, l.container, "/home/lotus_user/.lotus-local-net/token")
+	if err != nil {
+		return err
+	}
+
+	defer closer.CloseWithLogOnError("content", content)
+
+	tarContent := tar.NewReader(content)
+	if _, err := tarContent.Next(); err != nil { //nolint:govet
+		return err
+	}
+
+	token, err := ioutil.ReadAll(tarContent)
+	if err != nil {
+		return err
+	}
+
+	l.Token = string(token)
+
+	return nil
+}
+
+func (l *LotusNode) Close() error {
+	defer closer.CloseWithLogOnError("Docker client", l.client)
+	if l.container != "" {
+		if err := docker.RemoveContainer(context.Background(), l.client, l.container); err != nil {
+			return err
+		}
+	}
+
+	if l.Dir != "" {
+		// This may not happen if Docker fails to remove the container, but this isn't seen as a big problem
+		// as the OS is expected to clean it up
+		if err := os.RemoveAll(l.Dir); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func pullImage(ctx context.Context, client dockerclient.ImageAPIClient, image string) error {
+	_, _, err := client.ImageInspectWithRaw(ctx, image)
+	if err == nil {
+		return nil
+	}
+	if !dockerclient.IsErrNotFound(err) {
+		return err
+	}
+
+	log.Debug().Str("image", image).Msg("Pulling image as it wasn't found")
+
+	output, err := client.ImagePull(ctx, image, dockertypes.ImagePullOptions{})
+	if err != nil {
+		return err
+	}
+
+	defer closer.CloseWithLogOnError("image-pull", output)
+
+	stop := make(chan struct{}, 1)
+	defer func() {
+		stop <- struct{}{}
+	}()
+	t := time.NewTicker(3 * time.Second)
+	defer t.Stop()
+
+	layers := &sync.Map{}
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			case <-t.C:
+				logImagePullStatus(layers)
+			}
+		}
+	}()
+
+	dec := json.NewDecoder(output)
+	for {
+		var mess jsonmessage.JSONMessage
+		if err := dec.Decode(&mess); err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return err
+		}
+		if mess.Aux != nil {
+			continue
+		}
+		if mess.Error != nil {
+			return mess.Error
+		}
+		layers.Store(mess.ID, mess)
+	}
+}
+
+func logImagePullStatus(m *sync.Map) {
+	withUnits := map[string]*zerolog.Event{}
+	withoutUnits := map[string][]string{}
+	m.Range(func(_, value any) bool {
+		mess := value.(jsonmessage.JSONMessage)
+
+		if mess.Progress == nil || mess.Progress.Current <= 0 {
+			withoutUnits[mess.Status] = append(withoutUnits[mess.Status], mess.ID)
+		} else {
+			var status string
+			if mess.Progress.Total <= 0 {
+				status = fmt.Sprintf("%d %s", mess.Progress.Total, mess.Progress.Units)
+			} else {
+				status = fmt.Sprintf("%.3f%%", float64(mess.Progress.Current)/float64(mess.Progress.Total)*100) //nolint:gomnd
+			}
+
+			if _, ok := withUnits[mess.Status]; !ok {
+				withUnits[mess.Status] = zerolog.Dict()
+			}
+
+			withUnits[mess.Status].Str(mess.ID, status)
+		}
+
+		return true
+	})
+	e := log.Debug()
+	for s, l := range withUnits {
+		e = e.Dict(s, l)
+	}
+	for s, l := range withoutUnits {
+		sort.Strings(l)
+		e = e.Strs(s, l)
+	}
+
+	e.Msg("Pulling layers")
+}

--- a/pkg/executor/docker/executor.go
+++ b/pkg/executor/docker/executor.go
@@ -68,6 +68,7 @@ func NewExecutor(
 	}
 
 	cm.RegisterCallback(func() error {
+		// TODO this shouldn't be reusing the context as there's the possibility that it's already canceled
 		de.cleanupAll(ctx)
 		return nil
 	})
@@ -145,7 +146,7 @@ func (e *Executor) RunShard(
 		if volumeMount.Type == storage.StorageVolumeConnectorBind {
 			log.Ctx(ctx).Trace().Msgf("Input Volume: %+v %+v", spec, volumeMount)
 			mounts = append(mounts, mount.Mount{
-				Type: "bind",
+				Type: mount.TypeBind,
 				// this is an input volume so is read only
 				ReadOnly: true,
 				Source:   volumeMount.Source,
@@ -199,7 +200,7 @@ func (e *Executor) RunShard(
 		// create a mount so the output data does not need to be copied back to the host
 		mounts = append(mounts, mount.Mount{
 
-			Type: "bind",
+			Type: mount.TypeBind,
 			// this is an output volume so can be written to
 			ReadOnly: false,
 

--- a/pkg/test/devstack/concurrency_test.go
+++ b/pkg/test/devstack/concurrency_test.go
@@ -64,6 +64,7 @@ func (suite *DevstackConcurrencySuite) TestConcurrencyLimit() {
 		suite.T(),
 		3,
 		0,
+		false,
 		computenode.NewDefaultComputeNodeConfig(),
 	)
 

--- a/pkg/test/devstack/devstack_test.go
+++ b/pkg/test/devstack/devstack_test.go
@@ -64,6 +64,7 @@ func devStackDockerStorageTest(
 		t,
 		nodeCount,
 		0,
+		false,
 		computenode.NewDefaultComputeNodeConfig(),
 	)
 

--- a/pkg/test/devstack/errorlogs_test.go
+++ b/pkg/test/devstack/errorlogs_test.go
@@ -61,6 +61,7 @@ func (suite *DevstackErrorLogsSuite) TestErrorContainer() {
 		suite.T(),
 		1,
 		0,
+		false,
 		computenode.NewDefaultComputeNodeConfig(),
 	)
 

--- a/pkg/test/devstack/jobselection_test.go
+++ b/pkg/test/devstack/jobselection_test.go
@@ -72,7 +72,7 @@ func (suite *DevstackJobSelectionSuite) TestSelectAllJobs() {
 		cm.RegisterCallback(system.CleanupTraceProvider)
 
 		scenario := scenario.CatFileToStdout()
-		stack, cm := SetupTest(ctx, suite.T(), testCase.nodeCount, 0, computenode.ComputeNodeConfig{
+		stack, cm := SetupTest(ctx, suite.T(), testCase.nodeCount, 0, false, computenode.ComputeNodeConfig{
 			JobSelectionPolicy: testCase.policy,
 		})
 

--- a/pkg/test/devstack/lotus_test.go
+++ b/pkg/test/devstack/lotus_test.go
@@ -1,0 +1,72 @@
+//go:build !(unit && (windows || darwin))
+
+package devstack
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/filecoin-project/bacalhau/pkg/computenode"
+	"github.com/filecoin-project/bacalhau/pkg/system"
+	"github.com/filecoin-project/go-jsonrpc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLotusNode(t *testing.T) {
+	require.NoError(t, system.InitConfigForTesting())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	stack, _ := SetupTest(ctx, t, 1, 0, true, computenode.NewDefaultComputeNodeConfig())
+
+	require.NotNil(t, stack.Lotus)
+	assert.NotEmpty(t, stack.Lotus.Dir)
+	require.NotEmpty(t, stack.Lotus.Token)
+	require.NotEmpty(t, stack.Lotus.Port)
+
+	lotus := lotusApi(t, ctx, stack.Lotus.Port, stack.Lotus.Token)
+
+	version, err := lotus.Version(ctx)
+	require.NoError(t, err)
+
+	t.Log(version.Version)
+}
+
+func lotusApi(t *testing.T, ctx context.Context, port string, token string) *lotusNodeCommonStruct {
+	headers := http.Header{"Authorization": []string{fmt.Sprintf("Bearer %s", token)}}
+	addr := fmt.Sprintf("ws://localhost:%s/rpc/v0", port)
+
+	var lotus lotusNodeCommonStruct
+
+	closer, err := jsonrpc.NewMergeClient(ctx, addr, "Filecoin", []interface{}{&lotus.Internal}, headers)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		closer()
+	})
+
+	return &lotus
+}
+
+// Importing the Lotus API currently causes dependency issues, so only including the smallest part needed
+type lotusNodeCommonStruct struct {
+	Internal struct {
+		Version func(p0 context.Context) (APIVersion, error) `perm:"read"`
+	}
+}
+
+func (l *lotusNodeCommonStruct) Version(ctx context.Context) (APIVersion, error) {
+	return l.Internal.Version(ctx)
+}
+
+type APIVersion struct {
+	Version    string
+	APIVersion Version
+	BlockDelay uint64
+}
+
+type Version uint32

--- a/pkg/test/devstack/min_bids_test.go
+++ b/pkg/test/devstack/min_bids_test.go
@@ -71,6 +71,7 @@ func (suite *MinBidsSuite) TestMinBids() {
 			suite.T(),
 			testCase.nodes,
 			0,
+			false,
 			computenode.NewDefaultComputeNodeConfig(),
 		)
 

--- a/pkg/test/devstack/multiple_cid_test.go
+++ b/pkg/test/devstack/multiple_cid_test.go
@@ -67,6 +67,7 @@ func (s *MultipleCIDSuite) TestMultipleCIDs() {
 		s.T(),
 		1,
 		0,
+		false,
 		computenode.NewDefaultComputeNodeConfig(),
 	)
 
@@ -172,6 +173,7 @@ func (s *MultipleCIDSuite) TestMultipleURLs() {
 		s.T(),
 		1,
 		0,
+		false,
 		computenode.ComputeNodeConfig{
 			JobSelectionPolicy: computenode.JobSelectionPolicy{
 				Locality: computenode.Anywhere,
@@ -297,6 +299,7 @@ func (s *MultipleCIDSuite) TestIPFSURLCombo() {
 		s.T(),
 		1,
 		0,
+		false,
 		computenode.ComputeNodeConfig{
 			JobSelectionPolicy: computenode.JobSelectionPolicy{
 				Locality: computenode.Anywhere,

--- a/pkg/test/devstack/publish_on_error_test.go
+++ b/pkg/test/devstack/publish_on_error_test.go
@@ -57,6 +57,7 @@ func (s *PublishOnErrorSuite) TestPublishOnError() {
 		s.T(),
 		1,
 		0,
+		false,
 		computenode.NewDefaultComputeNodeConfig(),
 	)
 

--- a/pkg/test/devstack/pythonwasm_test.go
+++ b/pkg/test/devstack/pythonwasm_test.go
@@ -70,7 +70,7 @@ func (s *DevstackPythonWASMSuite) TestPythonWasmVolumes() {
 	fileContents := "pineapples"
 
 	ctx := context.Background()
-	stack, cm := SetupTest(ctx, s.T(), nodeCount, 0, computenode.NewDefaultComputeNodeConfig())
+	stack, cm := SetupTest(ctx, s.T(), nodeCount, 0, false, computenode.NewDefaultComputeNodeConfig())
 
 	t := system.GetTracer()
 	ctx, rootSpan := system.NewRootSpan(ctx, t, "pkg/test/devstack.TestPythonWasmVolumes")
@@ -174,7 +174,7 @@ func (s *DevstackPythonWASMSuite) TestSimplestPythonWasmDashC() {
 	s.T().Skip("This test fails when run directly after TestPythonWasmVolumes :-(")
 
 	ctx := context.Background()
-	stack, cm := SetupTest(ctx, s.T(), 1, 0, computenode.NewDefaultComputeNodeConfig())
+	stack, cm := SetupTest(ctx, s.T(), 1, 0, false, computenode.NewDefaultComputeNodeConfig())
 
 	t := system.GetTracer()
 	ctx, rootSpan := system.NewRootSpan(ctx, t, "pkg/test/devstack/pythonwasmtest/simplestpythonwasmdashc")
@@ -213,7 +213,7 @@ func (s *DevstackPythonWASMSuite) TestSimplePythonWasm() {
 	s.T().Skip("This test fails when run directly after TestPythonWasmVolumes :-(")
 
 	ctx := context.Background()
-	stack, cm := SetupTest(ctx, s.T(), 1, 0, computenode.NewDefaultComputeNodeConfig())
+	stack, cm := SetupTest(ctx, s.T(), 1, 0, false, computenode.NewDefaultComputeNodeConfig())
 
 	t := system.GetTracer()
 	ctx, rootSpan := system.NewRootSpan(ctx, t, "pkg/test/devstack/pythonwasmtest/simplepythonwasm")

--- a/pkg/test/devstack/sharding_test.go
+++ b/pkg/test/devstack/sharding_test.go
@@ -176,6 +176,7 @@ func (suite *ShardingSuite) TestEndToEnd() {
 
 		nodeCount,
 		0,
+		false,
 		computenode.NewDefaultComputeNodeConfig(),
 	)
 
@@ -323,6 +324,7 @@ func (suite *ShardingSuite) TestNoShards() {
 
 		nodeCount,
 		0,
+		false,
 		computenode.NewDefaultComputeNodeConfig(),
 	)
 
@@ -385,6 +387,7 @@ func (suite *ShardingSuite) TestExplodeVideos() {
 
 		nodeCount,
 		0,
+		false,
 		computenode.NewDefaultComputeNodeConfig(),
 	)
 

--- a/pkg/test/devstack/submit_test.go
+++ b/pkg/test/devstack/submit_test.go
@@ -50,6 +50,7 @@ func (suite *DevstackSubmitSuite) TestEmptySpec() {
 
 		1,
 		0,
+		false,
 		computenode.NewDefaultComputeNodeConfig(),
 	)
 

--- a/pkg/test/devstack/utils.go
+++ b/pkg/test/devstack/utils.go
@@ -22,14 +22,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var StorageNames = []model.StorageSourceType{
-	model.StorageSourceIPFS,
-}
-
 func SetupTest(
 	ctx context.Context,
 	t *testing.T,
 	nodes int, badActors int,
+	lotusNode bool,
 	//nolint:gocritic
 	config computenode.ComputeNodeConfig,
 ) (*devstack.DevStack, *system.CleanupManager) {
@@ -40,6 +37,7 @@ func SetupTest(
 	options := devstack.DevStackOptions{
 		NumberOfNodes:     nodes,
 		NumberOfBadActors: badActors,
+		LocalNetworkLotus: lotusNode,
 	}
 
 	stack, err := devstack.NewStandardDevStack(ctx, cm, options, config)

--- a/pkg/util/closer/closer.go
+++ b/pkg/util/closer/closer.go
@@ -1,0 +1,20 @@
+package closer
+
+import (
+	"errors"
+	"io"
+	"os"
+
+	"github.com/rs/zerolog/log"
+)
+
+// CloseWithLogOnError will close the given resource and log any relevant failure
+func CloseWithLogOnError(name string, c io.Closer) {
+	err := c.Close()
+	if err == nil || errors.Is(err, os.ErrClosed) {
+		return
+	}
+
+	l := log.With().CallerWithSkipFrameCount(3).Logger()
+	l.Err(err).Msgf("Failed to close %s", name)
+}

--- a/pkg/util/closer/closer_test.go
+++ b/pkg/util/closer/closer_test.go
@@ -1,0 +1,67 @@
+package closer
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCloseWithLogOnError_noErrors(t *testing.T) {
+	old := log.Logger
+	t.Cleanup(func() {
+		log.Logger = old
+	})
+
+	var sb strings.Builder
+	CloseWithLogOnError(t.Name(), closer{nil})
+	assert.Equal(t, "", sb.String())
+}
+
+func TestCloseWithLogOnError_logsErrors(t *testing.T) {
+	old := log.Logger
+	t.Cleanup(func() {
+		log.Logger = old
+	})
+
+	var b bytes.Buffer
+	log.Logger = log.With().Str("foo", "bar").Logger().Output(&b)
+
+	CloseWithLogOnError(t.Name(), closer{fmt.Errorf("error message")})
+
+	var content map[string]string
+	require.NoError(t, json.Unmarshal(b.Bytes(), &content))
+
+	assert.Equal(t, "bar", content["foo"])
+	assert.NotEmpty(t, content["message"])
+	assert.NotEmpty(t, content["caller"])
+	assert.True(t, strings.HasSuffix(content["caller"], "closer/closer_test.go:37"), "%s should end point to this function", content["caller"])
+}
+
+func TestCloseWithLogOnError_ignoresAlreadyClosed(t *testing.T) {
+	old := log.Logger
+	t.Cleanup(func() {
+		log.Logger = old
+	})
+
+	var sb strings.Builder
+	CloseWithLogOnError(t.Name(), closer{os.ErrClosed})
+	assert.Equal(t, "", sb.String())
+}
+
+var _ io.Closer = closer{}
+
+type closer struct {
+	err error
+}
+
+func (c closer) Close() error {
+	return c.err
+}


### PR DESCRIPTION
Add an option to `devstack` command to add the option of starting a Lotus node alongside the devstack. This will allow development of the Filecoin providers by using Lotus that is using a local network rather than the 'real' network.

Fixes #561