### PR TITLE
Prefer t.TempDir for temporary directories

### DIFF
--- a/cmd/bacalhau/docker_run_test.go
+++ b/cmd/bacalhau/docker_run_test.go
@@ -747,12 +747,10 @@ func (s *DockerRunSuite) TestRun_ExplodeVideos() {
 
 	*ODR = *NewDockerRunOptions()
 
-	dirPath, err := os.MkdirTemp("", "sharding-test")
-	defer os.RemoveAll(dirPath)
+	dirPath := s.T().TempDir()
 
-	require.NoError(s.T(), err)
 	for _, video := range videos {
-		err = os.WriteFile(
+		err := os.WriteFile(
 			filepath.Join(dirPath, video),
 			[]byte(fmt.Sprintf("hello %s", video)),
 			0644,
@@ -841,9 +839,6 @@ func (s *DockerRunSuite) TestTruncateReturn() {
 		"maxLength + 10000": {inputLength: system.MaxStdoutReturnLengthInBytes * 10,
 			truncated: true, expectedLength: system.MaxStdoutReturnLengthInBytes},
 	}
-
-	outputDir, _ := os.MkdirTemp(os.TempDir(), "bacalhau-truncate-test-*")
-	defer os.RemoveAll(outputDir)
 
 	for name, tc := range tests {
 		s.T().Run(name, func(t *testing.T) {

--- a/cmd/bacalhau/get_test.go
+++ b/cmd/bacalhau/get_test.go
@@ -65,8 +65,7 @@ func (suite *GetSuite) TestGetJob() {
 	port, _ := freeport.GetFreePort()
 	submittedJobID := ""
 
-	outputDir, _ := os.MkdirTemp(os.TempDir(), "bacalhau-get-test-*")
-	defer os.RemoveAll(outputDir)
+	outputDir := suite.T().TempDir()
 	for _, n := range numOfJobsTests {
 		func() {
 			c, cm := publicapi.SetupRequesterNodeForTestWithPort(suite.T(), port)

--- a/pkg/ipfs/downloader_test.go
+++ b/pkg/ipfs/downloader_test.go
@@ -3,7 +3,6 @@ package ipfs
 import (
 	"context"
 	"crypto/rand"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -46,8 +45,7 @@ func (ds *DownloaderSuite) SetupTest() {
 	swarm, err := node.SwarmAddresses()
 	require.NoError(ds.T(), err)
 
-	testOutputDir, err := ioutil.TempDir(os.TempDir(), "bacalhau-downloader-test-outputs-*")
-	require.NoError(ds.T(), err)
+	testOutputDir := ds.T().TempDir()
 	ds.outputDir = testOutputDir
 
 	ds.downloadSettings = IPFSDownloadSettings{
@@ -90,8 +88,7 @@ func generateFile(path string) ([]byte, error) {
 // files within the directory. At the end, the entire directory is saved to
 // IPFS.
 func mockShardOutput(ds *DownloaderSuite, setup func(string)) string {
-	testDir, err := ioutil.TempDir(os.TempDir(), "bacalhau-downloader-test-inputs-*")
-	require.NoError(ds.T(), err)
+	testDir := ds.T().TempDir()
 
 	setup(testDir)
 

--- a/pkg/ipfs/node_test.go
+++ b/pkg/ipfs/node_test.go
@@ -62,8 +62,7 @@ func (suite *NodeSuite) TestFunctionality() {
 	require.NoError(suite.T(), err)
 
 	// Create a file in a temp dir to upload to the nodes:
-	dirPath, err := os.MkdirTemp("", "ipfs-client-test")
-	require.NoError(suite.T(), err)
+	dirPath := suite.T().TempDir()
 
 	filePath := filepath.Join(dirPath, "test.txt")
 	file, err := os.Create(filePath)

--- a/pkg/storage/filecoin_unsealed/storage_test.go
+++ b/pkg/storage/filecoin_unsealed/storage_test.go
@@ -2,7 +2,6 @@ package filecoinunsealed
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -50,8 +49,7 @@ func (suite *FilecoinUnsealedSuite) SetupTest() {
 	var setupErr error
 	cm = system.NewCleanupManager()
 	ctx = context.Background()
-	tempDir, setupErr = ioutil.TempDir("", "bacalhau-filecoin-unsealed-test")
-	require.NoError(suite.T(), setupErr)
+	tempDir = suite.T().TempDir()
 	driver, setupErr = NewStorage(cm, filepath.Join(tempDir, "{{.CID}}"))
 	require.NoError(suite.T(), setupErr)
 }

--- a/pkg/system/utils_test.go
+++ b/pkg/system/utils_test.go
@@ -45,11 +45,7 @@ func (s *SystemUtilsSuite) TearDownAllSuite() {
 func (s *SystemUtilsSuite) TestBasicCommandExecution() {
 	cmd := "bash"
 	args := []string{"-c", "echo", fmt.Sprintf("%s", uuid.New())}
-	tmpDir, err := ioutil.TempDir("", "test-bacalhau-command-execution-")
-	defer os.RemoveAll(tmpDir)
-	if err != nil {
-		require.Fail(s.T(), "Could not create temp dir", err)
-	}
+	tmpDir := s.T().TempDir()
 
 	stdoutFile := tmpDir + "/stdout"
 	stderrFile := tmpDir + "/stderr"
@@ -59,11 +55,7 @@ func (s *SystemUtilsSuite) TestBasicCommandExecution() {
 func (s *SystemUtilsSuite) TestInternalCommandExecution() {
 	cmd := "bash"
 	args := []string{"-c", "echo", fmt.Sprintf("%s", uuid.New())}
-	tmpDir, err := ioutil.TempDir("", "test-bacalhau-command-execution-")
-	defer os.RemoveAll(tmpDir)
-	if err != nil {
-		require.Fail(s.T(), "Could not create temp dir", err)
-	}
+	tmpDir := s.T().TempDir()
 
 	stdoutFile := tmpDir + "/stdout"
 	stderrFile := tmpDir + "/stderr"
@@ -147,9 +139,7 @@ func (s *SystemUtilsSuite) TestInternalCommandExecutionStdoutTooBigForReturn() {
 			expectedLength: GenericMaxLengthInBytes},
 	}
 	cmd := "bash"
-	tmpDir, err := ioutil.TempDir("", "test-bacalhau-command-execution-")
-	defer os.RemoveAll(tmpDir)
-	require.NoError(s.T(), err, "Could not create temp dir")
+	tmpDir := s.T().TempDir()
 
 	for maxSizeCaseName, maxSizeCase := range maxSizeCases {
 		for outputPipeTestName, stdOutstdErrCase := range stdOutstdErrCases {

--- a/pkg/test/computenode/runjob_test.go
+++ b/pkg/test/computenode/runjob_test.go
@@ -5,7 +5,6 @@ package computenode
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -54,11 +53,7 @@ func (s *ComputeNodeRunJobSuite) TearDownAllSuite() {
 func (s *ComputeNodeRunJobSuite) TestRunJob() {
 	ctx := context.Background()
 
-	tmpOutputDir, err := ioutil.TempDir("", "bacalhau-test-run-job")
-	if err != nil {
-		s.T().Fatal(err)
-	}
-	defer os.RemoveAll(tmpOutputDir)
+	tmpOutputDir := s.T().TempDir()
 
 	EXAMPLE_TEXT := "hello"
 	stack := testutils.NewDevStack(ctx, s.T(), computenode.NewDefaultComputeNodeConfig())

--- a/pkg/test/computenode/utils.go
+++ b/pkg/test/computenode/utils.go
@@ -3,7 +3,6 @@ package computenode
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -70,8 +69,7 @@ func RunJobGetStdout(
 	computeNode *computenode.ComputeNode,
 	spec model.Spec,
 ) string {
-	result, err := ioutil.TempDir("", "bacalhau-RunJobGetStdout")
-	require.NoError(t, err)
+	result := t.TempDir()
 
 	j := &model.Job{
 		ID:   "test",

--- a/pkg/test/devstack/combodriver_test.go
+++ b/pkg/test/devstack/combodriver_test.go
@@ -5,7 +5,6 @@ package devstack
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -64,14 +63,13 @@ func (suite *ComboDriverSuite) TestComboDriver() {
 		defer cm.Cleanup()
 
 		cid := "apples"
-		basePath, err := os.MkdirTemp("", "combo-driver-test")
-		require.NoError(suite.T(), err)
+		basePath := suite.T().TempDir()
 		filePath := filepath.Join(basePath, "file.txt")
 		if unsealedMode {
 			os.MkdirAll(filepath.Join(basePath, cid), os.ModePerm)
 			filePath = filepath.Join(basePath, cid, "file.txt")
 		}
-		err = os.WriteFile(
+		err := os.WriteFile(
 			filePath,
 			[]byte(fmt.Sprintf(exampleText)),
 			0644,
@@ -164,8 +162,7 @@ func (suite *ComboDriverSuite) TestComboDriver() {
 		node, err := stack.GetNode(ctx, shard.NodeID)
 		require.NoError(suite.T(), err)
 
-		outputDir, err := ioutil.TempDir("", "bacalhau-ipfs-devstack-test")
-		require.NoError(suite.T(), err)
+		outputDir := suite.T().TempDir()
 		require.NotEmpty(suite.T(), shard.PublishedResult.CID)
 
 		outputPath := filepath.Join(outputDir, shard.PublishedResult.CID)

--- a/pkg/test/devstack/devstack_test.go
+++ b/pkg/test/devstack/devstack_test.go
@@ -4,7 +4,6 @@ package devstack
 
 import (
 	"context"
-	"io/ioutil"
 	"path/filepath"
 	"testing"
 
@@ -112,8 +111,7 @@ func devStackDockerStorageTest(
 		node, err := stack.GetNode(ctx, shard.NodeID)
 		require.NoError(t, err)
 
-		outputDir, err := ioutil.TempDir("", "bacalhau-ipfs-devstack-test")
-		require.NoError(t, err)
+		outputDir := t.TempDir()
 		require.NotEmpty(t, shard.PublishedResult.CID)
 
 		outputPath := filepath.Join(outputDir, shard.PublishedResult.CID)

--- a/pkg/test/devstack/errorlogs_test.go
+++ b/pkg/test/devstack/errorlogs_test.go
@@ -3,7 +3,6 @@ package devstack
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -113,8 +112,7 @@ func (suite *DevstackErrorLogsSuite) TestErrorContainer() {
 
 	state := shards[0]
 
-	outputDir, err := ioutil.TempDir("", "bacalhau-ipfs-devstack-test")
-	require.NoError(suite.T(), err)
+	outputDir := suite.T().TempDir()
 
 	node, err := stack.GetNode(ctx, nodeIDs[0])
 	require.NoError(suite.T(), err)

--- a/pkg/test/devstack/min_bids_test.go
+++ b/pkg/test/devstack/min_bids_test.go
@@ -75,7 +75,7 @@ func (suite *MinBidsSuite) TestMinBids() {
 			computenode.NewDefaultComputeNodeConfig(),
 		)
 
-		dirPath, err := prepareFolderWithFiles(testCase.shards)
+		dirPath, err := prepareFolderWithFiles(suite.T(), testCase.shards)
 		require.NoError(suite.T(), err)
 
 		directoryCid, err := devstack.AddFileToNodes(ctx, dirPath, devstack.ToIPFSClients(stack.Nodes[:testCase.nodes])...)

--- a/pkg/test/devstack/multiple_cid_test.go
+++ b/pkg/test/devstack/multiple_cid_test.go
@@ -5,7 +5,6 @@ package devstack
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -141,8 +140,7 @@ func (s *MultipleCIDSuite) TestMultipleCIDs() {
 	node, err := stack.GetNode(ctx, shard.NodeID)
 	require.NoError(s.T(), err)
 
-	outputDir, err := ioutil.TempDir("", "bacalhau-ipfs-multiple-cid-test")
-	require.NoError(s.T(), err)
+	outputDir := s.T().TempDir()
 	require.NotEmpty(s.T(), shard.PublishedResult.CID)
 
 	outputPath := filepath.Join(outputDir, shard.PublishedResult.CID)
@@ -243,8 +241,7 @@ func runURLTest(
 	)
 	require.NoError(t, err)
 
-	outputDir, err := ioutil.TempDir("", "bacalhau-ipfs-multiple-url-test")
-	require.NoError(t, err)
+	outputDir := t.TempDir()
 
 	shards, err := resolver.GetShards(ctx, submittedJob.ID)
 	require.NoError(t, err)
@@ -482,8 +479,7 @@ func (s *MultipleCIDSuite) TestIPFSURLCombo() {
 	node, err := stack.GetNode(ctx, shard.NodeID)
 	require.NoError(s.T(), err)
 
-	outputDir, err := ioutil.TempDir("", "bacalhau-ipfs-multiple-url-test")
-	require.NoError(s.T(), err)
+	outputDir := s.T().TempDir()
 	require.NotEmpty(s.T(), shard.PublishedResult.CID)
 
 	outputPath := filepath.Join(outputDir, shard.PublishedResult.CID)

--- a/pkg/test/devstack/publish_on_error_test.go
+++ b/pkg/test/devstack/publish_on_error_test.go
@@ -5,7 +5,6 @@ package devstack
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -108,8 +107,7 @@ func (s *PublishOnErrorSuite) TestPublishOnError() {
 	node, err := stack.GetNode(ctx, shard.NodeID)
 	require.NoError(s.T(), err)
 
-	outputDir, err := ioutil.TempDir("", "bacalhau-ipfs-publish-on-error-test")
-	require.NoError(s.T(), err)
+	outputDir := s.T().TempDir()
 	require.NotEmpty(s.T(), shard.PublishedResult.CID)
 
 	outputPath := filepath.Join(outputDir, shard.PublishedResult.CID)

--- a/pkg/test/devstack/pythonwasm_test.go
+++ b/pkg/test/devstack/pythonwasm_test.go
@@ -77,12 +77,7 @@ func (s *DevstackPythonWASMSuite) TestPythonWasmVolumes() {
 	defer rootSpan.End()
 	cm.RegisterCallback(system.CleanupTraceProvider)
 
-	tmpDir, err := ioutil.TempDir("", "devstack_test")
-	require.NoError(s.T(), err)
-	defer func() {
-		err := os.RemoveAll(tmpDir)
-		require.NoError(s.T(), err)
-	}()
+	tmpDir := s.T().TempDir()
 
 	oldDir, err := os.Getwd()
 	require.NoError(s.T(), err)
@@ -138,8 +133,7 @@ func (s *DevstackPythonWASMSuite) TestPythonWasmVolumes() {
 
 	shard := shards[0]
 
-	outputDir, err := ioutil.TempDir("", "bacalhau-devstack-python-wasm-test")
-	require.NoError(s.T(), err)
+	outputDir := s.T().TempDir()
 	require.NotEmpty(s.T(), shard.PublishedResult.CID)
 
 	finalOutputPath := filepath.Join(outputDir, shard.PublishedResult.CID)
@@ -220,12 +214,7 @@ func (s *DevstackPythonWASMSuite) TestSimplePythonWasm() {
 	defer rootSpan.End()
 	cm.RegisterCallback(system.CleanupTraceProvider)
 
-	tmpDir, err := ioutil.TempDir("", "devstack_test")
-	require.NoError(s.T(), err)
-	defer func() {
-		err := os.RemoveAll(tmpDir)
-		require.NoError(s.T(), err)
-	}()
+	tmpDir := s.T().TempDir()
 
 	oldDir, err := os.Getwd()
 	require.NoError(s.T(), err)

--- a/pkg/test/devstack/sharding_test.go
+++ b/pkg/test/devstack/sharding_test.go
@@ -53,14 +53,11 @@ func (suite *ShardingSuite) TearDownSuite() {
 
 }
 
-func prepareFolderWithFoldersAndFiles(folderCount, fileCount int) (string, error) {
-	basePath, err := os.MkdirTemp("", "sharding-test")
-	if err != nil {
-		return "", err
-	}
+func prepareFolderWithFoldersAndFiles(t *testing.T, folderCount, fileCount int) (string, error) {
+	basePath := t.TempDir()
 	for i := 0; i < folderCount; i++ {
 		subfolderPath := fmt.Sprintf("%s/folder%d", basePath, i)
-		err = os.Mkdir(subfolderPath, 0700)
+		err := os.Mkdir(subfolderPath, 0700)
 		if err != nil {
 			return "", err
 		}
@@ -78,13 +75,10 @@ func prepareFolderWithFoldersAndFiles(folderCount, fileCount int) (string, error
 	return basePath, nil
 }
 
-func prepareFolderWithFiles(fileCount int) (string, error) {
-	basePath, err := os.MkdirTemp("", "sharding-test")
-	if err != nil {
-		return "", err
-	}
+func prepareFolderWithFiles(t *testing.T, fileCount int) (string, error) {
+	basePath := t.TempDir()
 	for i := 0; i < fileCount; i++ {
-		err = os.WriteFile(
+		err := os.WriteFile(
 			fmt.Sprintf("%s/%d.txt", basePath, i),
 			[]byte(fmt.Sprintf("hello %d", i)),
 			0644,
@@ -117,7 +111,7 @@ func (suite *ShardingSuite) TestExplodeCid() {
 	node := stack.IPFSClients[0]
 
 	// make 10 folders each with 10 files
-	dirPath, err := prepareFolderWithFoldersAndFiles(folderCount, fileCount)
+	dirPath, err := prepareFolderWithFoldersAndFiles(suite.T(), folderCount, fileCount)
 	require.NoError(suite.T(), err)
 
 	directoryCid, err := devstack.AddFileToNodes(ctx, dirPath, stack.IPFSClients[:nodeCount]...)
@@ -185,7 +179,7 @@ func (suite *ShardingSuite) TestEndToEnd() {
 	defer rootSpan.End()
 	cm.RegisterCallback(system.CleanupTraceProvider)
 
-	dirPath, err := prepareFolderWithFiles(totalFiles)
+	dirPath, err := prepareFolderWithFiles(suite.T(), totalFiles)
 	require.NoError(suite.T(), err)
 
 	directoryCid, err := devstack.AddFileToNodes(ctx, dirPath, devstack.ToIPFSClients(stack.Nodes[:nodeCount])...)
@@ -257,8 +251,7 @@ func (suite *ShardingSuite) TestEndToEnd() {
 	require.NoError(suite.T(), err)
 	require.True(suite.T(), len(jobResults) > 0, "there should be > 0 results")
 
-	downloadFolder, err := ioutil.TempDir("", "bacalhau-shard-test")
-	require.NoError(suite.T(), err)
+	downloadFolder := suite.T().TempDir()
 
 	swarmAddresses, err := stack.Nodes[0].IPFSClient.SwarmAddresses(ctx)
 	require.NoError(suite.T(), err)
@@ -333,7 +326,7 @@ func (suite *ShardingSuite) TestNoShards() {
 	defer rootSpan.End()
 	cm.RegisterCallback(system.CleanupTraceProvider)
 
-	dirPath, err := prepareFolderWithFiles(0)
+	dirPath, err := prepareFolderWithFiles(suite.T(), 0)
 	require.NoError(suite.T(), err)
 
 	directoryCid, err := devstack.AddFileToNodes(ctx, dirPath, devstack.ToIPFSClients(stack.Nodes[:nodeCount])...)
@@ -402,10 +395,9 @@ func (suite *ShardingSuite) TestExplodeVideos() {
 		"Prominent Late Gothic styled architecture.mp4",
 	}
 
-	dirPath, err := os.MkdirTemp("", "sharding-test")
-	require.NoError(suite.T(), err)
+	dirPath := suite.T().TempDir()
 	for _, video := range videos {
-		err = os.WriteFile(
+		err := os.WriteFile(
 			filepath.Join(dirPath, video),
 			[]byte(fmt.Sprintf("hello %s", video)),
 			0644,

--- a/pkg/test/executor/executor_test.go
+++ b/pkg/test/executor/executor_test.go
@@ -4,7 +4,6 @@ package executor
 
 import (
 	"context"
-	"io/ioutil"
 	"strings"
 	"testing"
 	"time"
@@ -94,8 +93,7 @@ func runTestCase(
 		Index: 0,
 	}
 
-	resultsDirectory, err := ioutil.TempDir("", "bacalhau-executorStorageTest")
-	require.NoError(t, err)
+	resultsDirectory := t.TempDir()
 
 	runnerOutput, err := executor.RunShard(ctx, shard, resultsDirectory)
 	require.NoError(t, err)

--- a/pkg/test/ipfs/ipfs_host_storage_test.go
+++ b/pkg/test/ipfs/ipfs_host_storage_test.go
@@ -3,7 +3,6 @@ package ipfs
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -141,11 +140,10 @@ func runFolderTest(t *testing.T, engine model.StorageSourceType, getStorageDrive
 	defer rootSpan.End()
 	cm.RegisterCallback(system.CleanupTraceProvider)
 
-	dir, err := ioutil.TempDir("", "bacalhau-ipfs-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	EXAMPLE_TEXT := `hello world`
-	err = os.WriteFile(fmt.Sprintf("%s/file.txt", dir), []byte(EXAMPLE_TEXT), 0644)
+	err := os.WriteFile(fmt.Sprintf("%s/file.txt", dir), []byte(EXAMPLE_TEXT), 0644)
 	require.NoError(t, err)
 
 	// add this file to the server

--- a/pkg/util/touchfs/fs_test.go
+++ b/pkg/util/touchfs/fs_test.go
@@ -22,8 +22,7 @@ func TestTouchFSSuite(t *testing.T) {
 }
 
 func (suite *touchFsSuite) SetupTest() {
-	testDir, err := os.MkdirTemp("", "*")
-	require.NoError(suite.T(), err)
+	testDir := suite.T().TempDir()
 	suite.testDir = testDir
 
 	file, err := os.Create(filepath.Join(testDir, "test.txt"))


### PR DESCRIPTION
Use `t.TempDir` to create temporary directories to ensure the contents is automatically cleaned up. By removing these unneeded calls, it makes identifying the problem in #937 easier.