### PR TITLE
Use `t.Cleanup` rather than `defer TeardownTest`

### DIFF
--- a/cmd/bacalhau/docker_run_test.go
+++ b/cmd/bacalhau/docker_run_test.go
@@ -8,7 +8,6 @@ import (
 	crand "crypto/rand"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/big"
 	"net"
 	"net/url"
@@ -200,23 +199,20 @@ func (s *DockerRunSuite) TestRun_GenericSubmitWait() {
 	}
 
 	for i, tc := range tests {
-		func() {
+		s.Run(fmt.Sprintf("numberOfJobs:%v", tc.numberOfJobs), func() {
 			ctx := context.Background()
-			devstack, cm := devstack_tests.SetupTest(ctx, s.T(), 1, 0, computenode.ComputeNodeConfig{})
-			defer cm.Cleanup()
+			devstack, _ := devstack_tests.SetupTest(ctx, s.T(), 1, 0, computenode.ComputeNodeConfig{})
 
 			*ODR = *NewDockerRunOptions()
 
-			dir, err := ioutil.TempDir("", "bacalhau-TestRun_GenericSubmitWait")
-			require.NoError(s.T(), err)
+			dir := s.T().TempDir()
 
 			swarmAddresses, err := devstack.Nodes[0].IPFSClient.SwarmAddresses(ctx)
 			require.NoError(s.T(), err)
 			ODR.DownloadFlags.IPFSSwarmAddrs = strings.Join(swarmAddresses, ",")
 			ODR.DownloadFlags.OutputDir = dir
 
-			outputDir, err := ioutil.TempDir("", "bacalhau-ipfs-devstack-test")
-			require.NoError(s.T(), err)
+			outputDir := s.T().TempDir()
 
 			_, out, err := ExecuteTestCobraCommand(s.T(), s.rootCmd, "docker", "run",
 				"--api-host", devstack.Nodes[0].APIServer.Host,
@@ -231,7 +227,7 @@ func (s *DockerRunSuite) TestRun_GenericSubmitWait() {
 
 			c := publicapi.NewAPIClient(fmt.Sprintf("http://%s:%d", devstack.Nodes[0].APIServer.Host, devstack.Nodes[0].APIServer.Port))
 			_ = testutils.GetJobFromTestOutput(ctx, s.T(), c, out)
-		}()
+		})
 	}
 }
 
@@ -740,14 +736,13 @@ func (s *DockerRunSuite) TestRun_ExplodeVideos() {
 		"Prominent Late Gothic styled architecture.mp4",
 	}
 
-	stack, cm := devstack_tests.SetupTest(
+	stack, _ := devstack_tests.SetupTest(
 		ctx,
 		s.T(),
 		nodeCount,
 		0,
 		computenode.NewDefaultComputeNodeConfig(),
 	)
-	defer cm.Cleanup()
 
 	*ODR = *NewDockerRunOptions()
 
@@ -978,8 +973,7 @@ func (s *DockerRunSuite) TestRun_BadExecutables() {
 	}
 
 	ctx := context.TODO()
-	stack, cm := devstack_tests.SetupTest(ctx, s.T(), 1, 0, computenode.ComputeNodeConfig{})
-	defer cm.Cleanup()
+	stack, _ := devstack_tests.SetupTest(ctx, s.T(), 1, 0, computenode.ComputeNodeConfig{})
 
 	for name, tc := range tests {
 		*ODR = *NewDockerRunOptions()

--- a/pkg/test/devstack/concurrency_test.go
+++ b/pkg/test/devstack/concurrency_test.go
@@ -66,7 +66,6 @@ func (suite *DevstackConcurrencySuite) TestConcurrencyLimit() {
 		0,
 		computenode.NewDefaultComputeNodeConfig(),
 	)
-	defer TeardownTest(stack, cm)
 
 	testCase := scenario.CatFileToVolume()
 	inputStorageList, err := testCase.SetupStorage(ctx, model.StorageSourceIPFS, devstack.ToIPFSClients(stack.Nodes[:3])...)

--- a/pkg/test/devstack/devstack_test.go
+++ b/pkg/test/devstack/devstack_test.go
@@ -59,14 +59,13 @@ func devStackDockerStorageTest(
 ) {
 	ctx := context.Background()
 
-	stack, cm := SetupTest(
+	stack, _ := SetupTest(
 		ctx,
 		t,
 		nodeCount,
 		0,
 		computenode.NewDefaultComputeNodeConfig(),
 	)
-	defer TeardownTest(stack, cm)
 
 	nodeIDs, err := stack.GetNodeIds()
 	require.NoError(t, err)

--- a/pkg/test/devstack/errorlogs_test.go
+++ b/pkg/test/devstack/errorlogs_test.go
@@ -56,14 +56,13 @@ func (suite *DevstackErrorLogsSuite) TestErrorContainer() {
 
 	ctx := context.Background()
 
-	stack, cm := SetupTest(
+	stack, _ := SetupTest(
 		ctx,
 		suite.T(),
 		1,
 		0,
 		computenode.NewDefaultComputeNodeConfig(),
 	)
-	defer TeardownTest(stack, cm)
 
 	nodeIDs, err := stack.GetNodeIds()
 	require.NoError(suite.T(), err)

--- a/pkg/test/devstack/jobselection_test.go
+++ b/pkg/test/devstack/jobselection_test.go
@@ -75,7 +75,6 @@ func (suite *DevstackJobSelectionSuite) TestSelectAllJobs() {
 		stack, cm := SetupTest(ctx, suite.T(), testCase.nodeCount, 0, computenode.ComputeNodeConfig{
 			JobSelectionPolicy: testCase.policy,
 		})
-		defer TeardownTest(stack, cm)
 
 		nodeIDs, err := stack.GetNodeIds()
 		require.NoError(suite.T(), err)
@@ -149,6 +148,8 @@ func (suite *DevstackJobSelectionSuite) TestSelectAllJobs() {
 			expectedAccepts: 3,
 		},
 	} {
-		runTest(testCase)
+		suite.Run(testCase.name, func() {
+			runTest(testCase)
+		})
 	}
 }

--- a/pkg/test/devstack/min_bids_test.go
+++ b/pkg/test/devstack/min_bids_test.go
@@ -66,14 +66,13 @@ func (suite *MinBidsSuite) TestMinBids() {
 		ctx, span := system.NewRootSpan(ctx, t, "pkg/test/devstack/min_bids_test")
 		defer span.End()
 
-		stack, cm := SetupTest(
+		stack, _ := SetupTest(
 			ctx,
 			suite.T(),
 			testCase.nodes,
 			0,
 			computenode.NewDefaultComputeNodeConfig(),
 		)
-		defer TeardownTest(stack, cm)
 
 		dirPath, err := prepareFolderWithFiles(testCase.shards)
 		require.NoError(suite.T(), err)
@@ -119,50 +118,56 @@ func (suite *MinBidsSuite) TestMinBids() {
 	}
 
 	// sanity test that with min bids at zero and 1 node we get the job through
-	runTest(minBidsTestCase{
-		nodes:       1,
-		shards:      1,
-		concurrency: 1,
-		minBids:     0,
-		expectedResult: map[model.JobStateType]int{
-			model.JobStateCompleted: 1,
-		},
-		errorStates: []model.JobStateType{
-			model.JobStateError,
-		},
+	suite.Run("minBids0And1Node", func() {
+		runTest(minBidsTestCase{
+			nodes:       1,
+			shards:      1,
+			concurrency: 1,
+			minBids:     0,
+			expectedResult: map[model.JobStateType]int{
+				model.JobStateCompleted: 1,
+			},
+			errorStates: []model.JobStateType{
+				model.JobStateError,
+			},
+		})
 	})
 
 	// test that when min bids is concurrency we get the job through
-	runTest(minBidsTestCase{
-		nodes:       3,
-		shards:      1,
-		concurrency: 3,
-		minBids:     3,
-		expectedResult: map[model.JobStateType]int{
-			model.JobStateCompleted: 3,
-		},
-		errorStates: []model.JobStateType{
-			model.JobStateError,
-		},
+	suite.Run("minBidsIsConcurrency", func() {
+		runTest(minBidsTestCase{
+			nodes:       3,
+			shards:      1,
+			concurrency: 3,
+			minBids:     3,
+			expectedResult: map[model.JobStateType]int{
+				model.JobStateCompleted: 3,
+			},
+			errorStates: []model.JobStateType{
+				model.JobStateError,
+			},
+		})
 	})
 
 	// test that no bids are made because there are not enough nodes on the network
 	// to satisfy the min bids
-	runTest(minBidsTestCase{
-		nodes:       3,
-		shards:      1,
-		concurrency: 3,
-		minBids:     5,
-		expectedResult: map[model.JobStateType]int{
-			model.JobStateBidding: 3,
-		},
-		errorStates: []model.JobStateType{
-			model.JobStateError,
-			model.JobStateWaiting,
-			model.JobStateRunning,
-			model.JobStateVerifying,
-			model.JobStateCompleted,
-		},
+	suite.Run("noBids", func() {
+		runTest(minBidsTestCase{
+			nodes:       3,
+			shards:      1,
+			concurrency: 3,
+			minBids:     5,
+			expectedResult: map[model.JobStateType]int{
+				model.JobStateBidding: 3,
+			},
+			errorStates: []model.JobStateType{
+				model.JobStateError,
+				model.JobStateWaiting,
+				model.JobStateRunning,
+				model.JobStateVerifying,
+				model.JobStateCompleted,
+			},
+		})
 	})
 
 }

--- a/pkg/test/devstack/multiple_cid_test.go
+++ b/pkg/test/devstack/multiple_cid_test.go
@@ -69,7 +69,6 @@ func (s *MultipleCIDSuite) TestMultipleCIDs() {
 		0,
 		computenode.NewDefaultComputeNodeConfig(),
 	)
-	defer TeardownTest(stack, cm)
 
 	t := system.GetTracer()
 	ctx, rootSpan := system.NewRootSpan(ctx, t, "pkg/test/devstack/multiple_cid_test/testmultiplecids")
@@ -179,7 +178,6 @@ func (s *MultipleCIDSuite) TestMultipleURLs() {
 			},
 		},
 	)
-	defer TeardownTest(stack, cm)
 
 	t := system.GetTracer()
 	ctx, rootSpan := system.NewRootSpan(ctx, t, "pkg/test/devstack/multiple_cid_test/testmultipleurls")
@@ -305,7 +303,6 @@ func (s *MultipleCIDSuite) TestIPFSURLCombo() {
 			},
 		},
 	)
-	defer TeardownTest(stack, cm)
 
 	t := system.GetTracer()
 	ctx, rootSpan := system.NewRootSpan(ctx, t, "pkg/test/devstack/multiple_cid_test/testmultipleurls")

--- a/pkg/test/devstack/publish_on_error_test.go
+++ b/pkg/test/devstack/publish_on_error_test.go
@@ -59,7 +59,6 @@ func (s *PublishOnErrorSuite) TestPublishOnError() {
 		0,
 		computenode.NewDefaultComputeNodeConfig(),
 	)
-	defer TeardownTest(stack, cm)
 
 	t := system.GetTracer()
 	ctx, rootSpan := system.NewRootSpan(ctx, t, "pkg/test/devstack/publish_on_error/test")

--- a/pkg/test/devstack/pythonwasm_test.go
+++ b/pkg/test/devstack/pythonwasm_test.go
@@ -71,7 +71,6 @@ func (s *DevstackPythonWASMSuite) TestPythonWasmVolumes() {
 
 	ctx := context.Background()
 	stack, cm := SetupTest(ctx, s.T(), nodeCount, 0, computenode.NewDefaultComputeNodeConfig())
-	defer TeardownTest(stack, cm)
 
 	t := system.GetTracer()
 	ctx, rootSpan := system.NewRootSpan(ctx, t, "pkg/test/devstack.TestPythonWasmVolumes")
@@ -176,7 +175,6 @@ func (s *DevstackPythonWASMSuite) TestSimplestPythonWasmDashC() {
 
 	ctx := context.Background()
 	stack, cm := SetupTest(ctx, s.T(), 1, 0, computenode.NewDefaultComputeNodeConfig())
-	defer TeardownTest(stack, cm)
 
 	t := system.GetTracer()
 	ctx, rootSpan := system.NewRootSpan(ctx, t, "pkg/test/devstack/pythonwasmtest/simplestpythonwasmdashc")
@@ -216,7 +214,6 @@ func (s *DevstackPythonWASMSuite) TestSimplePythonWasm() {
 
 	ctx := context.Background()
 	stack, cm := SetupTest(ctx, s.T(), 1, 0, computenode.NewDefaultComputeNodeConfig())
-	defer TeardownTest(stack, cm)
 
 	t := system.GetTracer()
 	ctx, rootSpan := system.NewRootSpan(ctx, t, "pkg/test/devstack/pythonwasmtest/simplepythonwasm")

--- a/pkg/test/devstack/sharding_test.go
+++ b/pkg/test/devstack/sharding_test.go
@@ -178,7 +178,6 @@ func (suite *ShardingSuite) TestEndToEnd() {
 		0,
 		computenode.NewDefaultComputeNodeConfig(),
 	)
-	defer TeardownTest(stack, cm)
 
 	t := system.GetTracer()
 	ctx, rootSpan := system.NewRootSpan(ctx, t, "pkg/test/devstack/shardingtest/testendtoend")
@@ -326,7 +325,6 @@ func (suite *ShardingSuite) TestNoShards() {
 		0,
 		computenode.NewDefaultComputeNodeConfig(),
 	)
-	defer TeardownTest(stack, cm)
 
 	t := system.GetTracer()
 	ctx, rootSpan := system.NewRootSpan(ctx, t, "pkg/test/devstack/shardingtest/testnoshards")
@@ -389,7 +387,6 @@ func (suite *ShardingSuite) TestExplodeVideos() {
 		0,
 		computenode.NewDefaultComputeNodeConfig(),
 	)
-	defer TeardownTest(stack, cm)
 
 	t := system.GetTracer()
 	ctx, rootSpan := system.NewRootSpan(ctx, t, "pkg/devstack/shardingtest/testexplodevideos")

--- a/pkg/test/devstack/submit_test.go
+++ b/pkg/test/devstack/submit_test.go
@@ -52,7 +52,6 @@ func (suite *DevstackSubmitSuite) TestEmptySpec() {
 		0,
 		computenode.NewDefaultComputeNodeConfig(),
 	)
-	defer TeardownTest(stack, cm)
 
 	t := system.GetTracer()
 	ctx, rootSpan := system.NewRootSpan(ctx, t, "pkg/test/devstack/submittest/testemptyspec")

--- a/pkg/test/devstack/utils.go
+++ b/pkg/test/devstack/utils.go
@@ -45,14 +45,12 @@ func SetupTest(
 	stack, err := devstack.NewStandardDevStack(ctx, cm, options, config)
 	require.NoError(t, err)
 
+	t.Cleanup(cm.Cleanup)
+
 	// important to give the pubsub network time to connect
 	time.Sleep(time.Second)
 
 	return stack, cm
-}
-
-func TeardownTest(stack *devstack.DevStack, cm *system.CleanupManager) {
-	cm.Cleanup()
 }
 
 type DeterministicVerifierTestArgs struct {


### PR DESCRIPTION
Avoid accidents like forgetting to add `defer` or have the `defer` called too early by using `t.Cleanup`.

Also use `t.TempDir` rather than `ioutil.TempDir`

Fixes #881