### PR TITLE
Make Language jobs use Estuary publisher by default

### DIFF
--- a/pkg/job/factory.go
+++ b/pkg/job/factory.go
@@ -146,7 +146,6 @@ func ConstructDockerJob( //nolint:funlen
 }
 
 func ConstructLanguageJob(
-	a model.APIVersion,
 	inputVolumes []string,
 	inputUrls []string,
 	outputVolumes []string,
@@ -201,28 +200,22 @@ func ConstructLanguageJob(
 	if err != nil {
 		return &model.Job{}, err
 	}
-	j.APIVersion = a.String()
 
-	j.Spec = model.Spec{
-		Engine:   model.EngineLanguage,
-		Verifier: model.VerifierNoop,
-		// TODO: should this always be ipfs?
-		Publisher: model.PublisherIpfs,
-		Language: model.JobSpecLanguage{
-			Language:         language,
-			LanguageVersion:  languageVersion,
-			Deterministic:    deterministic,
-			Context:          model.StorageSpec{},
-			Command:          command,
-			ProgramPath:      programPath,
-			RequirementsPath: requirementsPath,
-		},
-		Inputs:      jobInputs,
-		Contexts:    jobContexts,
-		Outputs:     jobOutputs,
-		Annotations: jobAnnotations,
-		DoNotTrack:  doNotTrack,
+	j.Spec.Engine = model.EngineLanguage
+	j.Spec.Language = model.JobSpecLanguage{
+		Language:         language,
+		LanguageVersion:  languageVersion,
+		Deterministic:    deterministic,
+		Context:          model.StorageSpec{},
+		Command:          command,
+		ProgramPath:      programPath,
+		RequirementsPath: requirementsPath,
 	}
+	j.Spec.Inputs = jobInputs
+	j.Spec.Contexts = jobContexts
+	j.Spec.Outputs = jobOutputs
+	j.Spec.Annotations = jobAnnotations
+	j.Spec.DoNotTrack = doNotTrack
 
 	j.Deal = model.Deal{
 		Concurrency: concurrency,

--- a/pkg/model/job.go
+++ b/pkg/model/job.go
@@ -61,7 +61,7 @@ func NewJob() *Job {
 func NewJobWithSaneProductionDefaults() (*Job, error) {
 	j := NewJob()
 	err := mergo.Merge(j, &Job{
-		APIVersion: V1alpha1.String(),
+		APIVersion: APIVersionLatest().String(),
 		Spec: Spec{
 			Engine:    EngineDocker,
 			Verifier:  VerifierNoop,


### PR DESCRIPTION
The Docker command already picks Estuary by default, so all that is needed is to make this true for the Language runner (which covers WASM for now). 

Also remove the Verifier flag from the Language runner which doesn't do anything at the moment (it should – we need to unify the things that are common across our run commands).

Resolves #909.