### PR TITLE
Avoid failing if profiling fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ grc-test:
 	grc go test ./... -v -p 4
 
 .PHONY: grc-test-short
-grc-test:
+grc-test-short:
 	grc go test ./... -test.short -v
 
 .PHONY: test-debug


### PR DESCRIPTION
Don't fail the entire program if we're unable to create the memory profile.

Fixes #898