### PR TITLE
Add resilience to Estuary publishing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -316,7 +316,7 @@ require (
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/dig v1.14.0 // indirect
 	go.uber.org/fx v1.16.0 // indirect
-	go.uber.org/multierr v1.8.0 // indirect
+	go.uber.org/multierr v1.8.0
 	go.uber.org/zap v1.21.0 // indirect
 	go4.org v0.0.0-20201209231011-d4a079459e60 // indirect
 	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d // indirect

--- a/pkg/publisher/estuary/publisher.go
+++ b/pkg/publisher/estuary/publisher.go
@@ -2,17 +2,22 @@ package estuary
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math/rand"
 	"net/http"
+	"net/url"
 	"os"
+	"path/filepath"
 
 	"github.com/filecoin-project/bacalhau/pkg/ipfs/car"
 	"github.com/filecoin-project/bacalhau/pkg/job"
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/filecoin-project/bacalhau/pkg/publisher"
 	"github.com/filecoin-project/bacalhau/pkg/system"
+	"github.com/rs/zerolog/log"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -25,7 +30,16 @@ type EstuaryPublisher struct {
 	Config        EstuaryPublisherConfig
 }
 
+// Partial results from the '/viewer' API endpoint
+type EstuaryAPIConfig struct {
+	Settings struct {
+		ContentAddingDisabled bool
+		UploadEndpoints       []string
+	}
+}
+
 func NewEstuaryPublisher(
+	ctx context.Context,
 	cm *system.CleanupManager,
 	resolver *job.StateResolver,
 	config EstuaryPublisherConfig,
@@ -33,6 +47,8 @@ func NewEstuaryPublisher(
 	if config.APIKey == "" {
 		return nil, fmt.Errorf("APIKey is required")
 	}
+
+	log.Ctx(ctx).Debug().Msgf("Estuary publisher initialized")
 	return &EstuaryPublisher{
 		StateResolver: resolver,
 		Config:        config,
@@ -57,28 +73,51 @@ func (estuaryPublisher *EstuaryPublisher) PublishShardResult(
 ) (model.StorageSpec, error) {
 	ctx, span := newSpan(ctx, "PublishShardResult")
 	defer span.End()
+
+	log.Ctx(ctx).Info().Msgf("Publishing shard %v results to Estuary", shard)
 	tempDir, err := ioutil.TempDir("", "bacalhau-estuary-publisher")
 	if err != nil {
 		return model.StorageSpec{}, err
 	}
-	carFile := fmt.Sprintf("%s/results.car", tempDir)
+	carFile := filepath.Join(tempDir, "results.car")
 	cid, err := car.CreateCar(ctx, shardResultPath, carFile, 1)
 	if err != nil {
 		return model.StorageSpec{}, err
 	}
-	fileReader, err := os.Open(carFile)
+
+	uploadURLs, err := estuaryPublisher.getWriteAPIURLs(ctx, "/content/add-car")
+	if err == nil && len(uploadURLs) < 1 {
+		err = fmt.Errorf("cannot upload content because no Estuary servers are available")
+	}
 	if err != nil {
 		return model.StorageSpec{}, err
 	}
-	_, err = estuaryPublisher.doHTTPRequest(ctx, "POST", getWriteAPIURL("/content/add-car"), fileReader)
-	if err != nil {
-		return model.StorageSpec{}, err
+
+	// Shuffle the URLs so that we are distributing our work amongst the hosts.
+	rand.Shuffle(len(uploadURLs), func(i, j int) {
+		uploadURLs[i], uploadURLs[j] = uploadURLs[j], uploadURLs[i]
+	})
+
+	// Try each host until one succeeds.
+	for _, uploadURL := range uploadURLs {
+		fileReader, err := os.Open(carFile)
+		if err != nil {
+			return model.StorageSpec{}, err
+		}
+		_, err = estuaryPublisher.doHTTPRequest(ctx, "POST", uploadURL.String(), fileReader)
+		if err != nil {
+			log.Ctx(ctx).Error().Err(err).Msgf("Failed to upload to Estuary host '%s'", uploadURL.Host)
+			continue
+		} else {
+			return model.StorageSpec{
+				Name:          fmt.Sprintf("job-%s-shard-%d-host-%s", shard.Job.ID, shard.Index, hostID),
+				StorageSource: model.StorageSourceEstuary,
+				CID:           cid,
+			}, nil
+		}
 	}
-	return model.StorageSpec{
-		Name:          fmt.Sprintf("job-%s-shard-%d-host-%s", shard.Job.ID, shard.Index, hostID),
-		StorageSource: model.StorageSourceEstuary,
-		CID:           cid,
-	}, nil
+
+	return model.StorageSpec{}, fmt.Errorf("failed to upload to any Estuary host")
 }
 
 func (estuaryPublisher *EstuaryPublisher) ComposeResultReferences(
@@ -133,12 +172,45 @@ func getReadAPIURL(path string) string {
 	return baseURL + path
 }
 
-func getWriteAPIURL(path string) string {
+// getWriteAPIURLs returns a list of URLs that point to different Estuary hosts
+// with the given path appended. It uses an Estuary API call to retrieve the
+// latest set of write endpoints and checks that Estuary is currently accepting
+// writes.
+func (estuaryPublisher *EstuaryPublisher) getWriteAPIURLs(ctx context.Context, path string) ([]url.URL, error) {
 	baseURL := os.Getenv("BACALHAU_ESTUARY_WRITE_API_URL")
-	if baseURL == "" {
-		baseURL = "https://shuttle-6.estuary.tech"
+	if baseURL != "" {
+		log.Ctx(ctx).Debug().Msgf("Using env-defined '%s' as Estuary upload host", baseURL)
+		parsedURL, err := url.Parse(baseURL)
+		return []url.URL{*parsedURL}, err
 	}
-	return baseURL + path
+
+	estuaryConfig, err := estuaryPublisher.doHTTPRequest(ctx, "GET", getReadAPIURL("/viewer"), nil)
+	if err != nil {
+		return nil, fmt.Errorf("error trying to read Estuary config: %s", err.Error())
+	}
+
+	var config EstuaryAPIConfig
+	err = json.Unmarshal(estuaryConfig, &config)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing Estuary config: %s", err.Error())
+	}
+
+	if config.Settings.ContentAddingDisabled {
+		return nil, fmt.Errorf("cannot upload content because Estuary uploads are disabled")
+	}
+
+	uploadURLs := make([]url.URL, len(config.Settings.UploadEndpoints))
+	for _, server := range config.Settings.UploadEndpoints {
+		parsedURL, err := url.Parse(server)
+		if err != nil {
+			log.Ctx(ctx).Warn().Err(err).Msg("Estuary server URL malformed")
+			continue
+		}
+		parsedURL.Path = path
+		uploadURLs = append(uploadURLs, *parsedURL)
+	}
+
+	return uploadURLs, nil
 }
 
 func newSpan(ctx context.Context, apiName string) (context.Context, trace.Span) {

--- a/pkg/publisher/fallback/publisher.go
+++ b/pkg/publisher/fallback/publisher.go
@@ -1,0 +1,78 @@
+// fallback implements a publisher.Publisher that will try multiple other
+// Publishers in order until one suceeeds.
+//
+// The Publishers are tried in the order specified in the call to
+// NewFallbackPublisher. If and only if all of the Publishers return an error
+// result, the fallback publisher will also return an error result. Otherwise,
+// it will return the result of the first Publisher to succeed and will swallow
+// any errors. Subsequent Publishers will not be attempted after one succeeds.
+
+package fallback
+
+import (
+	"context"
+
+	"github.com/filecoin-project/bacalhau/pkg/model"
+	"github.com/filecoin-project/bacalhau/pkg/publisher"
+	"github.com/rs/zerolog/log"
+	"go.uber.org/multierr"
+)
+
+type fallbackPublisher struct {
+	publishers []publisher.Publisher
+}
+
+func NewFallbackPublisher(publishers ...publisher.Publisher) *fallbackPublisher {
+	return &fallbackPublisher{
+		publishers: publishers,
+	}
+}
+
+// fallback accepts a slice of publisher objects and passes them to the supplied
+// function in order, until one does not return an error value and then returns
+// that result. If all publishers return an error value, a composite error is
+// returned.
+func fallback[T any, P any](ctx context.Context, publishers []P, method func(P) (T, error)) (T, error) {
+	var anyErr error
+	for _, publisher := range publishers {
+		result, err := method(publisher)
+		if err == nil {
+			return result, nil
+		} else {
+			log.Ctx(ctx).Warn().Msgf("publisher %v returned an error: %s", publisher, err.Error())
+			anyErr = multierr.Append(anyErr, err)
+		}
+	}
+
+	var zeroResult T
+	return zeroResult, anyErr
+}
+
+// ComposeResultReferences implements publisher.Publisher
+func (f *fallbackPublisher) ComposeResultReferences(ctx context.Context, jobID string) ([]model.StorageSpec, error) {
+	return fallback(ctx, f.publishers, func(p publisher.Publisher) ([]model.StorageSpec, error) {
+		return p.ComposeResultReferences(ctx, jobID)
+	})
+}
+
+// IsInstalled implements publisher.Publisher
+func (f *fallbackPublisher) IsInstalled(ctx context.Context) (bool, error) {
+	return fallback(ctx, f.publishers, func(p publisher.Publisher) (bool, error) {
+		return p.IsInstalled(ctx)
+	})
+}
+
+// PublishShardResult implements publisher.Publisher
+func (f *fallbackPublisher) PublishShardResult(
+	ctx context.Context,
+	shard model.JobShard,
+	hostID string,
+	shardResultPath string,
+) (model.StorageSpec, error) {
+	return fallback(ctx, f.publishers, func(p publisher.Publisher) (model.StorageSpec, error) {
+		return p.PublishShardResult(ctx, shard, hostID, shardResultPath)
+	})
+}
+
+// Compile-time check that Publisher implements the correct interface:
+var _ publisher.Publisher = (*fallbackPublisher)(nil)

--- a/pkg/publisher/fallback/publisher_test.go
+++ b/pkg/publisher/fallback/publisher_test.go
@@ -1,0 +1,79 @@
+package fallback
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/filecoin-project/bacalhau/pkg/model"
+	"github.com/filecoin-project/bacalhau/pkg/publisher"
+	"github.com/stretchr/testify/require"
+)
+
+type mockPublisher struct {
+	isInstalled                bool
+	isInstalledErr             error
+	composeResultReferences    []model.StorageSpec
+	composeResultReferencesErr error
+	publishShardResult         model.StorageSpec
+	publishShardResultErr      error
+}
+
+// ComposeResultReferences implements publisher.Publisher
+func (m *mockPublisher) ComposeResultReferences(ctx context.Context, jobID string) ([]model.StorageSpec, error) {
+	return m.composeResultReferences, m.composeResultReferencesErr
+}
+
+// IsInstalled implements publisher.Publisher
+func (m *mockPublisher) IsInstalled(context.Context) (bool, error) {
+	return m.isInstalled, m.isInstalledErr
+}
+
+// PublishShardResult implements publisher.Publisher
+func (m *mockPublisher) PublishShardResult(ctx context.Context, shard model.JobShard, hostID string, shardResultPath string) (model.StorageSpec, error) {
+	return m.publishShardResult, m.publishShardResultErr
+}
+
+var _ publisher.Publisher = (*mockPublisher)(nil)
+
+var healthyPublisher = mockPublisher{
+	isInstalled:             true,
+	composeResultReferences: []model.StorageSpec{{Name: "test spec"}},
+	publishShardResult:      model.StorageSpec{Name: "test output"},
+}
+
+var errorPublisher = mockPublisher{
+	isInstalledErr:             fmt.Errorf("test error"),
+	composeResultReferencesErr: fmt.Errorf("test error"),
+	publishShardResultErr:      fmt.Errorf("test error"),
+}
+
+var testCases = map[string]struct {
+	publisher       fallbackPublisher
+	expectPublisher mockPublisher
+}{
+	"empty":   {*NewFallbackPublisher(), mockPublisher{}},
+	"single":  {*NewFallbackPublisher(&healthyPublisher), healthyPublisher},
+	"healthy": {*NewFallbackPublisher(&errorPublisher, &healthyPublisher), healthyPublisher},
+	"error":   {*NewFallbackPublisher(&errorPublisher, &errorPublisher), errorPublisher},
+}
+
+func TestFallbackPublisher(t *testing.T) {
+	for name, testCase := range testCases {
+		t.Run(name+"/IsInstalled", func(t *testing.T) {
+			result, err := testCase.publisher.IsInstalled(context.Background())
+			require.Equal(t, testCase.expectPublisher.isInstalledErr == nil, err == nil)
+			require.Equal(t, testCase.expectPublisher.isInstalled, result)
+		})
+		t.Run(name+"/ComposeResultReferences", func(t *testing.T) {
+			result, err := testCase.publisher.ComposeResultReferences(context.Background(), "")
+			require.Equal(t, testCase.expectPublisher.composeResultReferencesErr == nil, err == nil)
+			require.Equal(t, testCase.expectPublisher.composeResultReferences, result)
+		})
+		t.Run(name+"/PublishShardResult", func(t *testing.T) {
+			result, err := testCase.publisher.PublishShardResult(context.Background(), model.JobShard{}, "", "")
+			require.Equal(t, testCase.expectPublisher.publishShardResultErr == nil, err == nil)
+			require.Equal(t, testCase.expectPublisher.publishShardResult, result)
+		})
+	}
+}

--- a/pkg/publisher/util/utils.go
+++ b/pkg/publisher/util/utils.go
@@ -34,7 +34,7 @@ func NewIPFSPublishers(
 	// and so let's only add the
 	var estuaryPublisher publisher.Publisher = ipfsPublisher
 	if estuaryAPIKey != "" {
-		estuaryPublisher, err = estuary.NewEstuaryPublisher(cm, resolver, estuary.EstuaryPublisherConfig{
+		estuaryPublisher, err = estuary.NewEstuaryPublisher(ctx, cm, resolver, estuary.EstuaryPublisherConfig{
 			APIKey: estuaryAPIKey,
 		})
 		if err != nil {

--- a/pkg/publisher/util/utils.go
+++ b/pkg/publisher/util/utils.go
@@ -7,6 +7,7 @@ import (
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/filecoin-project/bacalhau/pkg/publisher"
 	"github.com/filecoin-project/bacalhau/pkg/publisher/estuary"
+	"github.com/filecoin-project/bacalhau/pkg/publisher/fallback"
 	"github.com/filecoin-project/bacalhau/pkg/publisher/ipfs"
 	"github.com/filecoin-project/bacalhau/pkg/publisher/noop"
 	"github.com/filecoin-project/bacalhau/pkg/system"
@@ -42,9 +43,12 @@ func NewIPFSPublishers(
 	}
 
 	return publisher.NewMappedPublisherProvider(map[model.Publisher]publisher.Publisher{
-		model.PublisherNoop:    noopPublisher,
-		model.PublisherIpfs:    ipfsPublisher,
-		model.PublisherEstuary: estuaryPublisher,
+		model.PublisherNoop: noopPublisher,
+		model.PublisherIpfs: ipfsPublisher,
+		model.PublisherEstuary: fallback.NewFallbackPublisher(
+			estuaryPublisher,
+			ipfsPublisher,
+		),
 	}), nil
 }
 


### PR DESCRIPTION
We now [fallback to IPFS storage if Estuary is unavailable](https://github.com/filecoin-project/bacalhau/commit/2c02079f3f2faca313313fd1cfd35bfcb0052c33) and [query the Estuary API for correct submission URLs](https://github.com/filecoin-project/bacalhau/commit/db7e3d969018b67ab51c02635adc3af5429229f1). This means we are able to retry the Estuary publication with multiple hosts and just write to IPFS if none work, so Estuary jobs should stop failing if their service goes down or one of the nodes in their network is affected.

Resolves #696 and #697.