### PR TITLE
Load WASM import modules from IPFS (#880)

### DIFF
--- a/cmd/bacalhau/wasm_run.go
+++ b/cmd/bacalhau/wasm_run.go
@@ -97,6 +97,15 @@ func init() { //nolint:gochecknoinits // idiomatic for cobra commands
 		EnvVarMapFlag(&wasmJob.Spec.Wasm.EnvironmentVariables), "env", "e",
 		`The environment variables to supply to the job (e.g. --env FOO=bar --env BAR=baz)`,
 	)
+	runWasmCommand.PersistentFlags().VarP(
+		NewURLStorageSpecArrayFlag(&wasmJob.Spec.Wasm.ImportModules), "import-module-urls", "U",
+		`URL of the WASM modules to import from a URL source. URL accept any valid URL supported by `+
+			`the 'wget' command, and supports both HTTP and HTTPS.`,
+	)
+	runWasmCommand.PersistentFlags().VarP(
+		NewIPFSStorageSpecArrayFlag(&wasmJob.Spec.Wasm.ImportModules), "import-module-volumes", "I",
+		`CID:path of the WASM modules to import from IPFS, if you need to set the path of the mounted data.`,
+	)
 }
 
 var wasmCmd = &cobra.Command{

--- a/pkg/executor/wasm/executor.go
+++ b/pkg/executor/wasm/executor.go
@@ -243,6 +243,23 @@ func (e *Executor) RunShard(
 		config = config.WithEnv(key, wasmSpec.EnvironmentVariables[key])
 	}
 	entryPoint := wasmSpec.EntryPoint
+	importedModules := []wazero.CompiledModule{}
+
+	// Load and instantiate imported modules
+	for _, wasmSpec := range wasmSpec.ImportModules {
+		log.Ctx(ctx).Info().Msgf("Load imported module '%s' for job '%s'", wasmSpec.Name, shard.Job.ID)
+		importedWasi, importErr := e.loadRemoteModule(ctx, wasmSpec)
+		if importErr != nil {
+			return failResult(importErr)
+		}
+		importedModules = append(importedModules, importedWasi)
+
+		log.Ctx(ctx).Info().Msgf("Add imported module '%s' to WASM namespace for job '%s'", importedWasi.Name(), shard.Job.ID)
+		_, instantiateErr := namespace.InstantiateModule(ctx, importedWasi, config)
+		if instantiateErr != nil {
+			return failResult(instantiateErr)
+		}
+	}
 
 	log.Ctx(ctx).Debug().Msgf("Compilation of WASI runtime for job '%s'", shard.Job.ID)
 	wasi, err := wasi_snapshot_preview1.NewBuilder(e.Engine).Compile(ctx)
@@ -264,8 +281,9 @@ func (e *Executor) RunShard(
 		return failResult(err)
 	}
 
-	// Check that it conforms to our requirements.
-	err = ValidateModuleAgainstJob(module, shard.Job.Spec, wasi)
+	// Check that all WASI modules conform to our requirements.
+	importedModules = append(importedModules, wasi)
+	err = ValidateModuleAgainstJob(module, shard.Job.Spec, importedModules...)
 	if err != nil {
 		return failResult(err)
 	}

--- a/pkg/model/job.go
+++ b/pkg/model/job.go
@@ -287,7 +287,7 @@ type JobSpecWasm struct {
 
 	// TODO #880: Other WASM modules whose exports will be available as imports
 	// to the EntryModule.
-	// ImportModules []StorageSpec `json:"ImportModules,omitempty"`
+	ImportModules []StorageSpec `json:"ImportModules,omitempty"`
 }
 
 // gives us a way to keep local data against a job


### PR DESCRIPTION
At the moment our WASM executor can load a single WASM module from IPFS (or anywhere) and execute it. The module has to be self contained i.e. the only imports in can have are the WASI ones.

With this commit we can now load WASM modules from other remote locations too and use them for their exports. This will mean we could e.g. host a Python module on IPFS and then allow user modules to import it and run Python code, or the same thing with SQLite.

The loading is not automatic at this stage – users still need to specify all the import modules in the job spec. The system then downloads and compiles them as it does for the entry module.