### PR TITLE
Fix canary to look in correct results folder

### DIFF
--- a/ops/aws/canary/lambda/pkg/scenarios/submitAndGet.go
+++ b/ops/aws/canary/lambda/pkg/scenarios/submitAndGet.go
@@ -40,11 +40,17 @@ func SubmitAndGet(ctx context.Context) error {
 		return fmt.Errorf("no results found")
 	}
 
+	outputDir, err := os.MkdirTemp(os.TempDir(), "submitAndGet")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(outputDir)
+
 	downloadSettings, err := getIPFSDownloadSettings()
 	if err != nil {
 		return err
 	}
-	defer os.RemoveAll(downloadSettings.OutputDir)
+	downloadSettings.OutputDir = outputDir
 
 	err = ipfs.DownloadJob(ctx, cm, submittedJob.Spec.Outputs, results, *downloadSettings)
 	if err != nil {


### PR DESCRIPTION
If the downloader doesn't get an output dir specified (which it does not by default) it will add an extra output folder unique to the job ID. This means if an output dir is unspecified there is not a reliable way to know what the output dir will be.

This commit changes the canary to manually create and specify an output dir, in which the results for the job should appear.