### PR TITLE
Support volumes with slashes for WASM jobs

### DIFF
--- a/pkg/test/scenario/test_scenarios.go
+++ b/pkg/test/scenario/test_scenarios.go
@@ -214,7 +214,7 @@ func WasmCsvTransform() TestCase {
 		SetupStorage: singleFileSetupStorageWithFile(
 			ctx,
 			"../../../testdata/wasm/csv/inputs",
-			"inputs",
+			"/inputs",
 		),
 		SetupContext: singleFileSetupStorageWithFile(
 			ctx,


### PR DESCRIPTION
Previously volumes for WASM jobs were not allowed to contain any slashes. But it is common for Docker-style mounts to have a slash at the front, and our URL mounter always puts a slash at the front.

This commit changes the behaviour to allow slashes at the front, and to "deep mount" by default so that volumes can be given an arbitrary directory structure.

Resolves #993. Resolves #994.