### PR TITLE
Connect logging when running tests with the tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,7 @@ jobs:
                   export GOBIN=${HOME}/bin
                   export PATH=$GOBIN:$PATH
                   go install gotest.tools/gotestsum@latest
-                  make test-and-report
+                  LOG_LEVEL=debug make test-and-report
                 no_output_timeout: 20m
 
       - when:

--- a/cmd/bacalhau/create_test.go
+++ b/cmd/bacalhau/create_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/publicapi"
 	"github.com/filecoin-project/bacalhau/pkg/system"
 	"github.com/spf13/cobra"
@@ -35,6 +36,7 @@ func (s *CreateSuite) SetupSuite() {
 
 // before each test
 func (s *CreateSuite) SetupTest() {
+	logger.ConfigureTestLogging(s.T())
 	require.NoError(s.T(), system.InitConfigForTesting())
 	s.rootCmd = RootCmd
 }

--- a/cmd/bacalhau/describe_test.go
+++ b/cmd/bacalhau/describe_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/filecoin-project/bacalhau/pkg/bacerrors"
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/filecoin-project/bacalhau/pkg/publicapi"
 	"github.com/filecoin-project/bacalhau/pkg/system"
@@ -34,6 +35,7 @@ func (suite *DescribeSuite) SetupAllSuite() {
 
 // Before each test
 func (suite *DescribeSuite) SetupTest() {
+	logger.ConfigureTestLogging(suite.T())
 	require.NoError(suite.T(), system.InitConfigForTesting())
 	suite.rootCmd = RootCmd
 }

--- a/cmd/bacalhau/docker_run_test.go
+++ b/cmd/bacalhau/docker_run_test.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 
 	"github.com/filecoin-project/bacalhau/pkg/devstack"
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/google/uuid"
 	"sigs.k8s.io/yaml"
@@ -57,6 +58,7 @@ func (s *DockerRunSuite) SetupSuite() {
 
 // Before each test
 func (s *DockerRunSuite) SetupTest() {
+	logger.ConfigureTestLogging(s.T())
 	require.NoError(s.T(), system.InitConfigForTesting())
 	s.rootCmd = RootCmd
 }

--- a/cmd/bacalhau/get_test.go
+++ b/cmd/bacalhau/get_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/publicapi"
 	"github.com/filecoin-project/bacalhau/pkg/storage/util"
 	"github.com/filecoin-project/bacalhau/pkg/system"
@@ -40,6 +41,7 @@ func (suite *GetSuite) SetupAllSuite() {
 
 // Before each test
 func (suite *GetSuite) SetupTest() {
+	logger.ConfigureTestLogging(suite.T())
 	require.NoError(suite.T(), system.InitConfigForTesting())
 	suite.rootCmd = RootCmd
 }

--- a/cmd/bacalhau/list_test.go
+++ b/cmd/bacalhau/list_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/filecoin-project/bacalhau/pkg/publicapi"
 	"github.com/filecoin-project/bacalhau/pkg/system"
@@ -42,6 +43,7 @@ func (suite *ListSuite) SetupAllSuite() {
 // Before each test
 func (suite *ListSuite) SetupTest() {
 	suite.rootCmd = RootCmd
+	logger.ConfigureTestLogging(suite.T())
 }
 
 func (suite *ListSuite) TearDownTest() {

--- a/cmd/bacalhau/serve_test.go
+++ b/cmd/bacalhau/serve_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/system"
 	"github.com/filecoin-project/bacalhau/pkg/types"
 	"github.com/phayes/freeport"
@@ -39,6 +40,7 @@ func (suite *ServeSuite) SetupSuite() {
 
 // Before each test
 func (suite *ServeSuite) SetupTest() {
+	logger.ConfigureTestLogging(suite.T())
 	require.NoError(suite.T(), system.InitConfigForTesting())
 	suite.rootCmd = RootCmd
 }

--- a/cmd/bacalhau/utils_test.go
+++ b/cmd/bacalhau/utils_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/filecoin-project/bacalhau/pkg/job"
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/filecoin-project/bacalhau/pkg/system"
 	"github.com/spf13/cobra"
@@ -32,6 +33,7 @@ func (s *UtilsSuite) SetupAllSuite() {
 // Before each test
 func (s *UtilsSuite) SetupTest() {
 	s.rootCmd = RootCmd
+	logger.ConfigureTestLogging(s.T())
 }
 
 func (s *UtilsSuite) TearDownTest() {

--- a/cmd/bacalhau/validate_test.go
+++ b/cmd/bacalhau/validate_test.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/publicapi"
 	"github.com/filecoin-project/bacalhau/pkg/system"
 	testutils "github.com/filecoin-project/bacalhau/pkg/test/utils"
@@ -30,6 +31,7 @@ func (s *ValidateSuite) SetupSuite() {
 
 // before each test
 func (s *ValidateSuite) SetupTest() {
+	logger.ConfigureTestLogging(s.T())
 	require.NoError(s.T(), system.InitConfigForTesting())
 	s.rootCmd = RootCmd
 }

--- a/cmd/bacalhau/version_test.go
+++ b/cmd/bacalhau/version_test.go
@@ -19,7 +19,7 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/filecoin-project/bacalhau/pkg/model"
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/publicapi"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
@@ -46,6 +46,7 @@ func (suite *VersionSuite) SetupAllSuite() {
 // Before each test
 func (suite *VersionSuite) SetupTest() {
 	suite.rootCmd = RootCmd
+	logger.ConfigureTestLogging(suite.T())
 }
 
 func (suite *VersionSuite) TearDownTest() {
@@ -69,11 +70,6 @@ func (suite *VersionSuite) Test_Version() {
 
 	require.Contains(suite.T(), string(out), "Client Version", "Client version not in output")
 	require.Contains(suite.T(), string(out), "Server Version", "Server version not in output")
-}
-
-type ThisVersions struct {
-	ClientVersion model.BuildVersionInfo `json:"clientVersion,omitempty"`
-	ServerVersion model.BuildVersionInfo `json:"serverVersion,omitempty"`
 }
 
 func (suite *VersionSuite) Test_VersionOutputs() {

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/kubectl v0.24.3
-	mvdan.cc/sh/v3 v3.5.1
 )
 
 require (
@@ -76,12 +75,14 @@ require (
 )
 
 require (
+	github.com/creack/pty v1.1.17 // indirect
 	github.com/filecoin-project/go-amt-ipld/v4 v4.0.0 // indirect
 	github.com/filecoin-project/go-bitfield v0.2.4 // indirect
 	github.com/filecoin-project/go-hamt-ipld/v3 v3.1.0 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0 // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
+	github.com/rogpeppe/go-internal v1.8.1 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	go.opencensus.io v0.23.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -225,6 +225,7 @@ github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7Do
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.17 h1:QeVUsEDNrLBW4tMgZHvxy18sKtr6VI492kBhUfhDJNI=
+github.com/creack/pty v1.1.17/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/cskr/pubsub v1.0.2 h1:vlOzMhl6PFn60gRlTQQsIfVwaPB/B/8MziK8FhEPt/0=
 github.com/cskr/pubsub v1.0.2/go.mod h1:/8MzYXk/NJAz782G8RPkFzXTZVu63VotefPnR9TIRis=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -1571,6 +1572,7 @@ github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5/go.mod h1:iIss55rK
 github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0jef7pBehbT1qWhCMrIgbYNnFAZCqQ5LRc=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pierrec/lz4 v2.6.1+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
+github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -1649,6 +1651,7 @@ github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6L
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
+github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/rs/cors v1.7.0 h1:+88SsELBHx5r+hZ8TCkggzSstaWNbDvThkVK8H6f9ik=
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
@@ -2586,8 +2589,6 @@ modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.1.1/go.mod h1:mZW8CKdRPY1v87qxC/wUdX5O1qDzXMP5TH3wjfpga6E=
 modernc.org/strutil v1.1.0/go.mod h1:lstksw84oURvj9y3tn8lGvRxyRC1S2+g5uuIzNfIOBs=
 modernc.org/xc v1.0.0/go.mod h1:mRNCo0bvLjGhHO9WsyuKVU4q0ceiDDDoEeWDJHrNx8I=
-mvdan.cc/sh/v3 v3.5.1 h1:hmP3UOw4f+EYexsJjFxvU38+kn+V/s2CclXHanIBkmQ=
-mvdan.cc/sh/v3 v3.5.1/go.mod h1:1JcoyAKm1lZw/2bZje/iYKWicU/KMd0rsyJeKHnsK4E=
 pgregory.net/rapid v0.4.7 h1:MTNRktPuv5FNqOO151TM9mDTa+XHcX6ypYeISDVD14g=
 pgregory.net/rapid v0.4.7/go.mod h1:UYpPVyjFHzYBGHIxLFoupi8vwk6rXNzRY9OMvVxFIOU=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=

--- a/pkg/capacitymanager/utils_test.go
+++ b/pkg/capacitymanager/utils_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/c2h5oh/datasize"
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/pbnjay/memory"
 	"github.com/stretchr/testify/require"
@@ -32,6 +33,7 @@ func (suite *ResourceUsageUtilsSuite) SetupAllSuite() {
 
 // Before each test
 func (suite *ResourceUsageUtilsSuite) SetupTest() {
+	logger.ConfigureTestLogging(suite.T())
 }
 
 func (suite *ResourceUsageUtilsSuite) TearDownTest() {

--- a/pkg/eventhandler/chained_handlers_test.go
+++ b/pkg/eventhandler/chained_handlers_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/google/uuid"
 
 	"github.com/filecoin-project/bacalhau/pkg/eventhandler/mock_eventhandler"
@@ -49,6 +50,7 @@ func (suite *jobEventHandlerSuite) SetupTest() {
 		ClientID:     "clientX",
 		Status:       "this is a test event",
 	}
+	logger.ConfigureTestLogging(suite.T())
 }
 
 func (suite *jobEventHandlerSuite) TearDownTest() {

--- a/pkg/ipfs/downloader_test.go
+++ b/pkg/ipfs/downloader_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/filecoin-project/bacalhau/pkg/system"
 	"github.com/stretchr/testify/require"
@@ -34,6 +35,7 @@ type DownloaderSuite struct {
 // Before each test
 func (ds *DownloaderSuite) SetupTest() {
 	ds.cm = *system.NewCleanupManager()
+	logger.ConfigureTestLogging(ds.T())
 	require.NoError(ds.T(), system.InitConfigForTesting())
 
 	node, err := NewLocalNode(context.Background(), &ds.cm, nil)

--- a/pkg/ipfs/node_test.go
+++ b/pkg/ipfs/node_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/system"
 	icorepath "github.com/ipfs/interface-go-ipfs-core/path"
-
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -31,6 +31,7 @@ func (suite *NodeSuite) SetupAllSuite() {
 
 // Before each test
 func (suite *NodeSuite) SetupTest() {
+	logger.ConfigureTestLogging(suite.T())
 	require.NoError(suite.T(), system.InitConfigForTesting())
 }
 

--- a/pkg/job/factory_test.go
+++ b/pkg/job/factory_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -29,6 +30,7 @@ func (suite *JobFactorySuite) SetupAllSuite() {
 
 // Before each test
 func (suite *JobFactorySuite) SetupTest() {
+	logger.ConfigureTestLogging(suite.T())
 }
 
 func (suite *JobFactorySuite) TearDownTest() {

--- a/pkg/job/sharding_test.go
+++ b/pkg/job/sharding_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -30,6 +31,7 @@ func (suite *JobShardingSuite) SetupAllSuite() {
 
 // Before each test
 func (suite *JobShardingSuite) SetupTest() {
+	logger.ConfigureTestLogging(suite.T())
 }
 
 func (suite *JobShardingSuite) TearDownTest() {

--- a/pkg/job/util_test.go
+++ b/pkg/job/util_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -29,6 +30,7 @@ func (s *JobUtilSuite) SetupAllSuite() {
 
 // Before each test
 func (s *JobUtilSuite) SetupTest() {
+	logger.ConfigureTestLogging(s.T())
 }
 
 func (s *JobUtilSuite) TearDownTest() {

--- a/pkg/publicapi/client_test.go
+++ b/pkg/publicapi/client_test.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"testing"
 
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/filecoin-project/bacalhau/pkg/system"
 	"github.com/stretchr/testify/require"
 )
 
 func TestGet(t *testing.T) {
+	logger.ConfigureTestLogging(t)
+
 	c, cm := SetupRequesterNodeForTests(t)
 	defer cm.Cleanup()
 

--- a/pkg/publicapi/server_test.go
+++ b/pkg/publicapi/server_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/types"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -33,6 +34,7 @@ func (suite *ServerSuite) SetupAllSuite() {
 
 // Before each test
 func (suite *ServerSuite) SetupTest() {
+	logger.ConfigureTestLogging(suite.T())
 }
 
 func (suite *ServerSuite) TearDownTest() {

--- a/pkg/publicapi/util.go
+++ b/pkg/publicapi/util.go
@@ -9,9 +9,8 @@ import (
 	"time"
 
 	"github.com/filecoin-project/bacalhau/pkg/eventhandler"
-	"github.com/filecoin-project/bacalhau/pkg/localdb"
-
 	"github.com/filecoin-project/bacalhau/pkg/executor/util"
+	"github.com/filecoin-project/bacalhau/pkg/localdb"
 	"github.com/filecoin-project/bacalhau/pkg/localdb/inmemory"
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	publisher_utils "github.com/filecoin-project/bacalhau/pkg/publisher/util"

--- a/pkg/publisher/filecoin_lotus/publisher_test.go
+++ b/pkg/publisher/filecoin_lotus/publisher_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/filecoin-project/bacalhau/pkg/job"
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 	_ "github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/filecoin-project/bacalhau/pkg/publisher/filecoin_lotus/api"
@@ -48,6 +49,7 @@ func TestFilecoinPublisherSuite(t *testing.T) {
 }
 
 func (s *FilecoinPublisherSuite) SetupTest() {
+	logger.ConfigureTestLogging(s.T())
 	require.NoError(s.T(), system.InitConfigForTesting())
 
 	cm := system.NewCleanupManager()

--- a/pkg/storage/filecoin_unsealed/storage_test.go
+++ b/pkg/storage/filecoin_unsealed/storage_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 	_ "github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/filecoin-project/bacalhau/pkg/system"
@@ -48,6 +49,7 @@ func (suite *FilecoinUnsealedSuite) SetupAllSuite() {
 // Before each test
 func (suite *FilecoinUnsealedSuite) SetupTest() {
 	var setupErr error
+	logger.ConfigureTestLogging(suite.T())
 	cm = system.NewCleanupManager()
 	ctx = context.Background()
 	tempDir, setupErr = ioutil.TempDir("", "bacalhau-filecoin-unsealed-test")

--- a/pkg/storage/url/urldownload/storage_test.go
+++ b/pkg/storage/url/urldownload/storage_test.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/filecoin-project/bacalhau/pkg/system"
 	"github.com/spf13/cobra"
@@ -36,6 +37,7 @@ func (s *StorageSuite) SetupSuite() {
 
 // Before each test
 func (s *StorageSuite) SetupTest() {
+	logger.ConfigureTestLogging(s.T())
 	require.NoError(s.T(), system.InitConfigForTesting())
 }
 

--- a/pkg/system/cleanup_test.go
+++ b/pkg/system/cleanup_test.go
@@ -3,6 +3,7 @@ package system
 import (
 	"testing"
 
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -24,6 +25,7 @@ func (suite *SystemCleanupSuite) SetupAllSuite() {
 
 // Before each test
 func (suite *SystemCleanupSuite) SetupTest() {
+	logger.ConfigureTestLogging(suite.T())
 	require.NoError(suite.T(), InitConfigForTesting())
 }
 

--- a/pkg/system/config_test.go
+++ b/pkg/system/config_test.go
@@ -3,6 +3,7 @@ package system
 import (
 	"testing"
 
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -24,6 +25,7 @@ func (suite *SystemConfigSuite) SetupAllSuite() {
 
 // Before each test
 func (suite *SystemConfigSuite) SetupTest() {
+	logger.ConfigureTestLogging(suite.T())
 	require.NoError(suite.T(), InitConfigForTesting())
 }
 

--- a/pkg/system/context_test.go
+++ b/pkg/system/context_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -25,6 +26,7 @@ func (suite *SystemContextSuite) SetupAllSuite() {
 
 // Before each test
 func (suite *SystemContextSuite) SetupTest() {
+	logger.ConfigureTestLogging(suite.T())
 	require.NoError(suite.T(), InitConfigForTesting())
 }
 

--- a/pkg/system/script_checker.go
+++ b/pkg/system/script_checker.go
@@ -3,58 +3,7 @@ package system
 import (
 	"fmt"
 	"strings"
-
-	"github.com/rs/zerolog/log"
-	"mvdan.cc/sh/v3/syntax"
 )
-
-func CheckBashSyntax(cmds []string) error {
-	script := strings.NewReader(strings.Join(cmds, "\n"))
-	_, err := syntax.NewParser().Parse(script, "")
-
-	return err
-}
-
-// Function for parsing the entrypoint of a docker command.
-// Could be more useful in the future (just does globs without shell parsing for now)
-func SanitizeImageAndEntrypoint(jobEntrypoint []string) (returnMessages []string, errorIsFatal bool) {
-	errorIsFatal = false // Should and everywhere and set to fatal if yes
-	shells := strings.Split(`/bin/sh
-/bin/bash
-/usr/bin/bash
-/bin/rbash
-/usr/bin/rbash
-/usr/bin/sh
-/bin/dash
-/usr/bin/dash
-/usr/bin/tmux
-/usr/bin/screen
-/bin/zsh
-/usr/bin/zsh`, "/n")
-
-	containsGlob := false
-	for _, entrypointArg := range jobEntrypoint {
-		if strings.ContainsAny(entrypointArg, "*") {
-			containsGlob = true
-		}
-	}
-
-	if containsGlob {
-		for _, shell := range shells {
-			if strings.Index(strings.TrimSpace(jobEntrypoint[0]), shell) == 0 {
-				containsGlob = false
-				break
-			}
-		}
-		if containsGlob {
-			msg := "We could not help but notice your command contains a glob, but does not start with a shell. This is almost certainly not going to work. To use globs, you must start your command with a shell (e.g. /bin/bash <your command>)." //nolint:lll // error message, ok to be long
-			returnMessages = append(returnMessages, msg)
-			log.Warn().Msgf(msg)
-		}
-	}
-
-	return returnMessages, errorIsFatal
-}
 
 // Function for validating the workdir of a docker command.
 func ValidateWorkingDir(jobWorkingDir string) error {

--- a/pkg/system/script_checker_test.go
+++ b/pkg/system/script_checker_test.go
@@ -1,9 +1,9 @@
 package system
 
 import (
-	"fmt"
 	"testing"
 
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 	_ "github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -26,6 +26,7 @@ func (suite *SystemScriptCheckerSuite) SetupAllSuite() {
 
 // Before each test
 func (suite *SystemScriptCheckerSuite) SetupTest() {
+	logger.ConfigureTestLogging(suite.T())
 	require.NoError(suite.T(), InitConfigForTesting())
 }
 
@@ -34,35 +35,6 @@ func (suite *SystemScriptCheckerSuite) TearDownTest() {
 
 func (suite *SystemScriptCheckerSuite) TearDownAllSuite() {
 
-}
-func (suite *SystemScriptCheckerSuite) TestSubmitSyntaxErrors() {
-	tests := map[string]struct {
-		cmds                     []string
-		error_code               int
-		expected_output_contains string
-		expected_error_contains  string
-	}{
-		"good_bash":      {cmds: []string{GOOD_PYTHON}, error_code: 0, expected_output_contains: "", expected_error_contains: ""},
-		"missing_quote":  {cmds: []string{MISSING_QUOTE}, error_code: 1, expected_output_contains: "", expected_error_contains: "reached EOF without closing quote"},
-		"unescaped_find": {cmds: []string{UNMATCHED_BRACKET}, error_code: 1, expected_output_contains: "", expected_error_contains: "reached EOF without matching"},
-	}
-
-	for name, tc := range tests {
-		suite.T().Run(name, func(t *testing.T) {
-			// t.Parallel()
-
-			err := CheckBashSyntax(tc.cmds)
-
-			if tc.error_code != 0 {
-				error_content := err.Error()
-				require.Error(t, err, fmt.Sprintf("Error was expected, but none found: %s", tc.expected_error_contains))
-				require.Contains(t, error_content, tc.expected_error_contains, fmt.Sprintf("Error was expected to contain: %s", tc.expected_error_contains))
-			} else {
-				require.NoError(t, err, "Error in running command.")
-			}
-
-		})
-	}
 }
 
 func (suite *SystemScriptCheckerSuite) TestValidateWorkingDir() {
@@ -90,14 +62,3 @@ func (suite *SystemScriptCheckerSuite) TestValidateWorkingDir() {
 		})
 	}
 }
-
-// https://github.com/koalaman/shellcheck
-var (
-	GOOD_PYTHON       = `python3 -c "time.sleep(10); %s"`
-	MISSING_QUOTE     = `python3 -c "time.sleep(10); %s` // note that trailing quote is missing
-	UNMATCHED_BRACKET = `function f1() {
-    echo "Hello World"
-
-f1`  // Unmatched bracket across several lines
-	// TODO: Need to do a test for binary listed not on path (possible??)
-)

--- a/pkg/system/utils_test.go
+++ b/pkg/system/utils_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 	_ "github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
@@ -32,6 +33,7 @@ func (s *SystemUtilsSuite) SetupAllSuite() {
 
 // Before each test
 func (s *SystemUtilsSuite) SetupTest() {
+	logger.ConfigureTestLogging(s.T())
 	require.NoError(s.T(), InitConfigForTesting())
 }
 

--- a/pkg/test/computenode/jobselection_test.go
+++ b/pkg/test/computenode/jobselection_test.go
@@ -8,11 +8,11 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/filecoin-project/bacalhau/pkg/devstack"
-
 	"github.com/filecoin-project/bacalhau/pkg/computenode"
 	"github.com/filecoin-project/bacalhau/pkg/config"
+	"github.com/filecoin-project/bacalhau/pkg/devstack"
 	noop_executor "github.com/filecoin-project/bacalhau/pkg/executor/noop"
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 	_ "github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/system"
 	testutils "github.com/filecoin-project/bacalhau/pkg/test/utils"
@@ -37,6 +37,7 @@ func (suite *ComputeNodeJobSelectionSuite) SetupAllSuite() {
 
 // Before each test
 func (suite *ComputeNodeJobSelectionSuite) SetupTest() {
+	logger.ConfigureTestLogging(suite.T())
 	err := system.InitConfigForTesting()
 	require.NoError(suite.T(), err)
 }

--- a/pkg/test/computenode/resourcelimits_test.go
+++ b/pkg/test/computenode/resourcelimits_test.go
@@ -11,18 +11,18 @@ import (
 	"testing"
 	"time"
 
-	"github.com/filecoin-project/bacalhau/pkg/devstack"
-	"github.com/filecoin-project/bacalhau/pkg/transport/inprocess"
-
 	"github.com/davecgh/go-spew/spew"
 	"github.com/filecoin-project/bacalhau/pkg/capacitymanager"
 	"github.com/filecoin-project/bacalhau/pkg/computenode"
+	"github.com/filecoin-project/bacalhau/pkg/devstack"
 	noop_executor "github.com/filecoin-project/bacalhau/pkg/executor/noop"
 	"github.com/filecoin-project/bacalhau/pkg/job"
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 	_ "github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/filecoin-project/bacalhau/pkg/system"
 	testutils "github.com/filecoin-project/bacalhau/pkg/test/utils"
+	"github.com/filecoin-project/bacalhau/pkg/transport/inprocess"
 	sync "github.com/lukemarsden/golang-mutex-tracer"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -45,6 +45,7 @@ func (suite *ComputeNodeResourceLimitsSuite) SetupAllSuite() {
 
 // Before each test
 func (suite *ComputeNodeResourceLimitsSuite) SetupTest() {
+	logger.ConfigureTestLogging(suite.T())
 	err := system.InitConfigForTesting()
 	require.NoError(suite.T(), err)
 }

--- a/pkg/test/computenode/runjob_test.go
+++ b/pkg/test/computenode/runjob_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/filecoin-project/bacalhau/pkg/devstack"
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 
 	"github.com/filecoin-project/bacalhau/pkg/computenode"
 	_ "github.com/filecoin-project/bacalhau/pkg/logger"
@@ -38,6 +39,7 @@ func (s *ComputeNodeRunJobSuite) SetupAllSuite() {
 
 // Before each test
 func (s *ComputeNodeRunJobSuite) SetupTest() {
+	logger.ConfigureTestLogging(s.T())
 	err := system.InitConfigForTesting()
 	require.NoError(s.T(), err)
 }

--- a/pkg/test/devstack/combodriver_test.go
+++ b/pkg/test/devstack/combodriver_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/filecoin-project/bacalhau/pkg/computenode"
 	"github.com/filecoin-project/bacalhau/pkg/devstack"
 	"github.com/filecoin-project/bacalhau/pkg/job"
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 	_ "github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/filecoin-project/bacalhau/pkg/publicapi"
@@ -40,6 +41,7 @@ func (suite *ComboDriverSuite) SetupSuite() {
 
 // Before each test
 func (suite *ComboDriverSuite) SetupTest() {
+	logger.ConfigureTestLogging(suite.T())
 	err := system.InitConfigForTesting()
 	require.NoError(suite.T(), err)
 }

--- a/pkg/test/devstack/concurrency_test.go
+++ b/pkg/test/devstack/concurrency_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/filecoin-project/bacalhau/pkg/devstack"
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 
 	"github.com/filecoin-project/bacalhau/pkg/computenode"
 	"github.com/filecoin-project/bacalhau/pkg/job"
@@ -37,6 +38,7 @@ func (suite *DevstackConcurrencySuite) SetupSuite() {
 
 // Before each test
 func (suite *DevstackConcurrencySuite) SetupTest() {
+	logger.ConfigureTestLogging(suite.T())
 	err := system.InitConfigForTesting()
 	require.NoError(suite.T(), err)
 }

--- a/pkg/test/devstack/deterministic_verifier_test.go
+++ b/pkg/test/devstack/deterministic_verifier_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/stretchr/testify/require"
 
 	_ "github.com/filecoin-project/bacalhau/pkg/logger"
@@ -30,6 +31,7 @@ func (suite *DeterministicVerifierSuite) SetupSuite() {
 
 // Before each test
 func (suite *DeterministicVerifierSuite) SetupTest() {
+	logger.ConfigureTestLogging(suite.T())
 	err := system.InitConfigForTesting()
 	require.NoError(suite.T(), err)
 }

--- a/pkg/test/devstack/devstack_test.go
+++ b/pkg/test/devstack/devstack_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/filecoin-project/bacalhau/pkg/devstack"
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 
 	"github.com/filecoin-project/bacalhau/pkg/computenode"
 	"github.com/filecoin-project/bacalhau/pkg/job"
@@ -38,6 +39,7 @@ func (suite *DevStackSuite) SetupSuite() {
 
 // Before each test
 func (suite *DevStackSuite) SetupTest() {
+	logger.ConfigureTestLogging(suite.T())
 	err := system.InitConfigForTesting()
 	require.NoError(suite.T(), err)
 }

--- a/pkg/test/devstack/errorlogs_test.go
+++ b/pkg/test/devstack/errorlogs_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/filecoin-project/bacalhau/pkg/computenode"
 	"github.com/filecoin-project/bacalhau/pkg/job"
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 	_ "github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/filecoin-project/bacalhau/pkg/publicapi"
@@ -36,6 +37,7 @@ func (suite *DevstackErrorLogsSuite) SetupSuite() {
 
 // Before each test
 func (suite *DevstackErrorLogsSuite) SetupTest() {
+	logger.ConfigureTestLogging(suite.T())
 	err := system.InitConfigForTesting()
 	require.NoError(suite.T(), err)
 }

--- a/pkg/test/devstack/jobselection_test.go
+++ b/pkg/test/devstack/jobselection_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/filecoin-project/bacalhau/pkg/devstack"
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 
 	"github.com/filecoin-project/bacalhau/pkg/computenode"
 	"github.com/filecoin-project/bacalhau/pkg/job"
@@ -34,6 +35,7 @@ func (suite *DevstackJobSelectionSuite) SetupSuite() {
 
 // Before each test
 func (suite *DevstackJobSelectionSuite) SetupTest() {
+	logger.ConfigureTestLogging(suite.T())
 	err := system.InitConfigForTesting()
 	require.NoError(suite.T(), err)
 }

--- a/pkg/test/devstack/lotus_test.go
+++ b/pkg/test/devstack/lotus_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/filecoin-project/bacalhau/pkg/computenode"
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/system"
 	"github.com/filecoin-project/go-jsonrpc"
 	"github.com/multiformats/go-multiaddr"
@@ -30,6 +31,7 @@ func TestLotusNodeSuite(t *testing.T) {
 }
 
 func (s *LotusNodeSuite) SetupTest() {
+	logger.ConfigureTestLogging(s.T())
 	require.NoError(s.T(), system.InitConfigForTesting())
 }
 

--- a/pkg/test/devstack/min_bids_test.go
+++ b/pkg/test/devstack/min_bids_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/filecoin-project/bacalhau/pkg/devstack"
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 
 	"github.com/filecoin-project/bacalhau/pkg/computenode"
 	"github.com/filecoin-project/bacalhau/pkg/job"
@@ -36,6 +37,7 @@ func (suite *MinBidsSuite) SetupSuite() {
 
 // Before each test
 func (suite *MinBidsSuite) SetupTest() {
+	logger.ConfigureTestLogging(suite.T())
 	err := system.InitConfigForTesting()
 	require.NoError(suite.T(), err)
 }

--- a/pkg/test/devstack/multiple_cid_test.go
+++ b/pkg/test/devstack/multiple_cid_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/filecoin-project/bacalhau/pkg/computenode"
 	"github.com/filecoin-project/bacalhau/pkg/devstack"
 	"github.com/filecoin-project/bacalhau/pkg/job"
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 	_ "github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/filecoin-project/bacalhau/pkg/publicapi"
@@ -44,6 +45,7 @@ func (s *MultipleCIDSuite) SetupSuite() {
 
 // Before each test
 func (s *MultipleCIDSuite) SetupTest() {
+	logger.ConfigureTestLogging(s.T())
 	err := system.InitConfigForTesting()
 	require.NoError(s.T(), err)
 }

--- a/pkg/test/devstack/publish_on_error_test.go
+++ b/pkg/test/devstack/publish_on_error_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/filecoin-project/bacalhau/pkg/computenode"
 	"github.com/filecoin-project/bacalhau/pkg/job"
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 	_ "github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/filecoin-project/bacalhau/pkg/publicapi"
@@ -37,6 +38,7 @@ func (s *PublishOnErrorSuite) SetupSuite() {
 
 // Before each test
 func (s *PublishOnErrorSuite) SetupTest() {
+	logger.ConfigureTestLogging(s.T())
 	err := system.InitConfigForTesting()
 	require.NoError(s.T(), err)
 }

--- a/pkg/test/devstack/pythonwasm_test.go
+++ b/pkg/test/devstack/pythonwasm_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/filecoin-project/bacalhau/pkg/devstack"
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 
 	cmd "github.com/filecoin-project/bacalhau/cmd/bacalhau"
 	"github.com/filecoin-project/bacalhau/pkg/computenode"
@@ -42,6 +43,7 @@ func (s *DevstackPythonWASMSuite) SetupSuite() {
 
 // Before each test
 func (s *DevstackPythonWASMSuite) SetupTest() {
+	logger.ConfigureTestLogging(s.T())
 	err := system.InitConfigForTesting()
 	require.NoError(s.T(), err)
 }

--- a/pkg/test/devstack/sharding_test.go
+++ b/pkg/test/devstack/sharding_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/filecoin-project/bacalhau/pkg/computenode"
 	"github.com/filecoin-project/bacalhau/pkg/devstack"
 	"github.com/filecoin-project/bacalhau/pkg/ipfs"
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 	_ "github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/filecoin-project/bacalhau/pkg/publicapi"
@@ -42,6 +43,7 @@ func (suite *ShardingSuite) SetupSuite() {
 
 // Before each test
 func (suite *ShardingSuite) SetupTest() {
+	logger.ConfigureTestLogging(suite.T())
 	err := system.InitConfigForTesting()
 	require.NoError(suite.T(), err)
 }

--- a/pkg/test/devstack/submit_test.go
+++ b/pkg/test/devstack/submit_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/filecoin-project/bacalhau/pkg/computenode"
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 	_ "github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/filecoin-project/bacalhau/pkg/publicapi"
@@ -30,6 +31,7 @@ func (suite *DevstackSubmitSuite) SetupSuite() {
 
 // Before each test
 func (suite *DevstackSubmitSuite) SetupTest() {
+	logger.ConfigureTestLogging(suite.T())
 	err := system.InitConfigForTesting()
 	require.NoError(suite.T(), err)
 }

--- a/pkg/test/executor/executor_test.go
+++ b/pkg/test/executor/executor_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/filecoin-project/bacalhau/pkg/computenode"
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 	_ "github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/filecoin-project/bacalhau/pkg/system"
@@ -31,6 +32,7 @@ func TestExecutorTestSuite(t *testing.T) {
 
 // Before each test
 func (suite *ExecutorTestSuite) SetupTest() {
+	logger.ConfigureTestLogging(suite.T())
 	err := system.InitConfigForTesting()
 	require.NoError(suite.T(), err)
 }

--- a/pkg/test/ipfs/ipfs_host_storage_test.go
+++ b/pkg/test/ipfs/ipfs_host_storage_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/filecoin-project/bacalhau/pkg/devstack"
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 
 	_ "github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/model"
@@ -37,6 +38,7 @@ func (suite *IPFSHostStorageSuite) SetupAllSuite() {
 
 // Before each test
 func (suite *IPFSHostStorageSuite) SetupTest() {
+	logger.ConfigureTestLogging(suite.T())
 	err := system.InitConfigForTesting()
 	require.NoError(suite.T(), err)
 }

--- a/pkg/test/transport/transport_test.go
+++ b/pkg/test/transport/transport_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/filecoin-project/bacalhau/pkg/computenode"
 	"github.com/filecoin-project/bacalhau/pkg/devstack"
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/node"
 	"github.com/filecoin-project/bacalhau/pkg/requesternode"
 
@@ -38,6 +39,7 @@ func (suite *TransportSuite) SetupAllSuite() {
 
 // Before each test
 func (suite *TransportSuite) SetupTest() {
+	logger.ConfigureTestLogging(suite.T())
 	err := system.InitConfigForTesting()
 	require.NoError(suite.T(), err)
 }

--- a/pkg/transport/libp2p/libp2p_test.go
+++ b/pkg/transport/libp2p/libp2p_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 	_ "github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/filecoin-project/bacalhau/pkg/system"
@@ -32,7 +33,7 @@ func (suite *Libp2pTransportSuite) SetupAllSuite() {
 
 // Before each test
 func (suite *Libp2pTransportSuite) SetupTest() {
-
+	logger.ConfigureTestLogging(suite.T())
 }
 
 func (suite *Libp2pTransportSuite) TearDownTest() {

--- a/pkg/util/touchfs/fs_test.go
+++ b/pkg/util/touchfs/fs_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -32,6 +33,7 @@ func (suite *touchFsSuite) SetupTest() {
 	_, err = file.WriteString("hello")
 	require.NoError(suite.T(), err)
 	file.Close()
+	logger.ConfigureTestLogging(suite.T())
 }
 
 func (suite *touchFsSuite) TearDownTest() {


### PR DESCRIPTION
By using `zerolog.ConsoleTestWriter`, we can associate the system logging with a particular test. This makes CI failures easier to understand as we run without `-v`.

Fixes #955