### PR TITLE
check the file does not exist and don't try to overwrite a file with …

### DIFF
--- a/pkg/ipfs/downloader.go
+++ b/pkg/ipfs/downloader.go
@@ -364,6 +364,18 @@ func appendFile(sourcePath, targetPath string) error {
 }
 
 func copyFile(sourcePath, targetPath string) error {
+	_, err := os.Stat(targetPath)
+	if err != nil {
+		// we got some other type of error
+		if !os.IsNotExist(err) {
+			return err
+		}
+		// file doesn't exist
+	} else {
+		// this means there was no error and so the file exists
+		return nil
+	}
+
 	return cp.CopyFile(
 		sourcePath,
 		targetPath,


### PR DESCRIPTION
…a hardlink

This fixes a bug where when we try to overwrite a hardlink (e.g. of the first shards file) with a subsequent shards file called the same thing - we are basically overwriting a hardlink with another hardlink and then funky things happen

This PR fixes that by checking if the target file exists and if yes then doesn't try to copy anything