### PR TITLE
Issue 880: Load WASM import modules from IPFS

### DIFF
--- a/cmd/bacalhau/wasm_run.go
+++ b/cmd/bacalhau/wasm_run.go
@@ -97,6 +97,16 @@ func init() { //nolint:gochecknoinits // idiomatic for cobra commands
 		EnvVarMapFlag(&wasmJob.Spec.Wasm.EnvironmentVariables), "env", "e",
 		`The environment variables to supply to the job (e.g. --env FOO=bar --env BAR=baz)`,
 	)
+	runWasmCommand.PersistentFlags().VarP(
+		NewURLStorageSpecArrayFlag(&wasmJob.Spec.Wasm.ImportModules), "import-module-urls", "mu",
+		`URL of the WASM modules to import from a URL source. Mounts data at '/inputs' (e.g. '-u http://foo.com/bar.tar.gz'
+		mounts 'bar.tar.gz' at '/inputs/bar.tar.gz'). URL accept any valid URL supported by the 'wget' command,
+		and supports both HTTP and HTTPS.`,
+	)
+	runWasmCommand.PersistentFlags().VarP(
+		NewIPFSStorageSpecArrayFlag(&wasmJob.Spec.Wasm.ImportModules), "import-module-volumes", "mv",
+		`CID:path of the WASM modules to import from IPFS, if you need to set the path of the mounted data.`,
+	)
 }
 
 var wasmCmd = &cobra.Command{

--- a/pkg/executor/wasm/executor.go
+++ b/pkg/executor/wasm/executor.go
@@ -234,7 +234,6 @@ func (e *Executor) RunShard(
 
 	// Load imported modules
 	for _, value := range wasmSpec.ImportModules {
-
 		log.Ctx(ctx).Info().Msgf("Load imported module '%s' for job '%s'", value.Name, shard.Job.ID)
 		importedWasi, err := e.loadRemoteModule(ctx, value)
 		if err != nil {
@@ -272,8 +271,9 @@ func (e *Executor) RunShard(
 		return failResult(err)
 	}
 
-	// Check that it conforms to our requirements.
-	err = ValidateModuleAgainstJob(module, shard.Job.Spec, wasi)
+	// Check that all WASI modules conform to our requirements.
+	importedModules = append(importedModules, wasi)
+	err = ValidateModuleAgainstJob(module, shard.Job.Spec, importedModules...)
 	if err != nil {
 		return failResult(err)
 	}

--- a/pkg/model/job.go
+++ b/pkg/model/job.go
@@ -287,7 +287,7 @@ type JobSpecWasm struct {
 
 	// TODO #880: Other WASM modules whose exports will be available as imports
 	// to the EntryModule.
-	// ImportModules []StorageSpec `json:"ImportModules,omitempty"`
+	ImportModules []StorageSpec `json:"ImportModules,omitempty"`
 }
 
 // gives us a way to keep local data against a job


### PR DESCRIPTION
Modified wasm_run.go, executor.go and job.go to enable WASM modules import in the executor as per issue 880.