### PR TITLE
Change the Lotus publisher to discover the miner

### DIFF
--- a/pkg/devstack/lotus.go
+++ b/pkg/devstack/lotus.go
@@ -24,7 +24,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-const defaultImage = "ghcr.io/bacalhau-project/lotus-filecoin-image:v0.0.1"
+const defaultImage = "ghcr.io/bacalhau-project/lotus-filecoin-image:v0.0.2"
 
 type LotusNode struct {
 	client    *dockerclient.Client
@@ -87,11 +87,11 @@ func (l *LotusNode) start(ctx context.Context) error {
 			"1234/tcp": {{}},
 		},
 		Mounts: []mount.Mount{
-			// Mount the temp directory at the same place within the container to aviod confusion between paths outside the
-			// container, that the user sees, and paths within the container, that the ClientImport command uses.
+			// Mount the temp directory at the same place within the container to avoid confusion between paths outside the
+			// container, that the user sees, and paths within the container, that the ClientImport/ClientExport command uses.
 			{
 				Type:     mount.TypeBind,
-				ReadOnly: true,
+				ReadOnly: false,
 				Source:   l.UploadDir,
 				Target:   l.UploadDir,
 			},

--- a/pkg/ipfs/client.go
+++ b/pkg/ipfs/client.go
@@ -239,7 +239,7 @@ func (cl *Client) NodesWithCID(ctx context.Context, cid string) ([]string, error
 	return res, nil
 }
 
-// HadCID returns true if the node has the given CID locally, whether pinned or not.
+// HasCID returns true if the node has the given CID locally, whether pinned or not.
 func (cl *Client) HasCID(ctx context.Context, cid string) (bool, error) {
 	ctx, span := system.GetTracer().Start(ctx, "pkg/ipfs.HasCID")
 	defer span.End()

--- a/pkg/publisher/filecoin_lotus/api/retrievalmarket/retrievalmarket.go
+++ b/pkg/publisher/filecoin_lotus/api/retrievalmarket/retrievalmarket.go
@@ -1,0 +1,3 @@
+package retrievalmarket
+
+type DealID uint64


### PR DESCRIPTION
Avoid having to have the miner baked into configuration and instead rely on being able to discover the miner.

Also change the waiting for deal state section to use a channel, rather than constantly retrieving the information, and document the further deal states.

Fixes #924