### PR TITLE
Avoid common test flake of IPFS failing to start

### DIFF
--- a/pkg/devstack/devstack_ipfs.go
+++ b/pkg/devstack/devstack_ipfs.go
@@ -14,9 +14,9 @@ type DevStackIPFS struct {
 	CleanupManager *system.CleanupManager
 }
 
-// A devstack but with only IPFS servers connected to each other
+// NewDevStackIPFS creates a devstack but with only IPFS servers connected to each other
 func NewDevStackIPFS(ctx context.Context, cm *system.CleanupManager, count int) (*DevStackIPFS, error) {
-	clients := []*ipfs.Client{}
+	var clients []*ipfs.Client
 	for i := 0; i < count; i++ {
 		log.Debug().Msgf(`Creating Node #%d`, i)
 

--- a/pkg/ipfs/address_in_use_other.go
+++ b/pkg/ipfs/address_in_use_other.go
@@ -1,0 +1,9 @@
+//go:build !unix
+
+package ipfs
+
+import (
+	"errors"
+)
+
+var addressInUseError = errors.New("unsure what error other OSes give for this so have an error which won't match anything")

--- a/pkg/ipfs/address_in_use_unix.go
+++ b/pkg/ipfs/address_in_use_unix.go
@@ -1,0 +1,7 @@
+//go:build unix
+
+package ipfs
+
+import "syscall"
+
+var addressInUseError = syscall.EADDRINUSE


### PR DESCRIPTION
A common test failure is to do with attempting to start up the devstack but failing with an error saying `failed to create ipfs node` due to `bind: address already in use`.

This error occurs because IPFS must be told which ports it is going to be used before the listener on that port can be started. This introduces a significant time delay after discovering a free port which allows other processes to start using that port.