### PR TITLE
Improve CI speed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,35 +60,20 @@ jobs:
 
       - when:
           condition:
-            equal: ["darwin", << parameters.target_os >>]
+            or:
+              - equal: ["linux", << parameters.target_os >>]
+              - equal: ["darwin", << parameters.target_os >>]
           steps:
             - run:
                 name: Install golang
                 command: |
-                  export BREW_GO_VERSION=$(echo $GOVER | grep -Eo '^\d\.\d+')
-                  brew install go@${BREW_GO_VERSION}
-                  echo "export PATH='/usr/local/opt/go/bin:$PATH'" >> ~/.bash_profile
-
-      - when:
-          condition:
-            equal: ["linux", << parameters.target_os >>]
-          steps:
-            - run:
-                name: Install golang
-                command: |
-                  sudo rm -fr /usr/local/go
-                  curl --silent --show-error --location --fail https://go.dev/dl/go$GOVER.linux-amd64.tar.gz | sudo tar --extract --gzip --file=- --directory=/usr/local
+                  sudo rm -fr /usr/local/go /usr/local/bin/go
+                  curl --silent --show-error --location --fail https://go.dev/dl/go$GOVER.<< parameters.target_os >>-amd64.tar.gz | sudo tar --extract --gzip --file=- --directory=/usr/local
+                  sudo ln -s /usr/local/go/bin/go /usr/local/bin/go
 
       - run:
-          name: Install IPFS
-          command: |
-            echo "Installing IPFS_VERSION: $IPFS_VERSION"
-            export IPFS_BUILD="$GOOS-$GOARCH"
-            if [ "${GOOS}" = "windows" ]; then export IPFS_EXT=zip; fi
-            if [ "${GOOS}" = "windows" ]; then export EXEC=bash; fi
-            curl -s -L -O "https://dist.ipfs.tech/go-ipfs/${IPFS_VERSION}/go-ipfs_${IPFS_VERSION}_${IPFS_BUILD}.${IPFS_EXT:-tar.gz}"
-            tar -xvzf "go-ipfs_${IPFS_VERSION}_${IPFS_BUILD}.${IPFS_EXT:-tar.gz}"
-            ${EXEC:-sudo bash} ./go-ipfs/install.sh
+          name: Set GOCACHE
+          command: echo "export GOCACHE=$HOME/.cache/go-build" >> $BASH_ENV
 
       - run:
           name: Init tools
@@ -109,8 +94,12 @@ jobs:
             poetry run python --version --version >> pre-commit-cache-key.txt
 
       - restore_cache:
-          keys:
-            - v1-pc-cache-{{ checksum "pre-commit-cache-key.txt" }}
+          name: Restoring pre-commit cache
+          key: v1-pc-cache-{{ checksum "pre-commit-cache-key.txt" }}
+
+      - restore_cache:
+          name: Restoring Go cache
+          key: go-mod-{{ arch }}-{{ checksum "go.sum" }}
 
       - run:
           name: Build
@@ -130,7 +119,7 @@ jobs:
                 command: |
                   export GOBIN=${HOME}/bin
                   export PATH=$GOBIN:$PATH
-                  go install gotest.tools/gotestsum@latest
+                  go install gotest.tools/gotestsum@v1.8.2
                   make test-and-report
                 no_output_timeout: 20m
             - store_test_results:
@@ -187,9 +176,17 @@ jobs:
           path: dist/
 
       - save_cache:
+          name: Saving pre-commit cache
           key: v1-pc-cache-{{ checksum "pre-commit-cache-key.txt" }}
           paths:
             - ~/.cache/pre-commit
+
+      - save_cache:
+          name: Saving Go cache
+          key: go-mod-{{ arch }}-{{ checksum "go.sum" }}
+          paths:
+            - ~/.cache/go-build
+            - ~/go/pkg/mod
 
   build_canary:
     parallelism: 1


### PR DESCRIPTION
* Share the Go cache between builds to avoid having to download and compile the modules everytime.
* Download Go using curl rather than Homebrew
* Don't download IPFS

Fixes #1157