### PR TITLE
Test Go packages in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@
 version: 2.1
 
 executors:
+  # Available resource classes - https://circleci.com/product/features/resource-classes/
   linux-amd64:
     machine:
       image: ubuntu-2204:2022.07.1
@@ -144,6 +145,7 @@ jobs:
                 environment:
                   LOG_LEVEL: debug
                   TEST_BUILD_TAGS: << parameters.build_tags >>
+                  TEST_PARALLEL_PACKAGES: 4 # This is set to 4 as xlarge instances have at least 8 CPUs, and we want to leave some CPU for the Docker instances
                 command: |
                   export GOBIN=${HOME}/bin
                   export PATH=$GOBIN:$PATH

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ BUILDDATE ?= $(eval BUILDDATE := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ'))$(BUILDD
 PACKAGE := $(shell echo "bacalhau_$(TAG)_${GOOS}_$(GOARCH)")
 PRECOMMIT_HOOKS_INSTALLED ?= $(shell grep -R "pre-commit.com" .git/hooks)
 TEST_BUILD_TAGS ?= unit,integration
+TEST_PARALLEL_PACKAGES ?= 1
 
 PRIVATE_KEY_FILE := /tmp/private.pem
 PUBLIC_KEY_FILE := /tmp/public.pem
@@ -298,7 +299,7 @@ ${COVER_FILE} unittests.xml ${TEST_OUTPUT_FILE_PREFIX}_unit.json: ${BINARY_PATH}
 		--junitfile unittests.xml \
 		--format standard-quiet \
 		-- \
-			-p 1 \
+			-p ${TEST_PARALLEL_PACKAGES} \
 			./pkg/... ./cmd/... \
 			-coverpkg=./... -coverprofile=${COVER_FILE} \
 			--tags=${TEST_BUILD_TAGS}


### PR DESCRIPTION
Reduce the CI time by testing Go packages in parallel. All CI instances have at least 8 CPUs (Windows has 16), so we set the number of parallel packages to _less_ than the number of CPUs to ensure that there's capacity to run additional Docker containers, devstacks, etc.

Also fix a test flake where APIServer was able to log _after_ the test as finished.

Fixes #1034 #1274