### PR TITLE
899 test for concurrent gpus

### DIFF
--- a/pkg/test/computenode/resourcelimits_test.go
+++ b/pkg/test/computenode/resourcelimits_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/filecoin-project/bacalhau/pkg/devstack"
+	"github.com/filecoin-project/bacalhau/pkg/transport/inprocess"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/filecoin-project/bacalhau/pkg/capacitymanager"
@@ -399,6 +400,123 @@ func (suite *ComputeNodeResourceLimitsSuite) TestTotalResourceLimits() {
 		},
 	)
 
+}
+
+// test that with 10 GPU nodes - that 10 jobs end up being allocated 1 per node
+// this is a check of the bidding & capacity manager system
+func (suite *ComputeNodeResourceLimitsSuite) TestParallelGPU() {
+	// we need to pretend that we have GPUs on each node
+	capacitymanager.SetIgnorePhysicalResources("1")
+	nodeCount := 2
+	seenJobs := 0
+	jobIds := []string{}
+
+	ctx := context.Background()
+
+	// the job needs to hang for a period of time so the other job will
+	// run on another node
+	jobHandler := func(ctx context.Context, shard model.JobShard, resultsDir string) (*model.RunCommandResult, error) {
+		time.Sleep(time.Second * 1)
+		seenJobs++
+		return &model.RunCommandResult{}, nil
+	}
+
+	stack := testutils.NewNoopStackMultinode(
+		ctx,
+		suite.T(),
+		nodeCount,
+		computenode.ComputeNodeConfig{
+			CapacityManagerConfig: capacitymanager.Config{
+				ResourceLimitTotal: model.ResourceUsageConfig{
+					CPU:    "1",
+					Memory: "1Gb",
+					Disk:   "1Gb",
+					GPU:    "1",
+				},
+			},
+		},
+		noop_executor.ExecutorConfig{
+			ExternalHooks: noop_executor.ExecutorConfigExternalHooks{
+				JobHandler: jobHandler,
+			},
+		},
+		inprocess.InProcessTransportClusterConfig{
+			GetMessageDelay: func(index int) time.Duration {
+				if index == 0 {
+					return time.Millisecond * 10
+				} else {
+					return time.Second * 1
+				}
+			},
+		},
+	)
+
+	cm := stack.CleanupManager
+	defer cm.Cleanup()
+
+	jobConfig := &model.Job{
+		Spec: model.Spec{
+			Engine:    model.EngineNoop,
+			Verifier:  model.VerifierNoop,
+			Publisher: model.PublisherNoop,
+			Docker: model.JobSpecDocker{
+				Image:      "ubuntu",
+				Entrypoint: []string{"/bin/bash", "-c", "echo hello"},
+			},
+			Resources: model.ResourceUsageConfig{
+				GPU: "1",
+			},
+		},
+		Deal: model.Deal{
+			Concurrency: 1,
+		},
+	}
+
+	resolver := job.NewStateResolver(
+		func(ctx context.Context, id string) (*model.Job, error) {
+			return stack.Nodes[0].LocalDB.GetJob(ctx, id)
+		},
+		func(ctx context.Context, id string) (model.JobState, error) {
+			return stack.Nodes[0].LocalDB.GetJobState(ctx, id)
+		},
+	)
+
+	for i := 0; i < nodeCount; i++ {
+		submittedJob, err := stack.Nodes[0].RequesterNode.SubmitJob(ctx, model.JobCreatePayload{
+			ClientID: "123",
+			Job:      jobConfig,
+		})
+		require.NoError(suite.T(), err)
+		jobIds = append(jobIds, submittedJob.ID)
+		time.Sleep(time.Millisecond * 500)
+	}
+
+	for _, jobId := range jobIds {
+		err := resolver.WaitUntilComplete(ctx, jobId)
+		require.NoError(suite.T(), err)
+	}
+
+	require.Equal(suite.T(), nodeCount, seenJobs)
+
+	allocationMap := map[string]int{}
+
+	for i := 0; i < nodeCount; i++ {
+		jobState, err := resolver.GetJobState(ctx, jobIds[i])
+		require.NoError(suite.T(), err)
+		completedShards := job.GetCompletedShardStates(jobState)
+		require.Equal(suite.T(), 1, len(completedShards))
+		require.Equal(suite.T(), model.JobStateCompleted, completedShards[0].State)
+		allocationMap[completedShards[0].NodeID]++
+	}
+
+	// test that each node has 1 job allocated to it
+	node1Count, ok := allocationMap[stack.Nodes[0].Transport.HostID()]
+	require.True(suite.T(), ok)
+	require.Equal(suite.T(), 1, node1Count)
+
+	node2Count, ok := allocationMap[stack.Nodes[1].Transport.HostID()]
+	require.True(suite.T(), ok)
+	require.Equal(suite.T(), 1, node2Count)
 }
 
 func (suite *ComputeNodeResourceLimitsSuite) TestDockerResourceLimitsCPU() {

--- a/pkg/transport/inprocess/inprocess_cluster.go
+++ b/pkg/transport/inprocess/inprocess_cluster.go
@@ -1,0 +1,108 @@
+package inprocess
+
+import (
+	"context"
+	"time"
+
+	"github.com/filecoin-project/bacalhau/pkg/model"
+	"github.com/filecoin-project/bacalhau/pkg/transport"
+	"github.com/multiformats/go-multiaddr"
+	"github.com/rs/zerolog/log"
+)
+
+type InProcessTransportClusterConfig struct {
+	Count int
+	// a function to get the network latency for a given node id
+	GetMessageDelay func(index int) time.Duration
+}
+
+// this is a set of "connected" in process transports
+// meaning that an event written to one of them will be delivered
+// to the subscribeFunctions and seen events of all of them
+type InProcessTransportCluster struct {
+	transports []*InProcessTransport
+	config     InProcessTransportClusterConfig
+}
+
+func NewInProcessTransportCluster(config InProcessTransportClusterConfig) (*InProcessTransportCluster, error) {
+	cluster := &InProcessTransportCluster{
+		transports: []*InProcessTransport{},
+		config:     config,
+	}
+	for i := 0; i < config.Count; i++ {
+		transport, err := NewInprocessTransport()
+		if err != nil {
+			return nil, err
+		}
+		transport.publishHandler = cluster.Publish
+		cluster.transports = append(cluster.transports, transport)
+	}
+	return cluster, nil
+}
+
+func (cluster *InProcessTransportCluster) Start(ctx context.Context) error {
+	return nil
+}
+
+func (cluster *InProcessTransportCluster) Shutdown(ctx context.Context) error {
+	return nil
+}
+
+func (cluster *InProcessTransportCluster) HostID() string {
+	return "cluster_root"
+}
+
+func (cluster *InProcessTransportCluster) HostAddrs() ([]multiaddr.Multiaddr, error) {
+	return []multiaddr.Multiaddr{}, nil
+}
+
+func (cluster *InProcessTransportCluster) GetEvents() []model.JobEvent {
+	return []model.JobEvent{}
+}
+
+/*
+
+  pub / sub
+
+*/
+
+// this function is assigned to the "publishHandler" of each transport
+// this means that calling "Publish" on one of the nodes transports
+// will end up here where we distribute the event to all the other nodes at the same time
+func (cluster *InProcessTransportCluster) Publish(ctx context.Context, ev model.JobEvent) error {
+	for i, transport := range cluster.transports {
+		transport := transport
+		i := i
+		go func() {
+			if cluster.config.GetMessageDelay != nil {
+				time.Sleep(cluster.config.GetMessageDelay(i))
+			}
+			err := transport.applyEvent(ctx, ev)
+			if err != nil {
+				log.Error().Msgf("error in handle event: %s\n%+v", err, ev)
+			}
+		}()
+	}
+	return nil
+}
+
+func (cluster *InProcessTransportCluster) Subscribe(ctx context.Context, fn transport.SubscribeFn) {}
+
+/*
+encrypt / decrypt
+*/
+
+func (*InProcessTransportCluster) Encrypt(ctx context.Context, data, encryptionKeyBytes []byte) ([]byte, error) {
+	return data, nil
+}
+
+func (*InProcessTransportCluster) Decrypt(ctx context.Context, data []byte) ([]byte, error) {
+	return data, nil
+}
+
+func (cluster *InProcessTransportCluster) GetTransport(i int) *InProcessTransport {
+	return cluster.transports[i]
+}
+
+// Static check to ensure that InProcessTransportCluster implements Transport:
+var _ transport.Transport = (*InProcessTransportCluster)(nil)

--- a/pkg/transport/inprocess/inprocess_cluster.go
+++ b/pkg/transport/inprocess/inprocess_cluster.go
@@ -5,15 +5,13 @@ import (
 	"time"
 
 	"github.com/filecoin-project/bacalhau/pkg/model"
-	"github.com/filecoin-project/bacalhau/pkg/transport"
-	"github.com/multiformats/go-multiaddr"
 	"github.com/rs/zerolog/log"
 )
 
 type InProcessTransportClusterConfig struct {
 	Count int
 	// a function to get the network latency for a given node id
-	GetMessageDelay func(index int) time.Duration
+	GetMessageDelay func(fromIndex, toIndex int) time.Duration
 }
 
 // this is a set of "connected" in process transports
@@ -34,75 +32,32 @@ func NewInProcessTransportCluster(config InProcessTransportClusterConfig) (*InPr
 		if err != nil {
 			return nil, err
 		}
-		transport.publishHandler = cluster.Publish
 		cluster.transports = append(cluster.transports, transport)
 	}
-	return cluster, nil
-}
 
-func (cluster *InProcessTransportCluster) Start(ctx context.Context) error {
-	return nil
-}
-
-func (cluster *InProcessTransportCluster) Shutdown(ctx context.Context) error {
-	return nil
-}
-
-func (cluster *InProcessTransportCluster) HostID() string {
-	return "cluster_root"
-}
-
-func (cluster *InProcessTransportCluster) HostAddrs() ([]multiaddr.Multiaddr, error) {
-	return []multiaddr.Multiaddr{}, nil
-}
-
-func (cluster *InProcessTransportCluster) GetEvents() []model.JobEvent {
-	return []model.JobEvent{}
-}
-
-/*
-
-  pub / sub
-
-*/
-
-// this function is assigned to the "publishHandler" of each transport
-// this means that calling "Publish" on one of the nodes transports
-// will end up here where we distribute the event to all the other nodes at the same time
-func (cluster *InProcessTransportCluster) Publish(ctx context.Context, ev model.JobEvent) error {
-	for i, transport := range cluster.transports {
-		transport := transport
-		i := i
-		go func() {
-			if cluster.config.GetMessageDelay != nil {
-				time.Sleep(cluster.config.GetMessageDelay(i))
+	for fromTransportIndex, fromTransport := range cluster.transports {
+		// override the publish handler for each transport and write to all the other transports
+		fromTransport.publishHandler = func(ctx context.Context, ev model.JobEvent) error {
+			for toTransportIndex, toTransport := range cluster.transports {
+				toTransport := toTransport
+				fromTransportIndex := fromTransportIndex
+				toTransportIndex := toTransportIndex
+				go func() {
+					if cluster.config.GetMessageDelay != nil {
+						time.Sleep(cluster.config.GetMessageDelay(fromTransportIndex, toTransportIndex))
+					}
+					err := toTransport.applyEvent(ctx, ev)
+					if err != nil {
+						log.Error().Msgf("error in handle event: %s\n%+v", err, ev)
+					}
+				}()
 			}
-			err := transport.applyEvent(ctx, ev)
-			if err != nil {
-				log.Error().Msgf("error in handle event: %s\n%+v", err, ev)
-			}
-		}()
+			return nil
+		}
 	}
-	return nil
-}
-
-func (cluster *InProcessTransportCluster) Subscribe(ctx context.Context, fn transport.SubscribeFn) {}
-
-/*
-encrypt / decrypt
-*/
-
-func (*InProcessTransportCluster) Encrypt(ctx context.Context, data, encryptionKeyBytes []byte) ([]byte, error) {
-	return data, nil
-}
-
-func (*InProcessTransportCluster) Decrypt(ctx context.Context, data []byte) ([]byte, error) {
-	return data, nil
+	return cluster, nil
 }
 
 func (cluster *InProcessTransportCluster) GetTransport(i int) *InProcessTransport {
 	return cluster.transports[i]
 }
-
-// Static check to ensure that InProcessTransportCluster implements Transport:
-var _ transport.Transport = (*InProcessTransportCluster)(nil)


### PR DESCRIPTION
This does not close #899 (because we still need to add 5 GPUs to the network) but it adds a test for concurrently scheduling GPU jobs to a network of varying latency and we now log when `CalculateJobNodeDistanceDelay` drops a job so we can catch when GPUs are not being scheduled to because of it

Additional features:

 * we now have a multi-node noop stack setup (we only ever had a single node noop stack)
 * we can introduce arbitrary network delays on the transports on any node
 * this actually gives us a fast (it's noop) stack for testing distributed networks