### PR TITLE
Put WASM env vars in a consistent order

### DIFF
--- a/pkg/executor/wasm/executor.go
+++ b/pkg/executor/wasm/executor.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 
 	"github.com/filecoin-project/bacalhau/pkg/job"
 	"github.com/filecoin-project/bacalhau/pkg/model"
@@ -41,7 +42,7 @@ func NewExecutor(
 	return executor, nil
 }
 
-func (e *Executor) IsInstalled(ctx context.Context) (bool, error) {
+func (e *Executor) IsInstalled(context.Context) (bool, error) {
 	// WASM executor runs natively in Go and so is always available
 	return true, nil
 }
@@ -222,8 +223,9 @@ func (e *Executor) RunShard(
 		WithStderr(stderr).
 		WithArgs(args...).
 		WithFS(fs)
-	for key, value := range wasmSpec.EnvironmentVariables {
-		config = config.WithEnv(key, value)
+	for _, key := range keys(wasmSpec.EnvironmentVariables) {
+		// Make sure we add the environment variables in a consistent order
+		config = config.WithEnv(key, wasmSpec.EnvironmentVariables[key])
 	}
 	entryPoint := wasmSpec.EntryPoint
 
@@ -289,4 +291,13 @@ func (e *Executor) RunShard(
 		result.ErrorMsg = wasmErr.Error()
 	}
 	return result, wasmErr
+}
+
+func keys(m map[string]string) []string {
+	var ks []string
+	for k := range m {
+		ks = append(ks, k)
+	}
+	sort.Strings(ks)
+	return ks
 }

--- a/pkg/test/executor/executor_test.go
+++ b/pkg/test/executor/executor_test.go
@@ -41,7 +41,6 @@ const TEST_NODE_COUNT = 1
 func runTestCase(
 	t *testing.T,
 	testCase scenario.TestCase,
-	getStorageDriver scenario.IGetStorageDriver,
 ) {
 	ctx := context.Background()
 	spec := testCase.GetJobSpec()
@@ -110,7 +109,7 @@ func (suite *ExecutorTestSuite) TestScenarios() {
 		for _, storageDriverFactory := range scenario.StorageDriverFactories {
 			suite.Run(
 				strings.Join([]string{testCase.Name, storageDriverFactory.Name}, "-"),
-				func() { runTestCase(suite.T(), testCase, storageDriverFactory.DriverFactory) },
+				func() { runTestCase(suite.T(), testCase) },
 			)
 		}
 	}

--- a/pkg/test/scenario/test_scenarios.go
+++ b/pkg/test/scenario/test_scenarios.go
@@ -219,7 +219,7 @@ func WasmEnvVars() TestCase {
 		ResultsChecker: singleFileResultsChecker(
 			ctx,
 			"stdout",
-			"TEST=yes\nAWESOME=definitely\n",
+			"AWESOME=definitely\nTEST=yes\n",
 			ExpectedModeEquals,
 			3, //nolint:gomnd // magic number appropriate for test
 		),


### PR DESCRIPTION
Fix flaky test
(TestExecutorTestSuite/TestScenarios/wasm_env_vars-apiCopy) by putting the environment variables in a consistent order.

Fixes #1050