### PR TITLE
Update Go version to 1.19

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
   build:
     parallelism: 1
     environment:
-      GOVER: 1.18.3
+      GOVER: 1.19.3
       IPFS_VERSION: v0.12.2
       GOPROXY: https://proxy.golang.org
       GOOS: << parameters.target_os >>
@@ -62,12 +62,20 @@ jobs:
           steps:
             - run:
                 name: Install golang
-                environment:
-                  HOMEBREW_NO_AUTO_UPDATE: 1
                 command: |
                   export BREW_GO_VERSION=$(echo $GOVER | grep -Eo '^\d\.\d+')
-                  brew install go@$BREW_GO_VERSION
-                  echo "export PATH='/usr/local/opt/go@$BREW_GO_VERSION/bin:$PATH'" >> ~/.bash_profile
+                  brew install go
+                  echo "export PATH='/usr/local/opt/go/bin:$PATH'" >> ~/.bash_profile
+
+      - when:
+          condition:
+            equal: ["linux", << parameters.target_os >>]
+          steps:
+            - run:
+                name: Install golang
+                command: |
+                  sudo rm -fr /usr/local/go
+                  curl --silent --show-error --location --fail https://go.dev/dl/go$GOVER.linux-amd64.tar.gz | sudo tar --extract --gzip --file=- --directory=/usr/local
 
       - run:
           name: Install IPFS
@@ -84,6 +92,8 @@ jobs:
           name: Init tools
           command: |
             make init
+            go version
+            which go
 
       - run:
           name: Install Pre-commit
@@ -175,13 +185,21 @@ jobs:
   lint:
     parallelism: 1
     environment:
-      GOVER: 1.18.3
+      GOVER: 1.19.3
       GOLANGCILINT: v1.49.0
       GOPROXY: https://proxy.golang.org
     working_directory: ~/repo
     executor: linux
     steps:
       - checkout
+
+      - run:
+          name: Install golang
+          command: |
+            sudo rm -fr /usr/local/go
+            curl --silent --show-error --location --fail https://go.dev/dl/go$GOVER.linux-amd64.tar.gz | sudo tar --extract --gzip --file=- --directory=/usr/local
+            go version
+            which go
 
       - run:
           name: Install golangci-lint

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,7 +1,7 @@
 version: 0.1
 runtimes:
   enabled:
-    - go@1.18.3
+    - go@1.19.3
     - node@16.14.2
     - python@3.10.3
 actions:

--- a/docs/running_locally.md
+++ b/docs/running_locally.md
@@ -8,7 +8,7 @@ This is useful to kick the tires and/or developing on the codebase.  It's also t
 
  * x86_64 of ARM64 architecture
     * Ubuntu 20.0+ has most often been used for development and testing
- * Go >= 1.18
+ * Go >= 1.19
  * [Docker Engine](https://docs.docker.com/get-docker/)
  * (Optional) A build of the [latest Bacalhau release](https://github.com/filecoin-project/bacalhau/releases/)
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/filecoin-project/bacalhau
 
-go 1.18
+go 1.19
 
 require (
 	github.com/BTBurke/k8sresource v1.2.0

--- a/pkg/devstack/utils.go
+++ b/pkg/devstack/utils.go
@@ -3,7 +3,6 @@ package devstack
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -39,7 +38,7 @@ func AddFileToNodes(ctx context.Context, filePath string, clients ...*ipfs.Clien
 }
 
 func AddTextToNodes(ctx context.Context, fileContent []byte, clients ...*ipfs.Client) (string, error) {
-	testDir, err := ioutil.TempDir("", "bacalhau-test")
+	testDir, err := os.MkdirTemp("", "bacalhau-test")
 	if err != nil {
 		return "", err
 	}

--- a/pkg/executor/docker/executor.go
+++ b/pkg/executor/docker/executor.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime/debug"
@@ -57,7 +56,7 @@ func NewExecutor(
 		return nil, err
 	}
 
-	dir, err := ioutil.TempDir("", "bacalhau-docker-executor")
+	dir, err := os.MkdirTemp("", "bacalhau-docker-executor")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/publicapi/endpoints_submit.go
+++ b/pkg/publicapi/endpoints_submit.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"path/filepath"
 
 	"github.com/filecoin-project/bacalhau/pkg/bacerrors"
@@ -70,7 +70,7 @@ func (apiServer *APIServer) submit(res http.ResponseWriter, req *http.Request) {
 			return
 		}
 
-		tmpDir, err := ioutil.TempDir("", "bacalhau-pin-context-")
+		tmpDir, err := os.MkdirTemp("", "bacalhau-pin-context-")
 		if err != nil {
 			log.Ctx(ctx).Debug().Msgf("====> Create tmp dir error: %s", err)
 			errorResponse := bacerrors.ErrorToErrorResponse(err)

--- a/pkg/publisher/estuary/publisher.go
+++ b/pkg/publisher/estuary/publisher.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"net/url"
@@ -72,7 +71,7 @@ func (estuaryPublisher *EstuaryPublisher) PublishShardResult(
 	defer span.End()
 
 	log.Ctx(ctx).Info().Msgf("Publishing shard %v results to Estuary", shard)
-	tempDir, err := ioutil.TempDir("", "bacalhau-estuary-publisher")
+	tempDir, err := os.MkdirTemp("", "bacalhau-estuary-publisher")
 	if err != nil {
 		return model.StorageSpec{}, err
 	}

--- a/pkg/storage/ipfs_apicopy/storage.go
+++ b/pkg/storage/ipfs_apicopy/storage.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -34,7 +33,7 @@ func NewStorage(cm *system.CleanupManager, ipfsAPIAddress string) (*StorageProvi
 	}
 
 	// TODO: consolidate the various config inputs into one package otherwise they are scattered across the codebase
-	dir, err := ioutil.TempDir(config.GetStoragePath(), "bacalhau-ipfs")
+	dir, err := os.MkdirTemp(config.GetStoragePath(), "bacalhau-ipfs")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/ipfs_fusedocker/storage.go
+++ b/pkg/storage/ipfs_fusedocker/storage.go
@@ -3,7 +3,6 @@ package fusedocker
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -424,7 +423,7 @@ func cleanupStorageDriver(ctx context.Context, storageHandler *StorageProvider) 
 
 func createMountDir() (string, error) {
 	// create a temporary directory to mount the ipfs volume with fuse
-	dir, err := ioutil.TempDir("", "bacalhau-ipfs")
+	dir, err := os.MkdirTemp("", "bacalhau-ipfs")
 	if err != nil {
 		return "", err
 	}

--- a/pkg/storage/url/urldownload/storage.go
+++ b/pkg/storage/url/urldownload/storage.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -34,7 +33,7 @@ type StorageProvider struct {
 
 func NewStorage(cm *system.CleanupManager) (*StorageProvider, error) {
 	// TODO: consolidate the various config inputs into one package otherwise they are scattered across the codebase
-	dir, err := ioutil.TempDir(config.GetStoragePath(), "bacalhau-url")
+	dir, err := os.MkdirTemp(config.GetStoragePath(), "bacalhau-url")
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +80,7 @@ func (sp *StorageProvider) PrepareStorage(ctx context.Context, storageSpec model
 		return storage.StorageVolume{}, err
 	}
 
-	outputPath, err := ioutil.TempDir(sp.LocalDir, "*")
+	outputPath, err := os.MkdirTemp(sp.LocalDir, "*")
 	if err != nil {
 		return storage.StorageVolume{}, err
 	}

--- a/pkg/system/config.go
+++ b/pkg/system/config.go
@@ -9,7 +9,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -76,7 +75,7 @@ func InitConfig() error {
 // for testing config-related stuff and user ID message signing.
 // NOTE: this will overwrite the global config cache if called twice.
 func InitConfigForTesting() error {
-	configDir, err := ioutil.TempDir("", "bacalhau-test")
+	configDir, err := os.MkdirTemp("", "bacalhau-test")
 	if err != nil {
 		return err
 	}

--- a/pkg/verifier/results/results.go
+++ b/pkg/verifier/results/results.go
@@ -2,7 +2,6 @@ package results
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/filecoin-project/bacalhau/pkg/model"
@@ -16,7 +15,7 @@ type Results struct {
 }
 
 func NewResults() (*Results, error) {
-	dir, err := ioutil.TempDir("", "bacalhau-results")
+	dir, err := os.MkdirTemp("", "bacalhau-results")
 	if err != nil {
 		return nil, err
 	}

--- a/testground/manifest.toml
+++ b/testground/manifest.toml
@@ -10,7 +10,7 @@ runner = "local:exec"
 
 [builders."docker:go"]
 enabled                = true
-build_base_image       = "golang:1.18-buster"
+build_base_image       = "golang:1.19-buster"
 
 [builders."docker:generic".build_args]
 build_image = "golang:alpine"


### PR DESCRIPTION
Update to the latest version of Go to make it easier for people to start developing on Bacalhau and get access to newer features.

Fixes #940