### PR TITLE
Add job timeout

### DIFF
--- a/cmd/bacalhau/devstack.go
+++ b/cmd/bacalhau/devstack.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strconv"
 
+	"github.com/filecoin-project/bacalhau/pkg/requesternode"
+
 	"github.com/filecoin-project/bacalhau/pkg/computenode"
 	"github.com/filecoin-project/bacalhau/pkg/config"
 	"github.com/filecoin-project/bacalhau/pkg/devstack"
@@ -124,9 +126,9 @@ var devstackCmd = &cobra.Command{
 		var stack *devstack.DevStack
 		var stackErr error
 		if IsNoop {
-			stack, stackErr = devstack.NewNoopDevStack(ctx, cm, *ODs, computeNodeConfig)
+			stack, stackErr = devstack.NewNoopDevStack(ctx, cm, *ODs, computeNodeConfig, requesternode.NewDefaultRequesterNodeConfig())
 		} else {
-			stack, stackErr = devstack.NewStandardDevStack(ctx, cm, *ODs, computeNodeConfig)
+			stack, stackErr = devstack.NewStandardDevStack(ctx, cm, *ODs, computeNodeConfig, requesternode.NewDefaultRequesterNodeConfig())
 		}
 		if stackErr != nil {
 			return stackErr

--- a/cmd/bacalhau/docker_run_test.go
+++ b/cmd/bacalhau/docker_run_test.go
@@ -15,6 +15,8 @@ import (
 	"path/filepath"
 	"strconv"
 
+	"github.com/filecoin-project/bacalhau/pkg/requesternode"
+
 	"github.com/filecoin-project/bacalhau/pkg/devstack"
 	"github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/model"
@@ -203,7 +205,10 @@ func (s *DockerRunSuite) TestRun_GenericSubmitWait() {
 	for i, tc := range tests {
 		s.Run(fmt.Sprintf("numberOfJobs:%v", tc.numberOfJobs), func() {
 			ctx := context.Background()
-			devstack, _ := devstack_tests.SetupTest(ctx, s.T(), 1, 0, false, computenode.ComputeNodeConfig{})
+			devstack, _ := devstack_tests.SetupTest(ctx, s.T(), 1, 0, false,
+				computenode.NewDefaultComputeNodeConfig(),
+				requesternode.NewDefaultRequesterNodeConfig(),
+			)
 
 			*ODR = *NewDockerRunOptions()
 
@@ -740,6 +745,7 @@ func (s *DockerRunSuite) TestRun_ExplodeVideos() {
 		0,
 		false,
 		computenode.NewDefaultComputeNodeConfig(),
+		requesternode.NewDefaultRequesterNodeConfig(),
 	)
 
 	*ODR = *NewDockerRunOptions()
@@ -962,7 +968,10 @@ func (s *DockerRunSuite) TestRun_BadExecutables() {
 
 	for name, tc := range tests {
 		s.Run(name, func() {
-			stack, _ := devstack_tests.SetupTest(ctx, s.T(), 1, 0, false, computenode.ComputeNodeConfig{})
+			stack, _ := devstack_tests.SetupTest(ctx, s.T(), 1, 0, false,
+				computenode.NewDefaultComputeNodeConfig(),
+				requesternode.NewDefaultRequesterNodeConfig(),
+			)
 			*ODR = *NewDockerRunOptions()
 
 			parsedBasedURI, _ := url.Parse(stack.Nodes[0].APIServer.GetURI())

--- a/cmd/bacalhau/get_test.go
+++ b/cmd/bacalhau/get_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/filecoin-project/bacalhau/pkg/requesternode"
+
 	"github.com/filecoin-project/bacalhau/pkg/computenode"
 	"github.com/filecoin-project/bacalhau/pkg/devstack"
 	"github.com/filecoin-project/bacalhau/pkg/ipfs"
@@ -159,7 +161,10 @@ func getDockerRunArgs(
 // all over the current directory
 func (s *GetSuite) TestDockerRunWriteToJobFolderAutoDownload() {
 	ctx := context.Background()
-	stack, _ := devstack_tests.SetupTest(ctx, s.T(), 1, 0, false, computenode.ComputeNodeConfig{})
+	stack, _ := devstack_tests.SetupTest(ctx, s.T(), 1, 0, false,
+		computenode.NewDefaultComputeNodeConfig(),
+		requesternode.NewDefaultRequesterNodeConfig(),
+	)
 	*ODR = *NewDockerRunOptions()
 
 	tempDir, cleanup := setupTempWorkingDir(s.T())
@@ -183,7 +188,10 @@ func (s *GetSuite) TestDockerRunWriteToJobFolderAutoDownload() {
 // the results layout adheres to the expected folder layout
 func (s *GetSuite) TestDockerRunWriteToJobFolderNamedDownload() {
 	ctx := context.Background()
-	stack, _ := devstack_tests.SetupTest(ctx, s.T(), 1, 0, false, computenode.ComputeNodeConfig{})
+	stack, _ := devstack_tests.SetupTest(ctx, s.T(), 1, 0, false,
+		computenode.NewDefaultComputeNodeConfig(),
+		requesternode.NewDefaultRequesterNodeConfig(),
+	)
 	*ODR = *NewDockerRunOptions()
 
 	tempDir, err := os.MkdirTemp("", "docker-run-download-test")
@@ -207,7 +215,10 @@ func (s *GetSuite) TestDockerRunWriteToJobFolderNamedDownload() {
 // all over the current directory
 func (s *GetSuite) TestGetWriteToJobFolderAutoDownload() {
 	ctx := context.Background()
-	stack, _ := devstack_tests.SetupTest(ctx, s.T(), 1, 0, false, computenode.ComputeNodeConfig{})
+	stack, _ := devstack_tests.SetupTest(ctx, s.T(), 1, 0, false,
+		computenode.NewDefaultComputeNodeConfig(),
+		requesternode.NewDefaultRequesterNodeConfig(),
+	)
 	*ODR = *NewDockerRunOptions()
 	*OG = *NewGetOptions()
 
@@ -240,7 +251,10 @@ func (s *GetSuite) TestGetWriteToJobFolderAutoDownload() {
 // the results layout adheres to the expected folder layout
 func (s *GetSuite) TestGetWriteToJobFolderNamedDownload() {
 	ctx := context.Background()
-	stack, _ := devstack_tests.SetupTest(ctx, s.T(), 1, 0, false, computenode.ComputeNodeConfig{})
+	stack, _ := devstack_tests.SetupTest(ctx, s.T(), 1, 0, false,
+		computenode.NewDefaultComputeNodeConfig(),
+		requesternode.NewDefaultRequesterNodeConfig(),
+	)
 	*ODR = *NewDockerRunOptions()
 	*OG = *NewGetOptions()
 

--- a/cmd/bacalhau/serve.go
+++ b/cmd/bacalhau/serve.go
@@ -318,7 +318,7 @@ var serveCmd = &cobra.Command{
 				JobSelectionPolicy:    getJobSelectionConfig(),
 				CapacityManagerConfig: getCapacityManagerConfig(),
 			},
-			RequesterNodeConfig: requesternode.RequesterNodeConfig{},
+			RequesterNodeConfig: requesternode.NewDefaultRequesterNodeConfig(),
 		}
 
 		if OS.LotusFilecoinStorageDuration != time.Duration(0) &&

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/filecoin-project/go-jsonrpc v0.1.9
 	github.com/filecoin-project/go-state-types v0.9.9
 	github.com/go-resty/resty/v2 v2.7.0
-	github.com/gobwas/ws v1.1.0
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-multierror v1.1.1
@@ -61,7 +60,6 @@ require (
 	github.com/spf13/viper v1.14.0
 	github.com/stretchr/testify v1.8.1
 	github.com/tetratelabs/wazero v1.0.0-pre.3
-	github.com/theckman/yacspin v0.13.12
 	github.com/tidwall/sjson v1.2.5
 	github.com/xeipuuv/gojsonschema v1.2.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.36.4
@@ -115,7 +113,6 @@ require (
 	github.com/elastic/gosigar v0.14.2 // indirect
 	github.com/elgris/jsondiff v0.0.0-20160530203242-765b5c24c302 // indirect
 	github.com/facebookgo/atomicfile v0.0.0-20151019160806-2de1f203e7d5 // indirect
-	github.com/fatih/color v1.13.0 // indirect
 	github.com/filecoin-project/go-amt-ipld/v4 v4.0.0 // indirect
 	github.com/filecoin-project/go-bitfield v0.2.4 // indirect
 	github.com/filecoin-project/go-hamt-ipld/v3 v3.1.0 // indirect
@@ -129,8 +126,6 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-pkgz/expirable-cache v0.1.0 // indirect
 	github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 // indirect
-	github.com/gobwas/httphead v0.1.0 // indirect
-	github.com/gobwas/pool v0.2.1 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect

--- a/go.sum
+++ b/go.sum
@@ -265,7 +265,6 @@ github.com/facebookgo/atomicfile v0.0.0-20151019160806-2de1f203e7d5/go.mod h1:Jp
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
-github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/filecoin-project/filecoin-ffi v0.30.4-0.20200910194244-f640612a1a1f/go.mod h1:+If3s2VxyjZn+KGGZIoRXBDSFQ9xL404JBJGf4WhEj0=
@@ -354,12 +353,6 @@ github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
-github.com/gobwas/httphead v0.1.0 h1:exrUm0f4YX0L7EBwZHuCF4GDp8aJfVeBrlLQrs6NqWU=
-github.com/gobwas/httphead v0.1.0/go.mod h1:O/RXo79gxV8G+RqlR/otEwx4Q36zl9rqC5u12GKvMCM=
-github.com/gobwas/pool v0.2.1 h1:xfeeEhW7pwmX8nuLVlqbzVc7udMDrwetjEv+TZIz1og=
-github.com/gobwas/pool v0.2.1/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
-github.com/gobwas/ws v1.1.0 h1:7RFti/xnNkMJnrK7D1yQ/iCIB5OrrY/54/H930kIbHA=
-github.com/gobwas/ws v1.1.0/go.mod h1:nzvNcVha5eUziGrbxFCo6qFIojQHjJV5cLYIbezhfL0=
 github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
@@ -1241,7 +1234,6 @@ github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaO
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
-github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
@@ -1250,7 +1242,6 @@ github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNx
 github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
-github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.13/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-isatty v0.0.16 h1:bq3VjFmv/sOjHtdEhmkEV4x1AJtvUvOJ2PFAZ5+peKQ=
@@ -1668,8 +1659,6 @@ github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cb
 github.com/tetratelabs/wazero v1.0.0-pre.3 h1:Z5fbogMUGcERzaQb9mQU8+yJSy0bVvv2ce3dfR4wcZg=
 github.com/tetratelabs/wazero v1.0.0-pre.3/go.mod h1:M8UDNECGm/HVjOfq0EOe4QfCY9Les1eq54IChMLETbc=
 github.com/texttheater/golang-levenshtein v0.0.0-20180516184445-d188e65d659e/go.mod h1:XDKHRm5ThF8YJjx001LtgelzsoaEcvnA7lVWz9EeX3g=
-github.com/theckman/yacspin v0.13.12 h1:CdZ57+n0U6JMuh2xqjnjRq5Haj6v1ner2djtLQRzJr4=
-github.com/theckman/yacspin v0.13.12/go.mod h1:Rd2+oG2LmQi5f3zC3yeZAOl245z8QOvrH4OPOJNZxLg=
 github.com/tidwall/gjson v1.14.2 h1:6BBkirS0rAHjumnjHF6qgy5d2YAJ1TLIaFE2lzfOLqo=
 github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
@@ -2096,7 +2085,6 @@ golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201207223542-d4d67f95c62d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201214210602-f9fddec55a1e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210104204734-6f8348627aad/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/computenode/computenode.go
+++ b/pkg/computenode/computenode.go
@@ -24,22 +24,8 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-const DefaultJobCPU = "100m"
-const DefaultJobMemory = "100Mb"
 const ControlLoopIntervalMillis = 100
 const ShardStateLogInterval = 5 * time.Minute
-const DelayBeforeBidMillisecondRange = 100
-const BidTimeoutSeconds = 60
-
-type ComputeNodeConfig struct {
-	// this contains things like data locality and per
-	// job resource limits
-	JobSelectionPolicy JobSelectionPolicy
-
-	// configure the resource capacity we are allowing for
-	// this compute node
-	CapacityManagerConfig capacitymanager.Config
-}
 
 type ComputeNode struct {
 	// The ID of this compute node in its configured transport.
@@ -61,12 +47,6 @@ type ComputeNode struct {
 	bidMu             sync.Mutex
 }
 
-func NewDefaultComputeNodeConfig() ComputeNodeConfig {
-	return ComputeNodeConfig{
-		JobSelectionPolicy: NewDefaultJobSelectionPolicy(),
-	}
-}
-
 func NewComputeNode(
 	ctx context.Context,
 	cm *system.CleanupManager,
@@ -84,7 +64,7 @@ func NewComputeNode(
 	defer span.End()
 
 	computeNode, err := constructComputeNode(
-		ctx, nodeID, localDB, localEventConsumer, jobEventPublisher, executors, verifiers, publishers, config)
+		ctx, cm, nodeID, localDB, localEventConsumer, jobEventPublisher, executors, verifiers, publishers, config)
 	if err != nil {
 		return nil, err
 	}
@@ -98,6 +78,7 @@ func NewComputeNode(
 // process the arguments and return a valid compoute node
 func constructComputeNode(
 	ctx context.Context,
+	cm *system.CleanupManager,
 	nodeID string,
 	localDB localdb.LocalDB,
 	localEventHandler eventhandler.LocalEventHandler,
@@ -107,7 +88,7 @@ func constructComputeNode(
 	publishers publisher.PublisherProvider,
 	config ComputeNodeConfig,
 ) (*ComputeNode, error) {
-	shardStateManager, err := NewShardComputeStateMachineManager()
+	shardStateManager, err := NewShardComputeStateMachineManager(ctx, cm, config)
 	if err != nil {
 		return nil, err
 	}
@@ -251,14 +232,6 @@ func processBidJob(ctx context.Context, bidShards []model.JobShard, i int, n *Co
 	}
 
 	shardState.Bid(ctx)
-
-	// We timeout the bid, to avoid holding open the capacity for it indefinitely.
-	go func() {
-		time.Sleep(BidTimeoutSeconds * time.Second)
-		if shardState.currentState == shardBidding {
-			shardState.Fail(ctx, "bid timed out")
-		}
-	}()
 }
 
 /*
@@ -278,16 +251,19 @@ func (n *ComputeNode) HandleJobEvent(ctx context.Context, event model.JobEvent) 
 		log.Ctx(ctx).Debug().Msgf("[%s] job created: %s", n.ID, job.ID)
 		return n.subscriptionEventCreated(ctx, event, job)
 	} else {
-		// we only care if the event is related to us
-		if event.TargetNodeID != n.ID {
-			return nil
-		}
 		shard := model.JobShard{
 			Job:   job,
 			Index: event.ShardIndex,
 		}
+
+		// we only care if the event is direct to us, or a global event related to a shard we are processing
+		if (event.TargetNodeID == "" && !n.shardStateManager.Has(shard.ID())) || event.TargetNodeID != n.ID {
+			return nil
+		}
+
 		switch event.EventName {
-		case model.JobEventBidAccepted, model.JobEventBidRejected, model.JobEventResultsAccepted, model.JobEventResultsRejected:
+		case model.JobEventBidAccepted, model.JobEventBidRejected, model.JobEventResultsAccepted,
+			model.JobEventResultsRejected, model.JobEventError:
 			return n.triggerStateTransition(ctx, event, shard)
 		}
 	}
@@ -450,6 +426,8 @@ func (n *ComputeNode) triggerStateTransition(ctx context.Context, event model.Jo
 			shardState.ResultsRejected(ctx)
 		case model.JobEventInvalidRequest:
 			shardState.FailSilently(ctx, "Request rejected due to: "+event.Status)
+		case model.JobEventError:
+			shardState.FailSilently(ctx, "Requester triggered failure due to: "+event.Status)
 		}
 	} else {
 		log.Ctx(ctx).Debug().Msgf("Received %s for unknown shard %s", event.EventName, shard)
@@ -469,6 +447,18 @@ func (n *ComputeNode) SelectJob(ctx context.Context, data JobSelectionPolicyProb
 	defer span.End()
 
 	requirements := model.ResourceUsageData{}
+
+	// skip bidding if the job spec defined a timeout value higher or lower than what we are willing to accept
+	if data.Spec.GetTimeout() > n.config.TimeoutConfig.MaxJobExecutionTimeout {
+		log.Ctx(ctx).Debug().Msgf("Compute node skipped bidding on job %s because job timeout %s exceeds maximum allowed %s",
+			data.JobID, data.Spec.GetTimeout(), n.config.TimeoutConfig.MaxJobExecutionTimeout)
+		return false, requirements, nil
+	}
+	if data.Spec.GetTimeout() < n.config.TimeoutConfig.MinJobExecutionTimeout {
+		log.Ctx(ctx).Debug().Msgf("Compute node skipped bidding on job %s because job timeout %s below minimum allowed %s",
+			data.JobID, data.Spec.GetTimeout(), n.config.TimeoutConfig.MinJobExecutionTimeout)
+		return false, requirements, nil
+	}
 
 	// check that we have the executor and it's installed
 	e, err := n.executors.GetExecutor(ctx, data.Spec.Engine)
@@ -585,6 +575,16 @@ func (n *ComputeNode) RunShard(ctx context.Context, shard model.JobShard) ([]byt
 	}
 
 	return shardProposal, runOutput, err
+}
+
+// Cancels the execution of a running shard.
+func (n *ComputeNode) CancelShard(ctx context.Context, shard model.JobShard) error {
+	// check that we have the executor to run this job
+	e, err := n.executors.GetExecutor(ctx, shard.Job.Spec.Engine)
+	if err != nil {
+		return err
+	}
+	return e.CancelShard(ctx, shard)
 }
 
 func (n *ComputeNode) PublishShard(ctx context.Context, shard model.JobShard) error {

--- a/pkg/computenode/config.go
+++ b/pkg/computenode/config.go
@@ -1,0 +1,64 @@
+package computenode
+
+import (
+	"time"
+
+	"github.com/filecoin-project/bacalhau/pkg/capacitymanager"
+)
+
+// DefaultStateTransitionTimeout default timeout value for each shard state, except running state
+const DefaultStateTransitionTimeout = 1 * time.Minute
+
+// DefaultMinJobExecutionTimeout default value for the minimum execution timeout this compute node supports. Jobs with
+// lower timeout requirements will not be bid on.
+const DefaultMinJobExecutionTimeout = 500 * time.Millisecond
+
+// DefaultMaxJobExecutionTimeout default value for the maximum execution timeout this compute node supports. Jobs with
+// higher timeout requirements will not be bid on.
+const DefaultMaxJobExecutionTimeout = 60 * time.Minute
+
+// DefaultStateManagerTaskInterval background task interval that periodically checks for expired states among other things.
+const DefaultStateManagerTaskInterval = 30 * time.Second
+
+type ComputeTimeoutConfig struct {
+	// Timeout value for each shard state, except running state
+	StateTransitionTimeout time.Duration
+
+	// Minimum timeout value for running a job. Jobs with lower timeout requirements will not be bid on.
+	MinJobExecutionTimeout time.Duration
+
+	// Maximum timeout value for running a job. Jobs with higher timeout requirements will not be bid on.
+	MaxJobExecutionTimeout time.Duration
+}
+
+func NewDefaultComputeTimeoutConfig() ComputeTimeoutConfig {
+	return ComputeTimeoutConfig{
+		StateTransitionTimeout: DefaultStateTransitionTimeout,
+		MinJobExecutionTimeout: DefaultMinJobExecutionTimeout,
+		MaxJobExecutionTimeout: DefaultMaxJobExecutionTimeout,
+	}
+}
+
+type ComputeNodeConfig struct {
+	// this contains things like data locality and per
+	// job resource limits
+	JobSelectionPolicy JobSelectionPolicy
+
+	// configure the resource capacity we are allowing for
+	// this compute node
+	CapacityManagerConfig capacitymanager.Config
+
+	// configure the timeout for each shard state
+	TimeoutConfig ComputeTimeoutConfig
+
+	// background task interval that periodically checks for expired states among other things.
+	StateManagerBackgroundTaskInterval time.Duration
+}
+
+func NewDefaultComputeNodeConfig() ComputeNodeConfig {
+	return ComputeNodeConfig{
+		JobSelectionPolicy:                 NewDefaultJobSelectionPolicy(),
+		TimeoutConfig:                      NewDefaultComputeTimeoutConfig(),
+		StateManagerBackgroundTaskInterval: DefaultStateManagerTaskInterval,
+	}
+}

--- a/pkg/devstack/devstack.go
+++ b/pkg/devstack/devstack.go
@@ -73,6 +73,7 @@ func NewDevStackForRunLocal(
 		cm,
 		options,
 		computeNodeConfig,
+		requesternode.NewDefaultRequesterNodeConfig(),
 	)
 }
 
@@ -81,8 +82,9 @@ func NewStandardDevStack(
 	cm *system.CleanupManager,
 	options DevStackOptions,
 	computeNodeConfig computenode.ComputeNodeConfig,
+	requesterNodeConfig requesternode.RequesterNodeConfig,
 ) (*DevStack, error) {
-	return NewDevStack(ctx, cm, options, computeNodeConfig, node.NewStandardNodeDependencyInjector())
+	return NewDevStack(ctx, cm, options, computeNodeConfig, requesterNodeConfig, node.NewStandardNodeDependencyInjector())
 }
 
 func NewNoopDevStack(
@@ -90,8 +92,9 @@ func NewNoopDevStack(
 	cm *system.CleanupManager,
 	options DevStackOptions,
 	computeNodeConfig computenode.ComputeNodeConfig,
+	requesterNodeConfig requesternode.RequesterNodeConfig,
 ) (*DevStack, error) {
-	return NewDevStack(ctx, cm, options, computeNodeConfig, NewNoopNodeDependencyInjector())
+	return NewDevStack(ctx, cm, options, computeNodeConfig, requesterNodeConfig, NewNoopNodeDependencyInjector())
 }
 
 //nolint:funlen,gocyclo
@@ -100,6 +103,7 @@ func NewDevStack(
 	cm *system.CleanupManager,
 	options DevStackOptions,
 	computeNodeConfig computenode.ComputeNodeConfig,
+	requesterNodeConfig requesternode.RequesterNodeConfig,
 	injector node.NodeDependencyInjector,
 ) (*DevStack, error) {
 	ctx, span := system.GetTracer().Start(ctx, "pkg/devstack.newdevstack")
@@ -234,7 +238,7 @@ func NewDevStack(
 			APIPort:              apiPort,
 			MetricsPort:          metricsPort,
 			ComputeNodeConfig:    computeNodeConfig,
-			RequesterNodeConfig:  requesternode.RequesterNodeConfig{},
+			RequesterNodeConfig:  requesterNodeConfig,
 			IsBadActor:           isBadActor,
 		}
 

--- a/pkg/docker/utils.go
+++ b/pkg/docker/utils.go
@@ -121,6 +121,23 @@ func GetLogs(ctx context.Context, dockerClient *dockerclient.Client, nameOrID st
 	return stdoutBuffer.String(), stderrBuffer.String(), nil
 }
 
+func StopContainer(ctx context.Context, dockerClient *dockerclient.Client, nameOrID string) error {
+	container, err := GetContainer(ctx, dockerClient, nameOrID)
+	if err != nil {
+		return err
+	}
+	if container == nil {
+		return nil
+	}
+	log.Ctx(ctx).Debug().Msgf("Container requested to stop: %s", container.ID)
+	timeout := time.Millisecond * 100
+	err = dockerClient.ContainerStop(ctx, container.ID, &timeout)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func RemoveContainer(ctx context.Context, dockerClient *dockerclient.Client, nameOrID string) error {
 	container, err := GetContainer(ctx, dockerClient, nameOrID)
 	if err != nil {

--- a/pkg/executor/docker/executor.go
+++ b/pkg/executor/docker/executor.go
@@ -364,6 +364,10 @@ func (e *Executor) RunShard(
 	return runResult, err
 }
 
+func (e *Executor) CancelShard(ctx context.Context, shard model.JobShard) error {
+	return docker.StopContainer(ctx, e.Client, e.jobContainerName(shard))
+}
+
 func returnStdErrWithErr(msg string, err error) *model.RunCommandResult {
 	log.Debug().Msgf("Returning error %s", msg)
 	log.Debug().Msgf("Returning error %s", err.Error())

--- a/pkg/executor/noop/executor.go
+++ b/pkg/executor/noop/executor.go
@@ -101,6 +101,10 @@ func (e *NoopExecutor) RunShard(
 	return &model.RunCommandResult{}, nil
 }
 
+func (e *NoopExecutor) CancelShard(ctx context.Context, shard model.JobShard) error {
+	return nil
+}
+
 // Compile-time check that Executor implements the Executor interface.
 var _ executor.ExecutorProvider = (*NoopExecutorProvider)(nil)
 var _ executor.Executor = (*NoopExecutor)(nil)

--- a/pkg/executor/python_wasm/executor.go
+++ b/pkg/executor/python_wasm/executor.go
@@ -82,5 +82,13 @@ func (e *Executor) RunShard(ctx context.Context, shard model.JobShard, resultsDi
 	return dockerExecutor.RunShard(ctx, shard, resultsDir)
 }
 
+func (e *Executor) CancelShard(ctx context.Context, shard model.JobShard) error {
+	dockerExecutor, err := e.executors.GetExecutor(ctx, model.EngineDocker)
+	if err != nil {
+		return err
+	}
+	return dockerExecutor.CancelShard(ctx, shard)
+}
+
 // Compile-time check that Executor implements the Executor interface.
 var _ executor.Executor = (*Executor)(nil)

--- a/pkg/executor/types.go
+++ b/pkg/executor/types.go
@@ -34,4 +34,10 @@ type Executor interface {
 		shard model.JobShard,
 		resultsDir string,
 	) (*model.RunCommandResult, error)
+
+	// Cancel a running shard.
+	CancelShard(
+		ctx context.Context,
+		shard model.JobShard,
+	) error
 }

--- a/pkg/executor/wasm/executor.go
+++ b/pkg/executor/wasm/executor.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"sort"
 
+	"github.com/filecoin-project/bacalhau/pkg/executor"
+
 	"github.com/filecoin-project/bacalhau/pkg/job"
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/filecoin-project/bacalhau/pkg/storage"
@@ -293,6 +295,11 @@ func (e *Executor) RunShard(
 	return result, wasmErr
 }
 
+func (e *Executor) CancelShard(ctx context.Context, shard model.JobShard) error {
+	// TODO: Implement CancelShard for WASM executor #1060
+	return nil
+}
+
 func keys(m map[string]string) []string {
 	var ks []string
 	for k := range m {
@@ -301,3 +308,6 @@ func keys(m map[string]string) []string {
 	sort.Strings(ks)
 	return ks
 }
+
+// Compile-time check that Executor implements the Executor interface.
+var _ executor.Executor = (*Executor)(nil)

--- a/pkg/model/job.go
+++ b/pkg/model/job.go
@@ -206,6 +206,10 @@ type Spec struct {
 	// the compute (cpy, ram) resources this job requires
 	Resources ResourceUsageConfig `json:"Resources,omitempty"`
 
+	// How long a job can run in seconds before it is killed.
+	// This doesn't include the time required to auction the job, find nodes or verify the result.
+	Timeout float64 `json:"Timeout,omitempty"`
+
 	// the data volumes we will read in the job
 	// for example "read this ipfs cid"
 	// TODO: #667 Replace with "Inputs", "Outputs" (note the caps) for yaml/json when we update the n.js file
@@ -229,6 +233,11 @@ type Spec struct {
 
 	// Do not track specified by the client
 	DoNotTrack bool `json:"DoNotTrack,omitempty"`
+}
+
+// Return timeout duration
+func (s *Spec) GetTimeout() time.Duration {
+	return time.Duration(s.Timeout * float64(time.Second))
 }
 
 // for VM style executors

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -129,6 +129,7 @@ func NewNode(
 
 	requesterNode, err := requesternode.NewRequesterNode(
 		ctx,
+		config.CleanupManager,
 		config.HostID,
 		config.LocalDB,
 		localEventConsumer,

--- a/pkg/publicapi/util.go
+++ b/pkg/publicapi/util.go
@@ -101,13 +101,14 @@ func SetupRequesterNodeForTestsWithPortAndConfig(t *testing.T, port int, config 
 
 	requesterNode, err := requesternode.NewRequesterNode(
 		ctx,
+		cm,
 		inprocessTransport.HostID(),
 		inmemoryDatastore,
 		localEventConsumer,
 		jobEventPublisher,
 		noopVerifiers,
 		noopStorageProviders,
-		requesternode.RequesterNodeConfig{},
+		requesternode.NewDefaultRequesterNodeConfig(),
 	)
 	require.NoError(t, err)
 

--- a/pkg/requesternode/config.go
+++ b/pkg/requesternode/config.go
@@ -1,0 +1,53 @@
+package requesternode
+
+import (
+	"time"
+)
+
+// DefaultStateTransitionTimeout default timeout value for each shard state, except running state
+const DefaultStateTransitionTimeout = 1 * time.Minute
+
+// DefaultJobExecutionTimeout default timeout value for running a job, if the user didn't define one in the spec
+const DefaultJobExecutionTimeout = 5 * time.Minute
+
+// DefaultMinJobExecutionTimeout requester node will replace any job execution timeout that is less than
+// this value with DefaultJobExecutionTimeout.
+const DefaultMinJobExecutionTimeout = 0 * time.Second
+
+// DefaultStateManagerTaskInterval background task interval that periodically checks for expired states among other things.
+const DefaultStateManagerTaskInterval = 30 * time.Second
+
+type RequesterTimeoutConfig struct {
+	// Timeout value for each shard state, except running state
+	StateTransitionTimeout time.Duration
+
+	// Timeout value for running a job, if the user didn't define one in the spec
+	DefaultJobExecutionTimeout time.Duration
+
+	// Requester node will replace any job execution timeout that is less than this
+	// value with DefaultJobExecutionTimeout.
+	MinJobExecutionTimeout time.Duration
+}
+
+func NewDefaultRequesterTimeoutConfig() RequesterTimeoutConfig {
+	return RequesterTimeoutConfig{
+		StateTransitionTimeout:     DefaultStateTransitionTimeout,
+		DefaultJobExecutionTimeout: DefaultJobExecutionTimeout,
+		MinJobExecutionTimeout:     DefaultMinJobExecutionTimeout,
+	}
+}
+
+type RequesterNodeConfig struct {
+	// configure the timeout for each shard state
+	TimeoutConfig RequesterTimeoutConfig
+
+	// background task interval that periodically checks for expired states among other things.
+	StateManagerBackgroundTaskInterval time.Duration
+}
+
+func NewDefaultRequesterNodeConfig() RequesterNodeConfig {
+	return RequesterNodeConfig{
+		TimeoutConfig:                      NewDefaultRequesterTimeoutConfig(),
+		StateManagerBackgroundTaskInterval: DefaultStateManagerTaskInterval,
+	}
+}

--- a/pkg/requesternode/requesternode.go
+++ b/pkg/requesternode/requesternode.go
@@ -19,8 +19,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-type RequesterNodeConfig struct{}
-
 type RequesterNode struct {
 	ID                 string
 	localDB            localdb.LocalDB
@@ -35,6 +33,7 @@ type RequesterNode struct {
 
 func NewRequesterNode(
 	ctx context.Context,
+	cm *system.CleanupManager,
 	nodeID string,
 	localDB localdb.LocalDB,
 	localEventConsumer eventhandler.LocalEventHandler,
@@ -52,7 +51,7 @@ func NewRequesterNode(
 		verifiers:          verifiers,
 		storageProviders:   storageProviders,
 		config:             config,
-		shardStateManager:  newShardStateMachineManager(),
+		shardStateManager:  newShardStateMachineManager(ctx, cm, config),
 	}
 	return requesterNode, nil
 }
@@ -106,6 +105,11 @@ func (node *RequesterNode) SubmitJob(ctx context.Context, data model.JobCreatePa
 	ev.Deal = data.Job.Deal
 	ev.JobExecutionPlan = executionPlan
 
+	// set a default timeout value if one is not passed or below an acceptable value
+	if ev.Spec.GetTimeout() <= node.config.TimeoutConfig.MinJobExecutionTimeout {
+		ev.Spec.Timeout = node.config.TimeoutConfig.DefaultJobExecutionTimeout.Seconds()
+	}
+
 	job := jobutils.ConstructJobFromEvent(ev)
 	err = node.localDB.AddJob(ctx, job)
 	if err != nil {
@@ -154,11 +158,12 @@ func (node *RequesterNode) triggerStateTransition(ctx context.Context, event mod
 		switch event.EventName {
 		case model.JobEventBid:
 			shardState.bid(ctx, event.SourceNodeID)
-		case model.JobEventResultsProposed, model.JobEventComputeError:
-			// will trigger verifying the results when all shards are complete, gracefully or ungracefully.
+		case model.JobEventResultsProposed:
 			shardState.verifyResult(ctx, event.SourceNodeID)
 		case model.JobEventResultsPublished:
 			shardState.resultsPublished(ctx, event.SourceNodeID)
+		case model.JobEventComputeError:
+			shardState.computeError(ctx, event.SourceNodeID)
 		}
 	} else {
 		log.Ctx(ctx).Debug().Msgf("Received %s for unknown shard %s", event.EventName, shard)

--- a/pkg/requesternode/shard_fsm.go
+++ b/pkg/requesternode/shard_fsm.go
@@ -21,21 +21,27 @@ const (
 	// bid received from a compute node.
 	actionBidReceived shardStateAction = iota // must be first
 
+	// an error reported by a compute node.
+	actionComputeError
+
 	// result received from a compute node.
 	actionResultReceived
 
 	// result published after it has been verified
 	actionResultsPublished
+
+	actionFail
 )
 
 func (a shardStateAction) String() string {
-	return [...]string{"ActionBidReceived", "ActionResultReceived", "ActionResultsPublished", "ActionFail"}[a]
+	return [...]string{"ActionBidReceived", "ActionComputeError", "ActionResultReceived", "ActionResultsPublished", "ActionFail"}[a]
 }
 
 // request to change the state of the fsm
 type shardStateRequest struct {
 	action       shardStateAction
 	sourceNodeID string // optional field indicating the node that triggered the request
+	reason       string
 }
 
 // types of shard state machines
@@ -79,12 +85,18 @@ type shardStateMachineManager struct {
 	// map fo the job ID and job state machine.
 	// Used to find the job state machine for a given ID.
 	shardStates map[string]*shardStateMachine
-	mu          sync.Mutex
+	// configure the timeout for each shard state
+	timeoutConfig RequesterTimeoutConfig
+	mu            sync.Mutex
 }
 
-func newShardStateMachineManager() *shardStateMachineManager {
+func newShardStateMachineManager(
+	ctx context.Context,
+	cm *system.CleanupManager,
+	config RequesterNodeConfig) *shardStateMachineManager {
 	stateManager := &shardStateMachineManager{
-		shardStates: make(map[string]*shardStateMachine),
+		shardStates:   make(map[string]*shardStateMachine),
+		timeoutConfig: config.TimeoutConfig,
 	}
 
 	stateManager.mu.EnableTracerWithOpts(sync.Opts{
@@ -92,7 +104,57 @@ func newShardStateMachineManager() *shardStateMachineManager {
 		Id:        "RequesterNode.ShardStateMachineManagerMu",
 	})
 
+	go stateManager.backgroundTaskSetup(ctx, cm, config)
 	return stateManager
+}
+
+func (m *shardStateMachineManager) backgroundTaskSetup(
+	ctx context.Context,
+	cm *system.CleanupManager,
+	config RequesterNodeConfig) {
+	ticker := time.NewTicker(config.StateManagerBackgroundTaskInterval)
+	ctx, cancelFunction := context.WithCancel(ctx)
+	cm.RegisterCallback(func() error {
+		cancelFunction()
+		return nil
+	})
+
+	for {
+		select {
+		case <-ticker.C:
+			m.backgroundTask()
+		case <-ctx.Done():
+			ticker.Stop()
+			return
+		}
+	}
+}
+
+// Background task that iterate over all the shard state machines and does the following:
+// 1. Remove the shard state machine if it is in a terminal state for more than a defined threshold
+// 2. Timeout and fail tasks that are in a non-terminal state for more than a defined threshold
+func (m *shardStateMachineManager) backgroundTask() {
+	ctx := context.Background()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var timeoutShardStates []*shardStateMachine
+	// current time
+	now := time.Now()
+
+	for key, item := range m.shardStates {
+		if item.timeoutAt.Before(now) {
+			if item.currentState == shardCompleted {
+				delete(m.shardStates, key)
+			} else {
+				timeoutShardStates = append(timeoutShardStates, item)
+			}
+		}
+	}
+
+	for _, item := range timeoutShardStates {
+		go item.fail(ctx, fmt.Sprintf("shard timed out while in state %s", item.currentState))
+	}
 }
 
 // Start a state machine for all the shards in the job, if they don't exit already
@@ -105,7 +167,7 @@ func (m *shardStateMachineManager) startShardsState(
 	for i := 0; i < job.ExecutionPlan.TotalShards; i++ {
 		shard := model.JobShard{Job: job, Index: i}
 		if _, ok := m.shardStates[shard.ID()]; !ok {
-			shardState := newShardStateMachine(ctx, shard, n)
+			shardState := m.newShardStateMachine(ctx, shard, n)
 			m.shardStates[shard.ID()] = shardState
 
 			go func() {
@@ -123,12 +185,14 @@ func (m *shardStateMachineManager) GetShardState(shard model.JobShard) (*shardSt
 }
 
 type shardStateMachine struct {
-	shard model.JobShard
-	node  *RequesterNode
-	req   chan shardStateRequest
+	shard   model.JobShard
+	manager *shardStateMachineManager
+	node    *RequesterNode
+	req     chan shardStateRequest
 
 	currentState  shardStateType
 	previousState shardStateType
+	timeoutAt     time.Time
 	errorMsg      string
 
 	// keep track of nodes that have already bid on this shard to deduplicate bids and only accept results
@@ -140,14 +204,16 @@ type shardStateMachine struct {
 	completedNodes map[string]struct{}
 }
 
-func newShardStateMachine(ctx context.Context, shard model.JobShard, node *RequesterNode) *shardStateMachine {
+func (m *shardStateMachineManager) newShardStateMachine(ctx context.Context, shard model.JobShard, node *RequesterNode) *shardStateMachine {
 	return &shardStateMachine{
 		shard:          shard,
+		manager:        m,
 		node:           node,
 		req:            make(chan shardStateRequest),
 		currentState:   shardInitialState,
 		biddingNodes:   make(map[string]struct{}),
 		completedNodes: make(map[string]struct{}),
+		timeoutAt:      time.Now().Add(m.timeoutConfig.StateTransitionTimeout),
 	}
 }
 
@@ -170,12 +236,20 @@ func (m *shardStateMachine) bid(ctx context.Context, sourceNodeID string) {
 	m.sendRequest(ctx, shardStateRequest{action: actionBidReceived, sourceNodeID: sourceNodeID})
 }
 
+func (m *shardStateMachine) computeError(ctx context.Context, sourceNodeID string) {
+	m.sendRequest(ctx, shardStateRequest{action: actionComputeError, sourceNodeID: sourceNodeID})
+}
+
 func (m *shardStateMachine) verifyResult(ctx context.Context, sourceNodeID string) {
 	m.sendRequest(ctx, shardStateRequest{action: actionResultReceived, sourceNodeID: sourceNodeID})
 }
 
 func (m *shardStateMachine) resultsPublished(ctx context.Context, sourceNodeID string) {
 	m.sendRequest(ctx, shardStateRequest{action: actionResultsPublished, sourceNodeID: sourceNodeID})
+}
+
+func (m *shardStateMachine) fail(ctx context.Context, reason string) {
+	m.sendRequest(ctx, shardStateRequest{action: actionFail, reason: reason})
 }
 
 // send a request to the state machine by enqueuing it in the request channel.
@@ -212,6 +286,12 @@ func (m *shardStateMachine) transitionedTo(ctx context.Context, newState shardSt
 	log.Ctx(ctx).Debug().Msgf("%s transitioning from %s -> %s", m, m.currentState, newState)
 	m.previousState = m.currentState
 	m.currentState = newState
+
+	if newState == shardWaitingForResults {
+		m.timeoutAt = time.Now().Add(m.shard.Job.Spec.GetTimeout())
+	} else {
+		m.timeoutAt = time.Now().Add(m.manager.timeoutConfig.StateTransitionTimeout)
+	}
 }
 
 // Shard is enqueuing bids waiting Min bids before start accepting/rejecting bids.
@@ -232,6 +312,17 @@ func enqueuedState(ctx context.Context, m *shardStateMachine) stateFn {
 			} else {
 				log.Ctx(ctx).Warn().Msgf("%s ignoring duplicate bid from %s", m, req.sourceNodeID)
 			}
+		case actionComputeError:
+			if _, ok := m.biddingNodes[req.sourceNodeID]; ok {
+				// remove the node from the bidding nodes list to be able to accept more bids
+				delete(m.biddingNodes, req.sourceNodeID)
+			} else {
+				m.notifyInvalidRequest(ctx, req, fmt.Sprintf(
+					"Received %s from node %s that has not bid on this shard", req.action, req.sourceNodeID))
+			}
+		case actionFail:
+			m.errorMsg = req.reason
+			return errorState
 		default:
 			m.notifyInvalidRequest(ctx, req, fmt.Sprintf("invalid action %s in state %s", req.action, m.currentState))
 		}
@@ -302,12 +393,25 @@ func acceptingBidsState(ctx context.Context, m *shardStateMachine) stateFn {
 			} else {
 				log.Ctx(ctx).Warn().Msgf("%s ignoring duplicate bid from %s", m, req.sourceNodeID)
 			}
+		case actionComputeError:
+			if _, ok := m.biddingNodes[req.sourceNodeID]; ok {
+				// remove the node from the bidding nodes list to be able to accept more bids
+				delete(m.biddingNodes, req.sourceNodeID)
+				// also delete the result from the results map, if any.
+				delete(m.completedNodes, req.sourceNodeID)
+			} else {
+				m.notifyInvalidRequest(ctx, req, fmt.Sprintf(
+					"Received %s from node %s that has not bid on this shard", req.action, req.sourceNodeID))
+			}
 		case actionResultReceived:
 			if _, ok := m.biddingNodes[req.sourceNodeID]; ok {
 				m.completedNodes[req.sourceNodeID] = struct{}{}
 			} else {
 				m.notifyInvalidRequest(ctx, req, "results received from a non-bidding node")
 			}
+		case actionFail:
+			m.errorMsg = req.reason
+			return errorState
 		default:
 			m.notifyInvalidRequest(ctx, req, fmt.Sprintf("invalid action %s in state %s", req.action, m.currentState))
 		}
@@ -327,6 +431,16 @@ func waitingForResultsState(ctx context.Context, m *shardStateMachine) stateFn {
 			if err != nil {
 				log.Ctx(ctx).Warn().Msgf("%s failed to notify bid rejection: %s", m, err)
 			}
+		case actionComputeError:
+			if _, ok := m.biddingNodes[req.sourceNodeID]; ok {
+				// remove the node from the bidding nodes list to be able to accept more bids
+				delete(m.biddingNodes, req.sourceNodeID)
+				// also delete the result from the results map, if any.
+				delete(m.completedNodes, req.sourceNodeID)
+			} else {
+				m.notifyInvalidRequest(ctx, req, fmt.Sprintf(
+					"Received %s from node %s that has not bid on this shard", req.action, req.sourceNodeID))
+			}
 		case actionResultReceived:
 			if _, ok := m.biddingNodes[req.sourceNodeID]; ok {
 				m.completedNodes[req.sourceNodeID] = struct{}{}
@@ -340,6 +454,9 @@ func waitingForResultsState(ctx context.Context, m *shardStateMachine) stateFn {
 			} else {
 				m.notifyInvalidRequest(ctx, req, "results received from a non-bidding node")
 			}
+		case actionFail:
+			m.errorMsg = req.reason
+			return errorState
 		default:
 			m.notifyInvalidRequest(ctx, req, fmt.Sprintf("invalid action %s in state %s", req.action, m.currentState))
 		}
@@ -373,6 +490,9 @@ func waitingToPublishResultsState(ctx context.Context, m *shardStateMachine) sta
 			// TODO: #831 verify that the published results are the same as the ones we expect, or let the verifier
 			//  publish the result and not all the compute nodes.
 			return completedState
+		case actionFail:
+			m.errorMsg = req.reason
+			return errorState
 		default:
 			m.notifyInvalidRequest(ctx, req, fmt.Sprintf("invalid action %s in state %s", req.action, m.currentState))
 		}

--- a/pkg/test/devstack/combodriver_test.go
+++ b/pkg/test/devstack/combodriver_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/filecoin-project/bacalhau/pkg/requesternode"
+
 	"github.com/filecoin-project/bacalhau/pkg/computenode"
 	"github.com/filecoin-project/bacalhau/pkg/devstack"
 	"github.com/filecoin-project/bacalhau/pkg/job"
@@ -78,7 +80,7 @@ func (suite *ComboDriverSuite) TestComboDriver() {
 			FilecoinUnsealedPath: unsealedPath,
 		}
 
-		stack, err := devstack.NewStandardDevStack(ctx, cm, options, computenode.NewDefaultComputeNodeConfig())
+		stack, err := devstack.NewStandardDevStack(ctx, cm, options, computenode.NewDefaultComputeNodeConfig(), requesternode.NewDefaultRequesterNodeConfig())
 		require.NoError(suite.T(), err)
 
 		if !unsealedMode {

--- a/pkg/test/devstack/concurrency_test.go
+++ b/pkg/test/devstack/concurrency_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/filecoin-project/bacalhau/pkg/requesternode"
+
 	"github.com/filecoin-project/bacalhau/pkg/devstack"
 	"github.com/filecoin-project/bacalhau/pkg/logger"
 
@@ -53,6 +55,7 @@ func (suite *DevstackConcurrencySuite) TestConcurrencyLimit() {
 		0,
 		false,
 		computenode.NewDefaultComputeNodeConfig(),
+		requesternode.NewDefaultRequesterNodeConfig(),
 	)
 
 	testCase := scenario.WasmHelloWorld()

--- a/pkg/test/devstack/errorlogs_test.go
+++ b/pkg/test/devstack/errorlogs_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/filecoin-project/bacalhau/pkg/requesternode"
+
 	"github.com/filecoin-project/bacalhau/pkg/computenode"
 	"github.com/filecoin-project/bacalhau/pkg/job"
 	"github.com/filecoin-project/bacalhau/pkg/logger"
@@ -64,6 +66,7 @@ func (suite *DevstackErrorLogsSuite) TestErrorContainer() {
 		0,
 		false,
 		computenode.NewDefaultComputeNodeConfig(),
+		requesternode.NewDefaultRequesterNodeConfig(),
 	)
 
 	nodeIDs, err := stack.GetNodeIds()

--- a/pkg/test/devstack/jobselection_test.go
+++ b/pkg/test/devstack/jobselection_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/filecoin-project/bacalhau/pkg/requesternode"
+
 	"github.com/filecoin-project/bacalhau/pkg/devstack"
 	"github.com/filecoin-project/bacalhau/pkg/logger"
 
@@ -76,7 +78,7 @@ func (suite *DevstackJobSelectionSuite) TestSelectAllJobs() {
 		scenario := scenario.CatFileToStdout()
 		stack, cm := SetupTest(ctx, suite.T(), testCase.nodeCount, 0, false, computenode.ComputeNodeConfig{
 			JobSelectionPolicy: testCase.policy,
-		})
+		}, requesternode.NewDefaultRequesterNodeConfig())
 
 		nodeIDs, err := stack.GetNodeIds()
 		require.NoError(suite.T(), err)

--- a/pkg/test/devstack/lotus_test.go
+++ b/pkg/test/devstack/lotus_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/filecoin-project/bacalhau/pkg/requesternode"
+
 	"github.com/filecoin-project/bacalhau/pkg/computenode"
 	"github.com/filecoin-project/bacalhau/pkg/devstack"
 	"github.com/filecoin-project/bacalhau/pkg/job"
@@ -44,7 +46,7 @@ func (s *lotusNodeSuite) TestLotusNode() {
 	testCase := scenario.WasmHelloWorld()
 	nodeCount := 1
 
-	stack, _ := SetupTest(ctx, s.T(), nodeCount, 0, true, computenode.NewDefaultComputeNodeConfig())
+	stack, _ := SetupTest(ctx, s.T(), nodeCount, 0, true, computenode.NewDefaultComputeNodeConfig(), requesternode.NewDefaultRequesterNodeConfig())
 
 	nodeIDs, err := stack.GetNodeIds()
 	require.NoError(s.T(), err)

--- a/pkg/test/devstack/min_bids_test.go
+++ b/pkg/test/devstack/min_bids_test.go
@@ -2,6 +2,7 @@ package devstack
 
 import (
 	"context"
+	"github.com/filecoin-project/bacalhau/pkg/requesternode"
 	"testing"
 
 	"github.com/filecoin-project/bacalhau/pkg/devstack"
@@ -57,6 +58,7 @@ func (s *MinBidsSuite) testMinBids(testCase minBidsTestCase) {
 		0,
 		false,
 		computenode.NewDefaultComputeNodeConfig(),
+		requesternode.NewDefaultRequesterNodeConfig(),
 	)
 
 	dirPath, err := prepareFolderWithFiles(s.T(), testCase.shards)

--- a/pkg/test/devstack/multiple_cid_test.go
+++ b/pkg/test/devstack/multiple_cid_test.go
@@ -14,6 +14,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/filecoin-project/bacalhau/pkg/requesternode"
+
 	"github.com/filecoin-project/bacalhau/pkg/computenode"
 	"github.com/filecoin-project/bacalhau/pkg/devstack"
 	"github.com/filecoin-project/bacalhau/pkg/job"
@@ -72,6 +74,7 @@ func (s *MultipleCIDSuite) TestMultipleCIDs() {
 		0,
 		false,
 		computenode.NewDefaultComputeNodeConfig(),
+		requesternode.NewDefaultRequesterNodeConfig(),
 	)
 
 	t := system.GetTracer()
@@ -183,6 +186,7 @@ func runURLTest(
 				Locality: computenode.Anywhere,
 			},
 		},
+		requesternode.NewDefaultRequesterNodeConfig(),
 	)
 
 	ctx, rootSpan := system.NewRootSpan(ctx, system.GetTracer(), "pkg/test/devstack/multiple_cid_test/testmultipleurls")
@@ -404,6 +408,7 @@ func (s *MultipleCIDSuite) TestIPFSURLCombo() {
 				Locality: computenode.Anywhere,
 			},
 		},
+		requesternode.NewDefaultRequesterNodeConfig(),
 	)
 
 	t := system.GetTracer()

--- a/pkg/test/devstack/publish_on_error_test.go
+++ b/pkg/test/devstack/publish_on_error_test.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/filecoin-project/bacalhau/pkg/requesternode"
+
 	"github.com/filecoin-project/bacalhau/pkg/computenode"
 	"github.com/filecoin-project/bacalhau/pkg/job"
 	"github.com/filecoin-project/bacalhau/pkg/logger"
@@ -60,6 +62,7 @@ func (s *PublishOnErrorSuite) TestPublishOnError() {
 		0,
 		false,
 		computenode.NewDefaultComputeNodeConfig(),
+		requesternode.NewDefaultRequesterNodeConfig(),
 	)
 
 	t := system.GetTracer()

--- a/pkg/test/devstack/pythonwasm_test.go
+++ b/pkg/test/devstack/pythonwasm_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/filecoin-project/bacalhau/pkg/requesternode"
+
 	"github.com/filecoin-project/bacalhau/pkg/devstack"
 	"github.com/filecoin-project/bacalhau/pkg/logger"
 
@@ -72,7 +74,9 @@ func (s *DevstackPythonWASMSuite) TestPythonWasmVolumes() {
 	fileContents := "pineapples"
 
 	ctx := context.Background()
-	stack, cm := SetupTest(ctx, s.T(), nodeCount, 0, false, computenode.NewDefaultComputeNodeConfig())
+	stack, cm := SetupTest(ctx, s.T(), nodeCount, 0, false,
+		computenode.NewDefaultComputeNodeConfig(),
+		requesternode.NewDefaultRequesterNodeConfig())
 
 	t := system.GetTracer()
 	ctx, rootSpan := system.NewRootSpan(ctx, t, "pkg/test/devstack.TestPythonWasmVolumes")
@@ -170,7 +174,9 @@ func (s *DevstackPythonWASMSuite) TestSimplestPythonWasmDashC() {
 	s.T().Skip("This test fails when run directly after TestPythonWasmVolumes :-(")
 
 	ctx := context.Background()
-	stack, cm := SetupTest(ctx, s.T(), 1, 0, false, computenode.NewDefaultComputeNodeConfig())
+	stack, cm := SetupTest(ctx, s.T(), 1, 0, false,
+		computenode.NewDefaultComputeNodeConfig(),
+		requesternode.NewDefaultRequesterNodeConfig())
 
 	t := system.GetTracer()
 	ctx, rootSpan := system.NewRootSpan(ctx, t, "pkg/test/devstack/pythonwasmtest/simplestpythonwasmdashc")
@@ -209,7 +215,9 @@ func (s *DevstackPythonWASMSuite) TestSimplePythonWasm() {
 	s.T().Skip("This test fails when run directly after TestPythonWasmVolumes :-(")
 
 	ctx := context.Background()
-	stack, cm := SetupTest(ctx, s.T(), 1, 0, false, computenode.NewDefaultComputeNodeConfig())
+	stack, cm := SetupTest(ctx, s.T(), 1, 0, false,
+		computenode.NewDefaultComputeNodeConfig(),
+		requesternode.NewDefaultRequesterNodeConfig())
 
 	t := system.GetTracer()
 	ctx, rootSpan := system.NewRootSpan(ctx, t, "pkg/test/devstack/pythonwasmtest/simplepythonwasm")

--- a/pkg/test/devstack/sharding_test.go
+++ b/pkg/test/devstack/sharding_test.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/filecoin-project/bacalhau/pkg/requesternode"
+
 	"github.com/filecoin-project/bacalhau/pkg/computenode"
 	"github.com/filecoin-project/bacalhau/pkg/devstack"
 	"github.com/filecoin-project/bacalhau/pkg/ipfs"
@@ -159,6 +161,7 @@ func (suite *ShardingSuite) TestEndToEnd() {
 		0,
 		false,
 		computenode.NewDefaultComputeNodeConfig(),
+		requesternode.NewDefaultRequesterNodeConfig(),
 	)
 
 	t := system.GetTracer()
@@ -308,6 +311,7 @@ func (suite *ShardingSuite) TestNoShards() {
 		0,
 		false,
 		computenode.NewDefaultComputeNodeConfig(),
+		requesternode.NewDefaultRequesterNodeConfig(),
 	)
 
 	t := system.GetTracer()
@@ -371,6 +375,7 @@ func (suite *ShardingSuite) TestExplodeVideos() {
 		0,
 		false,
 		computenode.NewDefaultComputeNodeConfig(),
+		requesternode.NewDefaultRequesterNodeConfig(),
 	)
 
 	t := system.GetTracer()

--- a/pkg/test/devstack/submit_test.go
+++ b/pkg/test/devstack/submit_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/filecoin-project/bacalhau/pkg/requesternode"
+
 	"github.com/filecoin-project/bacalhau/pkg/computenode"
 	"github.com/filecoin-project/bacalhau/pkg/logger"
 	_ "github.com/filecoin-project/bacalhau/pkg/logger"
@@ -54,6 +56,7 @@ func (suite *DevstackSubmitSuite) TestEmptySpec() {
 		0,
 		false,
 		computenode.NewDefaultComputeNodeConfig(),
+		requesternode.NewDefaultRequesterNodeConfig(),
 	)
 
 	t := system.GetTracer()

--- a/pkg/test/devstack/timeout_test.go
+++ b/pkg/test/devstack/timeout_test.go
@@ -1,0 +1,256 @@
+package devstack
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/filecoin-project/bacalhau/pkg/requesternode"
+
+	"github.com/filecoin-project/bacalhau/pkg/logger"
+
+	"github.com/filecoin-project/bacalhau/pkg/computenode"
+	"github.com/filecoin-project/bacalhau/pkg/job"
+	_ "github.com/filecoin-project/bacalhau/pkg/logger"
+	"github.com/filecoin-project/bacalhau/pkg/model"
+	"github.com/filecoin-project/bacalhau/pkg/publicapi"
+	"github.com/filecoin-project/bacalhau/pkg/system"
+	"github.com/filecoin-project/bacalhau/pkg/test/scenario"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type DevstackComputeTimeoutSuite struct {
+	suite.Suite
+}
+
+// In order for 'go test' to run this suite, we need to create
+// a normal test function and pass our suite to suite.Run
+func TestDevstackComputeTimeoutSuite(t *testing.T) {
+	suite.Run(t, new(DevstackComputeTimeoutSuite))
+}
+
+// Before all suite
+func (suite *DevstackComputeTimeoutSuite) SetupSuite() {
+
+}
+
+// Before each test
+func (suite *DevstackComputeTimeoutSuite) SetupTest() {
+	logger.ConfigureTestLogging(suite.T())
+	err := system.InitConfigForTesting()
+	require.NoError(suite.T(), err)
+}
+
+func (suite *DevstackComputeTimeoutSuite) TearDownTest() {
+
+}
+
+func (suite *DevstackComputeTimeoutSuite) TearDownSuite() {
+
+}
+
+func (suite *DevstackComputeTimeoutSuite) TestRunningTimeout() {
+
+	type TestCase struct {
+		name                   string
+		nodeCount              int
+		minBids                int
+		concurrency            int
+		computeTimeoutConfig   computenode.ComputeTimeoutConfig
+		requesterTimeoutConfig requesternode.RequesterTimeoutConfig
+		jobTimeout             float64
+		sleepSeconds           float32
+		completedCount         int
+		errorCount             int
+	}
+
+	runTest := func(testCase TestCase) {
+		ctx := context.Background()
+
+		cm := system.NewCleanupManager()
+		defer cm.Cleanup()
+
+		stack, cm := SetupTest(ctx, suite.T(), testCase.nodeCount, 0, false,
+			computenode.ComputeNodeConfig{
+				TimeoutConfig:                      testCase.computeTimeoutConfig,
+				StateManagerBackgroundTaskInterval: 1 * time.Second,
+			},
+			requesternode.RequesterNodeConfig{
+				TimeoutConfig:                      testCase.requesterTimeoutConfig,
+				StateManagerBackgroundTaskInterval: 1 * time.Second,
+			})
+
+		testScenario := scenario.Sleep(testCase.sleepSeconds)
+
+		j := &model.Job{}
+		j.Spec = testScenario.GetJobSpec()
+		j.Spec.Verifier = model.VerifierNoop
+		j.Spec.Publisher = model.PublisherNoop
+		j.Spec.Timeout = testCase.jobTimeout
+		j.Deal = model.Deal{
+			Concurrency: testCase.concurrency,
+			MinBids:     testCase.minBids,
+		}
+
+		apiUri := stack.Nodes[0].APIServer.GetURI()
+		apiClient := publicapi.NewAPIClient(apiUri)
+
+		submittedJob, err := apiClient.Submit(ctx, j, nil)
+		require.NoError(suite.T(), err)
+
+		resolver := apiClient.GetJobStateResolver()
+
+		err = resolver.Wait(
+			ctx,
+			submittedJob.ID,
+			testCase.nodeCount,
+			job.WaitForJobStates(map[model.JobStateType]int{
+				model.JobStateCompleted: testCase.completedCount,
+				model.JobStateError:     testCase.errorCount,
+			}),
+		)
+		require.NoError(suite.T(), err)
+	}
+
+	for _, testCase := range []TestCase{
+		{
+			name: "sleep_within_default_timeout",
+			computeTimeoutConfig: computenode.ComputeTimeoutConfig{
+				StateTransitionTimeout: 10 * time.Second,
+				MinJobExecutionTimeout: 0 * time.Nanosecond,
+				MaxJobExecutionTimeout: 1 * time.Minute},
+			requesterTimeoutConfig: requesternode.RequesterTimeoutConfig{
+				StateTransitionTimeout:     10 * time.Second,
+				DefaultJobExecutionTimeout: 10 * time.Second,
+				MinJobExecutionTimeout:     1 * time.Nanosecond},
+			nodeCount:      1,
+			minBids:        1,
+			concurrency:    1,
+			sleepSeconds:   0.1,
+			completedCount: 1,
+		},
+		{
+			name: "sleep_within_defined_timeout",
+			computeTimeoutConfig: computenode.ComputeTimeoutConfig{
+				StateTransitionTimeout: 10 * time.Second,
+				MinJobExecutionTimeout: 0 * time.Nanosecond,
+				MaxJobExecutionTimeout: 1 * time.Minute},
+			requesterTimeoutConfig: requesternode.RequesterTimeoutConfig{
+				StateTransitionTimeout:     10 * time.Second,
+				DefaultJobExecutionTimeout: 20 * time.Second,
+				MinJobExecutionTimeout:     1 * time.Nanosecond},
+			nodeCount:      1,
+			minBids:        1,
+			concurrency:    1,
+			jobTimeout:     10,
+			sleepSeconds:   0.1,
+			completedCount: 1,
+		},
+		{
+			name: "sleep_longer_than_default_running_timeout",
+			computeTimeoutConfig: computenode.ComputeTimeoutConfig{
+				StateTransitionTimeout: 10 * time.Second,
+				MinJobExecutionTimeout: 0 * time.Nanosecond,
+				MaxJobExecutionTimeout: 1 * time.Minute},
+			requesterTimeoutConfig: requesternode.RequesterTimeoutConfig{
+				StateTransitionTimeout:     10 * time.Second,
+				DefaultJobExecutionTimeout: 1 * time.Millisecond,
+				MinJobExecutionTimeout:     1 * time.Nanosecond},
+			nodeCount:    1,
+			minBids:      1,
+			concurrency:  1,
+			sleepSeconds: 20,
+			errorCount:   1,
+		},
+		{
+			name: "sleep_longer_than_defined_running_timeout",
+			computeTimeoutConfig: computenode.ComputeTimeoutConfig{
+				StateTransitionTimeout: 10 * time.Second,
+				MinJobExecutionTimeout: 0 * time.Nanosecond,
+				MaxJobExecutionTimeout: 1 * time.Minute},
+			requesterTimeoutConfig: requesternode.RequesterTimeoutConfig{
+				StateTransitionTimeout:     10 * time.Second,
+				DefaultJobExecutionTimeout: 40 * time.Second,
+				MinJobExecutionTimeout:     1 * time.Nanosecond},
+			nodeCount:    1,
+			minBids:      1,
+			concurrency:  1,
+			sleepSeconds: 20,
+			jobTimeout:   0.001, // 1 millisecond
+			errorCount:   1,
+		},
+		{
+			// no bid will be submitted, so the requester node should timeout
+			name: "job_timeout_longer_than_max_running_timeout",
+			computeTimeoutConfig: computenode.ComputeTimeoutConfig{
+				StateTransitionTimeout: 10 * time.Second,
+				MinJobExecutionTimeout: 0 * time.Nanosecond,
+				MaxJobExecutionTimeout: 1 * time.Minute},
+			requesterTimeoutConfig: requesternode.RequesterTimeoutConfig{
+				StateTransitionTimeout:     500 * time.Millisecond,
+				DefaultJobExecutionTimeout: 40 * time.Second,
+				MinJobExecutionTimeout:     0 * time.Nanosecond},
+			nodeCount:    1,
+			minBids:      1,
+			concurrency:  1,
+			sleepSeconds: 20,
+			jobTimeout:   120, // 2 minutes
+			errorCount:   1,
+		},
+		{
+			// no bid will be submitted, so the requester node should timeout
+			name: "job_timeout_less_than_min_running_timeout",
+			computeTimeoutConfig: computenode.ComputeTimeoutConfig{
+				StateTransitionTimeout: 10 * time.Second,
+				MinJobExecutionTimeout: 5 * time.Minute,
+				MaxJobExecutionTimeout: 10 * time.Minute},
+			requesterTimeoutConfig: requesternode.RequesterTimeoutConfig{
+				StateTransitionTimeout:     500 * time.Millisecond,
+				DefaultJobExecutionTimeout: 40 * time.Second,
+				MinJobExecutionTimeout:     0 * time.Nanosecond},
+			nodeCount:    1,
+			minBids:      1,
+			concurrency:  1,
+			sleepSeconds: 20,
+			jobTimeout:   120, // 2 minutes
+			errorCount:   1,
+		},
+		{
+			name: "bid_timeout",
+			computeTimeoutConfig: computenode.ComputeTimeoutConfig{
+				StateTransitionTimeout: 200 * time.Millisecond,
+				MinJobExecutionTimeout: 0 * time.Nanosecond,
+				MaxJobExecutionTimeout: 1 * time.Minute},
+			requesterTimeoutConfig: requesternode.RequesterTimeoutConfig{
+				StateTransitionTimeout:     10 * time.Second,
+				DefaultJobExecutionTimeout: 40 * time.Second,
+				MinJobExecutionTimeout:     0 * time.Nanosecond},
+			nodeCount:    1, // only one node is available
+			minBids:      2, // but we need two bids, so compute node should timeout while waiting for its bid to be accepted
+			concurrency:  1,
+			sleepSeconds: 0.1,
+			errorCount:   1,
+		},
+		{
+			name: "verification_timeout",
+			computeTimeoutConfig: computenode.ComputeTimeoutConfig{
+				StateTransitionTimeout: 10 * time.Second,
+				MinJobExecutionTimeout: 0 * time.Nanosecond,
+				MaxJobExecutionTimeout: 1 * time.Minute},
+			requesterTimeoutConfig: requesternode.RequesterTimeoutConfig{
+				StateTransitionTimeout:     200 * time.Millisecond,
+				DefaultJobExecutionTimeout: 40 * time.Second,
+				MinJobExecutionTimeout:     0 * time.Nanosecond},
+			nodeCount:    1, // only one node available
+			minBids:      1,
+			concurrency:  2, // but concurrency is 2, so requester should timeout on verification
+			sleepSeconds: 0.1,
+			errorCount:   1,
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			runTest(testCase)
+		})
+	}
+}

--- a/pkg/test/devstack/utils.go
+++ b/pkg/test/devstack/utils.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/filecoin-project/bacalhau/pkg/requesternode"
+
 	"github.com/filecoin-project/bacalhau/pkg/computenode"
 	"github.com/filecoin-project/bacalhau/pkg/devstack"
 	"github.com/filecoin-project/bacalhau/pkg/executor"
@@ -28,7 +30,8 @@ func SetupTest(
 	nodes int, badActors int,
 	lotusNode bool,
 	//nolint:gocritic
-	config computenode.ComputeNodeConfig,
+	computeNodeConfig computenode.ComputeNodeConfig,
+	requesterNodeConfig requesternode.RequesterNodeConfig,
 ) (*devstack.DevStack, *system.CleanupManager) {
 	require.NoError(t, system.InitConfigForTesting())
 
@@ -40,7 +43,7 @@ func SetupTest(
 		LocalNetworkLotus: lotusNode,
 	}
 
-	stack, err := devstack.NewStandardDevStack(ctx, cm, options, config)
+	stack, err := devstack.NewStandardDevStack(ctx, cm, options, computeNodeConfig, requesterNodeConfig)
 	require.NoError(t, err)
 
 	t.Cleanup(cm.Cleanup)
@@ -209,6 +212,7 @@ func RunDeterministicVerifierTest( //nolint:funlen
 		cm,
 		options,
 		computenode.NewDefaultComputeNodeConfig(),
+		requesternode.NewDefaultRequesterNodeConfig(),
 		injector,
 	)
 	require.NoError(t, err)

--- a/pkg/test/scenario/test_scenarios.go
+++ b/pkg/test/scenario/test_scenarios.go
@@ -2,6 +2,7 @@ package scenario
 
 import (
 	"context"
+	"fmt"
 
 	_ "github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/model"
@@ -12,6 +13,26 @@ const SimpleMountPath = "/data/file.txt"
 const SimpleOutputPath = "/output_data/output_file.txt"
 const stdoutString = "stdout"
 const CatProgram = "cat " + SimpleMountPath + " > " + SimpleOutputPath
+
+func Sleep(sleepSeconds float32) TestCase {
+	sleepSecondsStr := fmt.Sprintf("%.3f", sleepSeconds)
+
+	return TestCase{
+		Name: "sleep_" + sleepSecondsStr + "_seconds",
+		GetJobSpec: func() model.Spec {
+			return model.Spec{
+				Engine: model.EngineDocker,
+				Docker: model.JobSpecDocker{
+					Image: "ubuntu:latest",
+					Entrypoint: []string{
+						"sleep",
+						sleepSecondsStr,
+					},
+				},
+			}
+		},
+	}
+}
 
 func CatFileToStdout() TestCase {
 	ctx := context.Background()

--- a/pkg/test/transport/transport_test.go
+++ b/pkg/test/transport/transport_test.go
@@ -66,7 +66,7 @@ func setupTest(t *testing.T) *node.Node {
 		LocalDB:             datastore,
 		Transport:           transport,
 		ComputeNodeConfig:   computenode.NewDefaultComputeNodeConfig(),
-		RequesterNodeConfig: requesternode.RequesterNodeConfig{},
+		RequesterNodeConfig: requesternode.NewDefaultRequesterNodeConfig(),
 	}
 
 	node, err := devstack.NewNoopNode(ctx, nodeConfig)

--- a/pkg/test/utils/stack.go
+++ b/pkg/test/utils/stack.go
@@ -67,7 +67,7 @@ func NewDevStackMultiNode(
 		LocalDB:             datastore,
 		Transport:           transport,
 		ComputeNodeConfig:   computeNodeConfig,
-		RequesterNodeConfig: requesternode.RequesterNodeConfig{},
+		RequesterNodeConfig: requesternode.NewDefaultRequesterNodeConfig(),
 	}
 
 	injector := node.NewStandardNodeDependencyInjector()
@@ -124,7 +124,7 @@ func NewNoopStack(
 		LocalDB:             datastore,
 		Transport:           transport,
 		ComputeNodeConfig:   computeNodeconfig,
-		RequesterNodeConfig: requesternode.RequesterNodeConfig{},
+		RequesterNodeConfig: requesternode.NewDefaultRequesterNodeConfig(),
 	}
 
 	injector := devstack.NewNoopNodeDependencyInjector()
@@ -168,7 +168,7 @@ func NewNoopStackMultinode(
 			LocalDB:             datastore,
 			Transport:           transport,
 			ComputeNodeConfig:   computeNodeconfig,
-			RequesterNodeConfig: requesternode.RequesterNodeConfig{},
+			RequesterNodeConfig: requesternode.NewDefaultRequesterNodeConfig(),
 		}
 
 		injector := devstack.NewNoopNodeDependencyInjector()


### PR DESCRIPTION
Jobs can define a timeout value in which the execution will be terminated if it takes too long. In addition to that:
1. Requester nodes now define a default timeout value in which submitted jobs without a configued timeout value will be assigned a default one
1. Compute nodes now define min and max timeout values, and will only bid on jobs with timeout values within their accepted range
1. Both requester and compute nodes define a state transition timeout, in which a job stuck in a non-running state (e.g. bidding) will be terminated if it doesn't make progress