### PR TITLE
add /debug api and periodically log compute node active jobs

### DIFF
--- a/pkg/computenode/models.go
+++ b/pkg/computenode/models.go
@@ -1,0 +1,10 @@
+package computenode
+
+import "github.com/filecoin-project/bacalhau/pkg/model"
+
+// A job that is holding compute capacity, which can be in bidding or running state.
+type ActiveJob struct {
+	ShardID              string                  `json:"ShardID"`
+	State                string                  `json:"State"`
+	CapacityRequirements model.ResourceUsageData `json:"CapacityRequirements"`
+}

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -163,6 +163,7 @@ func NewNode(
 		config.LocalDB,
 		config.Transport,
 		requesterNode,
+		computeNode,
 		publishers,
 		storageProviders,
 	)

--- a/pkg/publicapi/endpoints_debug.go
+++ b/pkg/publicapi/endpoints_debug.go
@@ -1,0 +1,30 @@
+package publicapi
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/filecoin-project/bacalhau/pkg/computenode"
+
+	"github.com/filecoin-project/bacalhau/pkg/system"
+)
+
+type debugResponse struct {
+	ComputeJobs []computenode.ActiveJob `json:"ComputeJobs"`
+}
+
+// Returns debug information on what the current node is doing.
+func (apiServer *APIServer) debug(res http.ResponseWriter, req *http.Request) {
+	ctx, span := system.GetSpanFromRequest(req, "apiServer/debug")
+	defer span.End()
+
+	responseObj := debugResponse{
+		ComputeJobs: apiServer.ComputeNode.GetActiveJobs(ctx),
+	}
+
+	res.WriteHeader(http.StatusOK)
+	err := json.NewEncoder(res).Encode(responseObj)
+	if err != nil {
+		http.Error(res, err.Error(), http.StatusInternalServerError)
+	}
+}

--- a/pkg/publicapi/util.go
+++ b/pkg/publicapi/util.go
@@ -8,6 +8,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/filecoin-project/bacalhau/pkg/computenode"
+	noop_executor "github.com/filecoin-project/bacalhau/pkg/executor/noop"
+
 	"github.com/filecoin-project/bacalhau/pkg/eventhandler"
 	"github.com/filecoin-project/bacalhau/pkg/executor/util"
 	"github.com/filecoin-project/bacalhau/pkg/localdb"
@@ -82,6 +85,11 @@ func SetupRequesterNodeForTestsWithPortAndConfig(t *testing.T, port int, config 
 	)
 	require.NoError(t, err)
 
+	noopExecutor, err := noop_executor.NewNoopExecutor()
+	require.NoError(t, err)
+
+	noopExecutorProvider := noop_executor.NewNoopExecutorProvider(noopExecutor)
+
 	// prepare event handlers
 	tracerContextProvider := system.NewTracerContextProvider(inprocessTransport.HostID())
 	noopContextProvider := system.NewNoopContextProvider()
@@ -100,6 +108,20 @@ func SetupRequesterNodeForTestsWithPortAndConfig(t *testing.T, port int, config 
 		noopVerifiers,
 		noopStorageProviders,
 		requesternode.RequesterNodeConfig{},
+	)
+	require.NoError(t, err)
+
+	computeNode, err := computenode.NewComputeNode(
+		ctx,
+		cm,
+		inprocessTransport.HostID(),
+		inmemoryDatastore,
+		localEventConsumer,
+		jobEventPublisher,
+		noopExecutorProvider,
+		noopVerifiers,
+		noopPublishers,
+		computenode.NewDefaultComputeNodeConfig(),
 	)
 	require.NoError(t, err)
 
@@ -123,7 +145,7 @@ func SetupRequesterNodeForTestsWithPortAndConfig(t *testing.T, port int, config 
 	host := "0.0.0.0"
 
 	s := NewServerWithConfig(ctx, host, port, inmemoryDatastore, inprocessTransport,
-		requesterNode, noopPublishers, noopStorageProviders, config)
+		requesterNode, computeNode, noopPublishers, noopStorageProviders, config)
 	cl := NewAPIClient(s.GetURI())
 	go func() {
 		require.NoError(t, s.ListenAndServe(ctx, cm))


### PR DESCRIPTION
```
curl http://0.0.0.0:20000/debug  | jq .
{
  "ComputeJobs": [
    {
      "ShardID": "b8b44518-6c4b-4afb-94d5-020d507c3238:0",
      "State": "Running",
      "CapacityRequirements": {
        "CPU": 0.1,
        "Memory": 104857600
      }
    },
    {
      "ShardID": "2997a5e1-4acb-4852-8e2c-4c6041d43fe4:0",
      "State": "Running",
      "CapacityRequirements": {
        "CPU": 0.1,
        "Memory": 104857600
      }
    }
  ]
}
```