### PR TITLE
Only log container start failure when there was actually a failure

### DIFF
--- a/pkg/executor/docker/executor.go
+++ b/pkg/executor/docker/executor.go
@@ -249,8 +249,8 @@ func (e *Executor) RunShard(
 		jobContainer.ID,
 		dockertypes.ContainerStartOptions{},
 	)
-	log.Ctx(ctx).Err(err).Msg("Failed to start container")
 	if containerStartError != nil {
+		log.Ctx(ctx).Err(err).Msg("Failed to start container")
 		// Special error to alert people about bad executable
 		internalContainerStartErrorMsg := "failed to start container: "
 		if strings.Contains(containerStartError.Error(), "executable file not found") {


### PR DESCRIPTION
Move 'failed to start container' log line to only happen when the container did indeed fail to start