### PR TITLE
Write all handled event to a JSON log file

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -108,8 +108,13 @@ func GetLibp2pTracerPath() string {
 	return filepath.Join(configPath, "bacalhau-libp2p-tracer.json")
 }
 
+func GetEventTracerPath() string {
+	configPath := GetConfigPath()
+	return filepath.Join(configPath, "bacalhau-event-tracer.json")
+}
+
 func GetConfigPath() string {
-	suffix := "/.bacalhau"
+	suffix := ".bacalhau"
 	env := os.Getenv("BACALHAU_PATH")
 	var d string
 	if env == "" {
@@ -118,10 +123,10 @@ func GetConfigPath() string {
 		if err != nil {
 			log.Fatal().Err(err)
 		}
-		d = dirname + suffix
+		d = filepath.Join(dirname, suffix)
 	} else {
 		// e.g. /data/.bacalhau
-		d = env + suffix
+		d = filepath.Join(env, suffix)
 	}
 	// create dir if not exists
 	if err := os.MkdirAll(d, util.OS_USER_RWX); err != nil {

--- a/pkg/eventhandler/tracer.go
+++ b/pkg/eventhandler/tracer.go
@@ -1,0 +1,82 @@
+package eventhandler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+
+	"github.com/filecoin-project/bacalhau/pkg/config"
+	"github.com/filecoin-project/bacalhau/pkg/model"
+	"github.com/rs/zerolog"
+)
+
+// Tracer is a JobEventHandler that will marshal the received event to a
+// file-based log.
+//
+// Note that we don't need any mutexes here because writing to an os.File is
+// thread-safe (see https://github.com/rs/zerolog/blob/master/writer.go#L33)
+type Tracer struct {
+	LogFile *os.File
+	Logger  zerolog.Logger
+}
+
+const eventTracerFilePerms fs.FileMode = 0644
+
+// Returns an eventhandler.Tracer that writes to config.GetEventTracerPath(), or
+// an error if the file can't be opened.
+func NewTracer() (*Tracer, error) {
+	return NewTracerToFile(config.GetEventTracerPath())
+}
+
+// Returns an eventhandler.Tracer that writes to the specified filename, or an
+// error if the file can't be opened.
+func NewTracerToFile(filename string) (*Tracer, error) {
+	file, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_APPEND, eventTracerFilePerms)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Tracer{
+		LogFile: file,
+		Logger:  zerolog.New(file).With().Timestamp().Logger(),
+	}, nil
+}
+
+// HandleLocalEvent implements LocalEventHandler
+func (t *Tracer) HandleLocalEvent(ctx context.Context, event model.JobLocalEvent) error {
+	trace(t.Logger, event)
+	return nil
+}
+
+// HandleJobEvent implements JobEventHandler
+func (t *Tracer) HandleJobEvent(ctx context.Context, event model.JobEvent) error {
+	trace(t.Logger, event)
+	return nil
+}
+
+func trace[Event any](log zerolog.Logger, event Event) {
+	log.Log().
+		Str("Type", fmt.Sprintf("%T", event)).
+		Func(func(e *zerolog.Event) {
+			// TODO: #828 Potential hotspot - json.Marshaling is expensive, and
+			// we do it for every event.
+			eventJSON, err := json.Marshal(event)
+			if err == nil {
+				e.RawJSON("Event", eventJSON)
+			} else {
+				e.AnErr("MarshalError", err)
+			}
+		}).Send()
+}
+
+func (t *Tracer) Shutdown() error {
+	err := t.LogFile.Close()
+	t.LogFile = nil
+	t.Logger = zerolog.Nop()
+	return err
+}
+
+var _ JobEventHandler = (*Tracer)(nil)
+var _ LocalEventHandler = (*Tracer)(nil)


### PR DESCRIPTION
In an effort to get metrics out of our system, we now write every event we see to a line delimited JSON log file, in the Bacalhau config directory. We now don't write the full event payload to the screen in prod, as it's written to this file instead.