### PR TITLE
Avoid reusing cancelled context in cleanup

### DIFF
--- a/pkg/ipfs/node.go
+++ b/pkg/ipfs/node.go
@@ -363,7 +363,7 @@ func serveAPI(cm *system.CleanupManager, node *core.IpfsNode, repoPath string) e
 	for _, listener := range listeners {
 		go func(listener manet.Listener) {
 			cm.RegisterCallback(func() error {
-				return listener.Close()
+				return fmt.Errorf("problem when shutting down IPFS listener: %w", listener.Close())
 			})
 
 			// NOTE: this is not critical, but we should log for debugging

--- a/pkg/publicapi/server.go
+++ b/pkg/publicapi/server.go
@@ -151,12 +151,14 @@ func (apiServer *APIServer) ListenAndServe(ctx context.Context, cm *system.Clean
 
 	// Cleanup resources when system is done:
 	cm.RegisterCallback(func() error {
-		return srv.Shutdown(ctx)
+		// We have to use a separate context, rather than the one passed in, as it may have already been
+		// canceled and so would prevent us from performing any cleanup work.
+		return srv.Shutdown(context.Background())
 	})
 
 	err := srv.ListenAndServe()
 	if err == http.ErrServerClosed {
-		log.Debug().Msgf(
+		log.Ctx(ctx).Debug().Msgf(
 			"API server closed for host %s on %s.", hostID, srv.Addr)
 		return nil // expected error if the server is shut down
 	}

--- a/pkg/transport/libp2p/libp2p.go
+++ b/pkg/transport/libp2p/libp2p.go
@@ -178,7 +178,6 @@ func (t *LibP2PTransport) Start(ctx context.Context) error {
 }
 
 func (t *LibP2PTransport) Shutdown(ctx context.Context) error {
-	//nolint:ineffassign,staticcheck
 	ctx, span := system.GetTracer().Start(ctx, "pkg/transport/libp2p.Shutdown")
 	defer span.End()
 


### PR DESCRIPTION
By the time that cleanup is run, the context that is passed in during construction would have been cancelled as this is the signal to stop work. This means that some attempts to use that context would always fail, such as calls to Docker,m and so need to be replaced with a 'fresh' context.

This should fix _most_ of the errors that are logged when shutting down. The error for the IPFS listener has been reworded, to make it obvious where it comes from, as I wasn't able to prevent the error.

Fixes #893