### PR TITLE
Fix compute nodes stuck at bidding

### DIFF
--- a/pkg/computenode/computenode.go
+++ b/pkg/computenode/computenode.go
@@ -412,6 +412,8 @@ func (n *ComputeNode) triggerStateTransition(ctx context.Context, event model.Jo
 			shardState.Publish(ctx)
 		case model.JobEventResultsRejected:
 			shardState.ResultsRejected(ctx)
+		case model.JobEventInvalidRequest:
+			shardState.FailSilently(ctx, "Request rejected due to: "+event.Status)
 		}
 	} else {
 		log.Ctx(ctx).Debug().Msgf("Received %s for unknown shard %s", event.EventName, shard)

--- a/pkg/job/state.go
+++ b/pkg/job/state.go
@@ -400,11 +400,7 @@ func HasShardReachedCapacity(ctx context.Context, j *model.Job, jobState model.J
 		}
 	}
 
-	if acceptedBidsSeen >= j.Deal.Concurrency {
-		return true
-	}
-
-	return false
+	return acceptedBidsSeen >= j.Deal.Concurrency
 }
 
 // group states by shard index so we can easily iterate over a whole set of them

--- a/pkg/job/state.go
+++ b/pkg/job/state.go
@@ -392,22 +392,15 @@ func HasShardReachedCapacity(ctx context.Context, j *model.Job, jobState model.J
 		return false
 	}
 
-	bidsSeen := 0
 	acceptedBidsSeen := 0
 
 	for _, shardState := range shardStates { //nolint:gocritic
-		if shardState.State == model.JobStateBidding {
-			bidsSeen++
-		} else if shardState.State == model.JobStateWaiting {
+		if shardState.State.HasPassedBidAcceptedStage() {
 			acceptedBidsSeen++
 		}
 	}
 
 	if acceptedBidsSeen >= j.Deal.Concurrency {
-		return true
-	}
-
-	if bidsSeen >= j.Deal.Concurrency*2 {
 		return true
 	}
 

--- a/pkg/model/job_state.go
+++ b/pkg/model/job_state.go
@@ -132,7 +132,7 @@ func GetStateFromEvent(eventType JobEventType) JobStateType {
 		return JobStateRunning
 
 	// yikes
-	case JobEventError, JobEventComputeError:
+	case JobEventError, JobEventComputeError, JobEventInvalidRequest:
 		return JobStateError
 
 	// we are complete

--- a/pkg/model/job_state.go
+++ b/pkg/model/job_state.go
@@ -57,6 +57,10 @@ func (s JobStateType) IsComplete() bool {
 	return s == JobStateCompleted || s == JobStateError
 }
 
+func (s JobStateType) HasPassedBidAcceptedStage() bool {
+	return s == JobStateWaiting || s == JobStateRunning || s == JobStateVerifying || s == JobStateError || s == JobStateCompleted
+}
+
 func (s JobStateType) IsError() bool {
 	return s == JobStateError
 }

--- a/pkg/model/jobeventtype.go
+++ b/pkg/model/jobeventtype.go
@@ -76,7 +76,7 @@ func (je JobEventType) IsTerminal() bool {
 // ignore the rest of the job's lifecycle. This is the case for events caused
 // by a node's bid being rejected.
 func (je JobEventType) IsIgnorable() bool {
-	return je.IsTerminal() || je == JobEventComputeError || je == JobEventBidRejected
+	return je.IsTerminal() || je == JobEventComputeError || je == JobEventBidRejected || je == JobEventInvalidRequest
 }
 
 func ParseJobEventType(str string) (JobEventType, error) {

--- a/pkg/model/jobeventtype.go
+++ b/pkg/model/jobeventtype.go
@@ -56,6 +56,13 @@ const (
 	// a requester node declared an error running a job
 	JobEventError
 
+	// the requester node gives a compute node permission
+	// to forget about the job and free any resources it might
+	// currently be reserving - this can happen if a compute node
+	// bids when a job has completed - if the compute node does
+	// not hear back it will be stuck in reserving the resources for the job
+	JobEventInvalidRequest
+
 	jobEventDone // must be last
 )
 

--- a/pkg/model/jobeventtype_string.go
+++ b/pkg/model/jobeventtype_string.go
@@ -22,12 +22,13 @@ func _() {
 	_ = x[JobEventResultsRejected-11]
 	_ = x[JobEventResultsPublished-12]
 	_ = x[JobEventError-13]
-	_ = x[jobEventDone-14]
+	_ = x[JobEventInvalidRequest-14]
+	_ = x[jobEventDone-15]
 }
 
-const _JobEventType_name = "jobEventUnknownCreatedDealUpdatedBidBidAcceptedBidRejectedBidCancelledRunningComputeErrorResultsProposedResultsAcceptedResultsRejectedResultsPublishedErrorjobEventDone"
+const _JobEventType_name = "jobEventUnknownCreatedDealUpdatedBidBidAcceptedBidRejectedBidCancelledRunningComputeErrorResultsProposedResultsAcceptedResultsRejectedResultsPublishedErrorInvalidRequestjobEventDone"
 
-var _JobEventType_index = [...]uint8{0, 15, 22, 33, 36, 47, 58, 70, 77, 89, 104, 119, 134, 150, 155, 167}
+var _JobEventType_index = [...]uint8{0, 15, 22, 33, 36, 47, 58, 70, 77, 89, 104, 119, 134, 150, 155, 169, 181}
 
 func (i JobEventType) String() string {
 	if i < 0 || i >= JobEventType(len(_JobEventType_index)-1) {

--- a/pkg/requesternode/requesternode.go
+++ b/pkg/requesternode/requesternode.go
@@ -144,6 +144,11 @@ func (node *RequesterNode) triggerStateTransition(ctx context.Context, event mod
 		}
 	} else {
 		log.Ctx(ctx).Debug().Msgf("Received %s for unknown shard %s", event.EventName, shard)
+		if err := node.notifyShardInvalidRequest(ctx, shard, event.SourceNodeID, "shard state not found"); err != nil {
+			log.Ctx(ctx).Warn().Msgf(
+				"Received %s for unknown shard %s, and failed to notify the source node %s",
+				event.EventName, shard, event.SourceNodeID)
+		}
 	}
 	return nil
 }
@@ -266,15 +271,17 @@ func (node *RequesterNode) notifyShardError(
 	return node.jobEventPublisher.HandleJobEvent(ctx, ev)
 }
 
-// func (node *RequesterNode) notifyShardInvalidRequest(
-// 	ctx context.Context,
-// 	shard model.JobShard,
-// 	status string,
-// ) error {
-// 	ev := node.constructShardEvent(shard, model.JobEventInvalidRequest)
-// 	ev.Status = status
-// 	return node.jobEventPublisher.HandleJobEvent(ctx, ev)
-// }
+func (node *RequesterNode) notifyShardInvalidRequest(
+	ctx context.Context,
+	shard model.JobShard,
+	targetNodeID string,
+	status string,
+) error {
+	ev := node.constructShardEvent(shard, model.JobEventInvalidRequest)
+	ev.Status = status
+	ev.TargetNodeID = targetNodeID
+	return node.jobEventPublisher.HandleJobEvent(ctx, ev)
+}
 
 func (node *RequesterNode) constructJobEvent(jobID string, eventName model.JobEventType) model.JobEvent {
 	return model.JobEvent{

--- a/pkg/requesternode/requesternode.go
+++ b/pkg/requesternode/requesternode.go
@@ -266,6 +266,16 @@ func (node *RequesterNode) notifyShardError(
 	return node.jobEventPublisher.HandleJobEvent(ctx, ev)
 }
 
+// func (node *RequesterNode) notifyShardInvalidRequest(
+// 	ctx context.Context,
+// 	shard model.JobShard,
+// 	status string,
+// ) error {
+// 	ev := node.constructShardEvent(shard, model.JobEventInvalidRequest)
+// 	ev.Status = status
+// 	return node.jobEventPublisher.HandleJobEvent(ctx, ev)
+// }
+
 func (node *RequesterNode) constructJobEvent(jobID string, eventName model.JobEventType) model.JobEvent {
 	return model.JobEvent{
 		SourceNodeID: node.ID,

--- a/pkg/requesternode/shard_fsm.go
+++ b/pkg/requesternode/shard_fsm.go
@@ -189,6 +189,9 @@ func (m *shardStateMachine) sendRequest(ctx context.Context, request shardStateR
 	defer func() {
 		if r := recover(); r != nil {
 			log.Ctx(ctx).Warn().Msgf("%s ignoring action after channel closed: %s", m, request.action)
+			go func() {
+
+			}()
 		}
 	}()
 	m.req <- request

--- a/pkg/requesternode/shard_fsm.go
+++ b/pkg/requesternode/shard_fsm.go
@@ -188,13 +188,19 @@ func (m *shardStateMachine) resultsPublished(ctx context.Context, sourceNodeID s
 func (m *shardStateMachine) sendRequest(ctx context.Context, request shardStateRequest) {
 	defer func() {
 		if r := recover(); r != nil {
-			log.Ctx(ctx).Warn().Msgf("%s ignoring action after channel closed: %s", m, request.action)
-			go func() {
-
-			}()
+			go m.notifyInvalidRequest(ctx, request, "shard fsm is completed")
 		}
 	}()
 	m.req <- request
+}
+
+// Notify the compute node that the request is invalid.
+func (m *shardStateMachine) notifyInvalidRequest(ctx context.Context, request shardStateRequest, reason string) {
+	log.Ctx(ctx).Warn().Msgf("%s ignoring request due to `%s`: %+v", m, reason, request)
+
+	if err := m.node.notifyShardInvalidRequest(ctx, m.shard, request.sourceNodeID, reason); err != nil {
+		log.Ctx(ctx).Warn().Msgf("%s failed to notify invalid request `%s`: %+v due to %s", m, reason, request, err)
+	}
 }
 
 // ------------------------------------
@@ -227,7 +233,7 @@ func enqueuedState(ctx context.Context, m *shardStateMachine) stateFn {
 				log.Ctx(ctx).Warn().Msgf("%s ignoring duplicate bid from %s", m, req.sourceNodeID)
 			}
 		default:
-			log.Ctx(ctx).Warn().Msgf("%s ignoring unknown action: %s", m, req.action)
+			m.notifyInvalidRequest(ctx, req, fmt.Sprintf("invalid action %s in state %s", req.action, m.currentState))
 		}
 	}
 }
@@ -300,10 +306,10 @@ func acceptingBidsState(ctx context.Context, m *shardStateMachine) stateFn {
 			if _, ok := m.biddingNodes[req.sourceNodeID]; ok {
 				m.completedNodes[req.sourceNodeID] = struct{}{}
 			} else {
-				log.Ctx(ctx).Warn().Msgf("%s ignoring result from %s", m, req.sourceNodeID)
+				m.notifyInvalidRequest(ctx, req, "results received from a non-bidding node")
 			}
 		default:
-			log.Ctx(ctx).Warn().Msgf("%s ignoring unknown action: %s", m, req.action)
+			m.notifyInvalidRequest(ctx, req, fmt.Sprintf("invalid action %s in state %s", req.action, m.currentState))
 		}
 	}
 }
@@ -332,10 +338,10 @@ func waitingForResultsState(ctx context.Context, m *shardStateMachine) stateFn {
 					return verifyingResultsState
 				}
 			} else {
-				log.Ctx(ctx).Warn().Msgf("%s ignoring result from %s", m, req.sourceNodeID)
+				m.notifyInvalidRequest(ctx, req, "results received from a non-bidding node")
 			}
 		default:
-			log.Ctx(ctx).Warn().Msgf("%s ignoring unknown action: %s", m, req.action)
+			m.notifyInvalidRequest(ctx, req, fmt.Sprintf("invalid action %s in state %s", req.action, m.currentState))
 		}
 	}
 }
@@ -368,7 +374,7 @@ func waitingToPublishResultsState(ctx context.Context, m *shardStateMachine) sta
 			//  publish the result and not all the compute nodes.
 			return completedState
 		default:
-			log.Ctx(ctx).Warn().Msgf("%s ignoring unknown action: %s", m, req.action)
+			m.notifyInvalidRequest(ctx, req, fmt.Sprintf("invalid action %s in state %s", req.action, m.currentState))
 		}
 	}
 }


### PR DESCRIPTION
A compute node can bid on a job even after another bid was accepted and results were published, which will result in that compute node getting stuck in bidding state with capacity reserved as the requester node will ignore the bid and won't reject it. There are couple bugs that were fixed to mitigate this issue:

1. Fix a bug in the compute node that checks if a shard has reached capacity before bidding on. Previously it checks if there are enough nodes in bid accepted state, but it should also check if any state post bid accepted, such as completed!
2. Requester node now returns a `InvalidRequest` event back to the compute node if it bids on a job that is no longer biddable (e.g. completed or reached capacity), or if the job doesn't exist (e.g. requester node restarted)

A long term solution is to implement timeouts in each state to let the compute node fail rather than getting stuck, if for example the requester node is no longer available. This is tracked in https://github.com/filecoin-project/bacalhau/issues/663 