### PR TITLE
add --timeout cli option

### DIFF
--- a/cmd/bacalhau/docker_run.go
+++ b/cmd/bacalhau/docker_run.go
@@ -61,6 +61,7 @@ type DockerRunOptions struct {
 	Concurrency      int      // Number of concurrent jobs to run
 	Confidence       int      // Minimum number of nodes that must agree on a verification result
 	MinBids          int      // Minimum number of bids before they will be accepted (at random)
+	Timeout          float64  // Job execution timeout in seconds
 	CPU              string
 	Memory           string
 	GPU              string
@@ -96,6 +97,7 @@ func NewDockerRunOptions() *DockerRunOptions {
 		Concurrency:        1,
 		Confidence:         0,
 		MinBids:            0, // 0 means no minimum before bidding
+		Timeout:            DefaultTimeout.Seconds(),
 		CPU:                "",
 		Memory:             "",
 		GPU:                "",
@@ -162,6 +164,10 @@ func init() { //nolint:gochecknoinits,funlen // Using init in cobra command is i
 	dockerRunCmd.PersistentFlags().IntVar(
 		&ODR.MinBids, "min-bids", ODR.MinBids,
 		`Minimum number of bids that must be received before concurrency-many bids will be accepted (at random)`,
+	)
+	dockerRunCmd.PersistentFlags().Float64Var(
+		&ODR.Timeout, "timeout", ODR.Timeout,
+		`Job execution timeout in seconds (e.g. 300 for 5 minutes and 0.1 for 100ms)`,
 	)
 	dockerRunCmd.PersistentFlags().StringVar(
 		&ODR.CPU, "cpu", ODR.CPU,
@@ -348,6 +354,7 @@ func CreateJob(ctx context.Context,
 		odr.Concurrency,
 		odr.Confidence,
 		odr.MinBids,
+		odr.Timeout,
 		odr.Labels,
 		odr.WorkingDirectory,
 		odr.ShardingGlobPattern,

--- a/cmd/bacalhau/run_python.go
+++ b/cmd/bacalhau/run_python.go
@@ -36,6 +36,7 @@ type LanguageRunOptions struct {
 	Concurrency   int      // Number of concurrent jobs to run
 	Confidence    int      // Minimum number of nodes that must agree on a verification result
 	MinBids       int      // Minimum number of bids that must be received before any are accepted (at random)
+	Timeout       float64  // Job execution timeout in seconds
 	Labels        []string // Labels for the job on the Bacalhau network (for searching)
 
 	Command          string // Command to execute
@@ -65,6 +66,8 @@ func NewLanguageRunOptions() *LanguageRunOptions {
 		Env:              []string{},
 		Concurrency:      1,
 		Confidence:       0,
+		MinBids:          0, // 0 means no minimum before bidding
+		Timeout:          DefaultTimeout.Seconds(),
 		Labels:           []string{},
 		Command:          "",
 		RequirementsPath: "",
@@ -110,6 +113,14 @@ func init() {
 	runPythonCmd.PersistentFlags().IntVar(
 		&OLR.Confidence, "confidence", OLR.Confidence,
 		`The minimum number of nodes that must agree on a verification result`,
+	)
+	runPythonCmd.PersistentFlags().IntVar(
+		&OLR.MinBids, "min-bids", OLR.MinBids,
+		`Minimum number of bids that must be received before concurrency-many bids will be accepted (at random)`,
+	)
+	runPythonCmd.PersistentFlags().Float64Var(
+		&OLR.Timeout, "timeout", OLR.Timeout,
+		`Job execution timeout in seconds (e.g. 300 for 5 minutes and 0.1 for 100ms)`,
 	)
 	runPythonCmd.PersistentFlags().StringVarP(
 		&OLR.Command, "command", "c", OLR.Command,
@@ -195,6 +206,7 @@ var runPythonCmd = &cobra.Command{
 			OLR.Concurrency,
 			OLR.Confidence,
 			OLR.MinBids,
+			OLR.Timeout,
 			language,
 			version,
 			OLR.Command,

--- a/cmd/bacalhau/utils.go
+++ b/cmd/bacalhau/utils.go
@@ -16,6 +16,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/filecoin-project/bacalhau/pkg/requesternode"
+
 	"github.com/Masterminds/semver"
 	"github.com/filecoin-project/bacalhau/pkg/bacerrors"
 	"github.com/filecoin-project/bacalhau/pkg/devstack"
@@ -37,7 +39,8 @@ const (
 	DefaultDockerRunWaitSeconds               = 600
 	PrintoutCanceledButRunningNormally string = "printout canceled but running normally"
 	// what permissions do we give to a folder we create when downloading results
-	AutoDownloadFolderPerm = 0755
+	AutoDownloadFolderPerm               = 0755
+	DefaultTimeout         time.Duration = requesternode.DefaultJobExecutionTimeout
 )
 
 var eventsWorthPrinting = map[model.JobEventType]eventStruct{
@@ -388,7 +391,8 @@ func ExecuteJob(ctx context.Context,
 		printOut += fmt.Sprintf("Node %s:\n", nodeIndexes[i][:8])
 		for j, s := range n.Shards { //nolint:gocritic // very small loop, ok to be costly
 			printOut += fmt.Sprintf(indentOne+"Shard %d:\n", j)
-			printOut += fmt.Sprintf(indentTwo+"Status: %s\n", s.State)
+			printOut += fmt.Sprintf(indentTwo+"State: %s\n", s.State)
+			printOut += fmt.Sprintf(indentTwo+"Status: %s\n", s.Status)
 			if s.RunOutput == nil {
 				printOut += fmt.Sprintf(indentTwo + "No RunOutput for this shard\n")
 			} else {

--- a/cmd/bacalhau/wasm_run.go
+++ b/cmd/bacalhau/wasm_run.go
@@ -31,6 +31,7 @@ func init() { //nolint:gochecknoinits // idiomatic for cobra commands
 	wasmJob, _ = model.NewJobWithSaneProductionDefaults()
 	wasmJob.Spec.Engine = model.EngineWasm
 	wasmJob.Spec.Verifier = model.VerifierDeterministic
+	wasmJob.Spec.Timeout = DefaultTimeout.Seconds()
 	wasmJob.Spec.Wasm.EntryPoint = "_start"
 	wasmJob.Spec.Wasm.EnvironmentVariables = map[string]string{}
 	wasmJob.Spec.Outputs = []model.StorageSpec{
@@ -68,6 +69,14 @@ func init() { //nolint:gochecknoinits // idiomatic for cobra commands
 	runWasmCommand.PersistentFlags().IntVar(
 		&wasmJob.Deal.Confidence, "confidence", wasmJob.Deal.Confidence,
 		`The minimum number of nodes that must agree on a verification result`,
+	)
+	runWasmCommand.PersistentFlags().IntVar(
+		&wasmJob.Deal.MinBids, "min-bids", wasmJob.Deal.MinBids,
+		`Minimum number of bids that must be received before concurrency-many bids will be accepted (at random)`,
+	)
+	runWasmCommand.PersistentFlags().Float64Var(
+		&wasmJob.Spec.Timeout, "timeout", wasmJob.Spec.Timeout,
+		`Job execution timeout in seconds (e.g. 300 for 5 minutes and 0.1 for 100ms)`,
 	)
 	wasmCmd.PersistentFlags().StringVar(
 		&wasmJob.Spec.Wasm.EntryPoint, "entry-point", wasmJob.Spec.Wasm.EntryPoint,

--- a/pkg/job/factory.go
+++ b/pkg/job/factory.go
@@ -46,6 +46,7 @@ func ConstructDockerJob( //nolint:funlen
 	concurrency int,
 	confidence int,
 	minBids int,
+	timeout float64,
 	annotations []string,
 	workingDir string,
 	shardingGlobPattern string,
@@ -117,7 +118,7 @@ func ConstructDockerJob( //nolint:funlen
 			Entrypoint:           entrypoint,
 			EnvironmentVariables: env,
 		},
-
+		Timeout:     timeout,
 		Resources:   jobResources,
 		Inputs:      jobInputs,
 		Contexts:    jobContexts,
@@ -149,6 +150,7 @@ func ConstructLanguageJob(
 	concurrency int,
 	confidence int,
 	minBids int,
+	timeout float64,
 	// See JobSpecLanguage
 	language string,
 	languageVersion string,
@@ -203,6 +205,7 @@ func ConstructLanguageJob(
 		ProgramPath:      programPath,
 		RequirementsPath: requirementsPath,
 	}
+	j.Spec.Timeout = timeout
 	j.Spec.Inputs = jobInputs
 	j.Spec.Contexts = jobContexts
 	j.Spec.Outputs = jobOutputs
@@ -212,6 +215,7 @@ func ConstructLanguageJob(
 	j.Deal = model.Deal{
 		Concurrency: concurrency,
 		Confidence:  confidence,
+		MinBids:     minBids,
 	}
 
 	return j, err

--- a/pkg/job/factory_test.go
+++ b/pkg/job/factory_test.go
@@ -94,6 +94,7 @@ func (suite *JobFactorySuite) TestRun_Outputs() {
 					1,          // concurrency
 					0,          // confidence
 					0,          // min bids
+					300,        // timeout
 					[]string{}, // annotations
 					"",         // working dir
 					"",         // sharding base path


### PR DESCRIPTION
### Example with 2s timeout:
```
→ bacalhau_local docker run --timeout 2 ubuntu sleep 20
Job successfully submitted. Job ID: f8dbe34c-d482-4845-82bb-7f8c623584ff
Checking job status... (Enter Ctrl+C to exit at any time, your job will continue running):

	       Creating job for submission ... done ✅
	       Finding node(s) for the job ... done ✅
	             Node accepted the job ... done ✅
	   Error while executing the job.

Job Results By Node:
Node QmevXg76:
  Shard 0:
    State: Error
    Status: errorState: error completing job due to: shard timed out while in state Running
    Container Exit Code: 137
    Stdout: <NONE>
    Stderr: <NONE>
Node Qmf6xGXC:
  Shard 0:
    State: Error
    Status: [Qmf6xGXC] shard: f8dbe34c-d482-4845-82bb-7f8c623584ff:0 at state: Error error completing job due to shard timed out while in state WaitingForResults
    No RunOutput for this shard

To download the results, execute:
  bacalhau get f8dbe34c-d482-4845-82bb-7f8c623584ff

To get more details about the run, execute:
  bacalhau describe f8dbe34c-d482-4845-82bb-7f8c623584ff
```


### Example without defining an explicit timeout, which uses 30 minutes as a default value:
```
→ bacalhau_local docker run  ubuntu sleep 20
Job successfully submitted. Job ID: c5907797-5771-4859-9775-ec94d3bae52c
Checking job status... (Enter Ctrl+C to exit at any time, your job will continue running):

	       Creating job for submission ... done ✅
	       Finding node(s) for the job ... done ✅
	             Node accepted the job ... done ✅
	   Job finished, verifying results ... done ✅
	      Results accepted, publishing ... Results CID: QmWUXBndMuq2G6B6ndQCmkRHjZ6CvyJ8qLxXBG3YsSFzQG
Job Results By Node:
Node Qmf6xGXC:
  Shard 0:
    State: Completed
    Status: Got results proposal of length: 0
    Container Exit Code: 0
    Stdout: <NONE>
    Stderr: <NONE>

To download the results, execute:
  bacalhau get c5907797-5771-4859-9775-ec94d3bae52c

To get more details about the run, execute:
  bacalhau describe c5907797-5771-4859-9775-ec94d3bae52c
```