### PR TITLE
Validate size limit on all context files, not just the compressed blob

### DIFF
--- a/pkg/util/targzip/targzip.go
+++ b/pkg/util/targzip/targzip.go
@@ -1,0 +1,221 @@
+package targzip
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/c2h5oh/datasize"
+	"github.com/filecoin-project/bacalhau/pkg/system"
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	MaximumContextSize            datasize.ByteSize = 10 * datasize.MB
+	worldReadOwnerWritePermission fs.FileMode       = 0755
+)
+
+func Compress(ctx context.Context, src string, buf io.Writer) error {
+	return compress(ctx, src, buf, MaximumContextSize)
+}
+
+func Decompress(src io.Reader, dst string) error {
+	return decompress(src, dst, MaximumContextSize)
+}
+
+// from https://github.com/mimoo/eureka/blob/master/folders.go under Apache 2
+//
+//nolint:gocyclo
+func compress(ctx context.Context, src string, buf io.Writer, max datasize.ByteSize) error {
+	_, span := system.GetTracer().Start(ctx, "pkg/util/targzip.Compress")
+	defer span.End()
+
+	// tar > gzip > buf
+	zr := gzip.NewWriter(buf)
+	tw := tar.NewWriter(zr)
+
+	// is file a folder?
+	fi, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	mode := fi.Mode()
+	if mode.IsRegular() {
+		if fi.Size() > int64(max) {
+			return fmt.Errorf("file %s bigger than max size %s", src, max.HumanReadable())
+		}
+		// get header
+		var header *tar.Header
+		header, err = tar.FileInfoHeader(fi, src)
+		if err != nil {
+			return err
+		}
+		// write header
+		if err = tw.WriteHeader(header); err != nil { //nolint:gocritic
+			return err
+		}
+		// get content
+		var data *os.File
+		data, err = os.Open(src)
+		if err != nil {
+			return err
+		}
+		if _, err = io.Copy(tw, data); err != nil {
+			return err
+		}
+	} else if mode.IsDir() { // folder
+		// walk through every file in the folder
+		err = filepath.Walk(src, func(file string, fi os.FileInfo, _ error) error {
+			// generate tar header
+			var header *tar.Header
+			header, err = tar.FileInfoHeader(fi, file)
+			if err != nil {
+				return err
+			}
+
+			// must provide real name
+			// (see https://golang.org/src/archive/tar/common.go?#L626)
+			header.Name = filepath.ToSlash(file)
+
+			// write header
+			if err = tw.WriteHeader(header); err != nil { //nolint:gocritic
+				return err
+			}
+			// if not a dir, write file content
+			if !fi.IsDir() {
+				var data *os.File
+				var fi os.FileInfo
+				fi, err = os.Stat(file)
+				if err != nil {
+					return err
+				}
+				if fi.Size() > int64(max) {
+					return fmt.Errorf("file %s bigger than max size %s", file, max.HumanReadable())
+				}
+				data, err = os.Open(file)
+				if err != nil {
+					return err
+				}
+				if _, err = io.Copy(tw, data); err != nil { //nolint:gocritic
+					return err
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	} else {
+		return fmt.Errorf("error: file type not supported")
+	}
+
+	// produce tar
+	if err := tw.Close(); err != nil {
+		return err
+	}
+	// produce gzip
+	if err := zr.Close(); err != nil {
+		return err
+	}
+	//
+	return nil
+}
+
+func decompress(src io.Reader, dst string, max datasize.ByteSize) error {
+	// ensure destination directory exists
+	err := os.Mkdir(dst, worldReadOwnerWritePermission)
+	if err != nil {
+		return err
+	}
+
+	// ungzip
+	zr, err := gzip.NewReader(src)
+	if err != nil {
+		return err
+	}
+	// untar
+	tr := tar.NewReader(zr)
+
+	// uncompress each element
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			break // End of archive
+		}
+		if err != nil {
+			return err
+		}
+		target := header.Name
+
+		// validate name against path traversal
+		if !validRelPath(header.Name) {
+			return fmt.Errorf("tar contained invalid name error %q", target)
+		}
+
+		// add dst + re-format slashes according to system
+		target, err = sanitizeArchivePath(dst, header.Name)
+		if err != nil {
+			return err
+		}
+		// if no join is needed, replace with ToSlash:
+		// target = filepath.ToSlash(header.Name)
+
+		// check the type
+		switch header.Typeflag {
+		// if its a dir and it doesn't exist create it (with 0755 permission)
+		case tar.TypeDir:
+			if _, err := os.Stat(target); err != nil {
+				if err := os.MkdirAll(target, worldReadOwnerWritePermission); err != nil {
+					return err
+				}
+			}
+		// if it's a file create it (with same permission)
+		case tar.TypeReg:
+			if header.Size > int64(max) {
+				return fmt.Errorf("file %s bigger than max size %s", header.Name, max.HumanReadable())
+			}
+			fileToWrite, err := os.OpenFile(target, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
+			if err != nil {
+				return err
+			}
+			// copy over contents (max 10MB per file!)
+			if _, err := io.CopyN(fileToWrite, tr, int64(max)); err != nil { //nolint:gomnd
+				log.Debug().Msgf("CopyN err is %s", err)
+				// io.EOF is expected
+				if err != io.EOF {
+					return err
+				}
+			}
+			// manually close here after each file operation; defering would cause each file close
+			// to wait until all operations have completed.
+			fileToWrite.Close()
+		}
+	}
+
+	//
+	return nil
+}
+
+// check for path traversal and correct forward slashes
+func validRelPath(p string) bool {
+	if p == "" || strings.Contains(p, `\`) || strings.HasPrefix(p, "/") || strings.Contains(p, "../") {
+		return false
+	}
+	return true
+}
+
+// Sanitize archive file pathing from "G305: Zip Slip vulnerability"
+func sanitizeArchivePath(d, t string) (v string, err error) {
+	v = filepath.Join(d, t)
+	if strings.HasPrefix(v, filepath.Clean(d)) {
+		return v, nil
+	}
+
+	return "", fmt.Errorf("%s: %s", "content filepath is tainted", t)
+}

--- a/pkg/util/targzip/targzip_test.go
+++ b/pkg/util/targzip/targzip_test.go
@@ -1,0 +1,125 @@
+package targzip
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/c2h5oh/datasize"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testModeFile = "file"
+	testModeDir  = "dir"
+	testModePwd  = "pwd"
+)
+
+type errorChecker func(require.TestingT, error, ...interface{})
+
+var testSizes = map[datasize.ByteSize]errorChecker{
+	0 * datasize.B:                    require.NoError,
+	1 * datasize.B:                    require.NoError,
+	MaximumContextSize:                require.NoError,
+	MaximumContextSize + 1*datasize.B: require.Error,
+}
+
+func setup(t *testing.T, size datasize.ByteSize, mode string) (tgzFile *os.File, tgzInput string) {
+	rootDir, err := os.MkdirTemp(os.TempDir(), "bacalhau-targzip-test*")
+	require.NoError(t, err)
+
+	testDir := rootDir
+	if mode == testModeDir {
+		testDir = filepath.Join(testDir, "testdir")
+		err := os.Mkdir(testDir, worldReadOwnerWritePermission)
+		require.NoError(t, err)
+	}
+
+	testFilename := filepath.Join(testDir, "data.txt")
+	testFile, err := os.Create(testFilename)
+	require.NoError(t, err)
+
+	err = testFile.Truncate(int64(size))
+	require.NoError(t, err)
+	testFile.Close()
+
+	scratchDir, err := os.MkdirTemp(os.TempDir(), "bacalhau-targzip-test*")
+	require.NoError(t, err)
+	tgzFilename := filepath.Join(scratchDir, "data.tgz")
+	tgzFile, err = os.Create(tgzFilename)
+	require.NoError(t, err)
+
+	err = os.Chdir(rootDir)
+	require.NoError(t, err)
+	relFilename, err := filepath.Rel(rootDir, testFilename)
+	require.NoError(t, err)
+	relDir, err := filepath.Rel(rootDir, testDir)
+	require.NoError(t, err)
+
+	tgzInput = map[string]string{
+		testModeFile: relFilename,
+		testModeDir:  relDir,
+		testModePwd:  ".",
+	}[mode]
+	return tgzFile, tgzInput
+}
+
+func TestRoundTrip(t *testing.T) {
+	for mode, expectedFile := range map[string]string{
+		testModeFile: "data.txt",
+		testModeDir:  filepath.Join("testdir", "data.txt"),
+		testModePwd:  "data.txt",
+	} {
+		t.Run(mode, func(t *testing.T) {
+			tgzFile, tgzInput := setup(t, datasize.KB, mode)
+			defer tgzFile.Close()
+
+			err := Compress(context.Background(), tgzInput, tgzFile)
+			require.NoError(t, err)
+
+			_, err = tgzFile.Seek(0, 0)
+			require.NoError(t, err)
+
+			outputDir := filepath.Join(t.TempDir(), "outdir")
+			err = Decompress(tgzFile, outputDir)
+			require.NoError(t, err)
+			require.FileExists(t, filepath.Join(outputDir, expectedFile))
+		})
+	}
+}
+
+func TestCompressionSizeLimiting(t *testing.T) {
+	for _, mode := range []string{testModeFile, testModeDir} {
+		for size, errorChecker := range testSizes {
+			t.Run(mode+"/"+size.String(), func(t *testing.T) {
+				tgzFile, tgzInput := setup(t, size, mode)
+				defer tgzFile.Close()
+
+				err := Compress(context.Background(), tgzInput, tgzFile)
+				errorChecker(t, err)
+			})
+		}
+	}
+}
+
+func TestDecompressionSizeLimiting(t *testing.T) {
+	for _, mode := range []string{testModeFile, testModeDir} {
+		for size, errorChecker := range testSizes {
+			t.Run(mode+"/"+size.String(), func(t *testing.T) {
+				tgzFile, tgzInput := setup(t, size, mode)
+				defer tgzFile.Close()
+
+				err := compress(context.Background(), tgzInput, tgzFile, size*2)
+				require.NoError(t, err)
+
+				_, err = tgzFile.Seek(0, 0)
+				require.NoError(t, err)
+
+				outputDir := filepath.Join(t.TempDir(), "outdir")
+				err = Decompress(tgzFile, outputDir)
+				errorChecker(t, err)
+			})
+		}
+	}
+}


### PR DESCRIPTION
Previously the compressor would validate that the final TGZ that it builds from context files was less than 10MB, but the decompressor would truncate each file to 10MB. The point of this feature is to stop gzip bombs, so the latter behaviour is desirable. This commit changes the validation to apply per file on compress, and also throws a real error on decompress rather than silently truncating.

Resolves #916.