### PR TITLE
Websockets

### DIFF
--- a/cmd/bacalhau/create_test.go
+++ b/cmd/bacalhau/create_test.go
@@ -51,7 +51,7 @@ func (s *CreateSuite) TestCreateJSON_GenericSubmit() {
 	for i, tc := range tests {
 		func() {
 			ctx := context.Background()
-			c, cm := publicapi.SetupRequesterNodeForTests(s.T())
+			c, cm := publicapi.SetupRequesterNodeForTests(s.T(), false)
 			defer cm.Cleanup()
 
 			*OC = *NewCreateOptions()
@@ -94,7 +94,7 @@ func (s *CreateSuite) TestCreateYAML_GenericSubmit() {
 		for _, testFile := range testFiles {
 			func() {
 				ctx := context.Background()
-				c, cm := publicapi.SetupRequesterNodeForTests(s.T())
+				c, cm := publicapi.SetupRequesterNodeForTests(s.T(), false)
 				defer cm.Cleanup()
 
 				*OC = *NewCreateOptions()
@@ -127,7 +127,7 @@ func (s *CreateSuite) TestCreateFromStdin() {
 
 	Fatal = FakeFatalErrorHandler
 
-	c, cm := publicapi.SetupRequesterNodeForTests(s.T())
+	c, cm := publicapi.SetupRequesterNodeForTests(s.T(), false)
 	defer cm.Cleanup()
 
 	*OC = *NewCreateOptions()

--- a/cmd/bacalhau/describe_test.go
+++ b/cmd/bacalhau/describe_test.go
@@ -58,7 +58,7 @@ func (suite *DescribeSuite) TestDescribeJob() {
 			func() {
 				var submittedJob *model.Job
 				ctx := context.Background()
-				c, cm := publicapi.SetupRequesterNodeForTests(suite.T())
+				c, cm := publicapi.SetupRequesterNodeForTests(suite.T(), false)
 				defer cm.Cleanup()
 
 				for i := 0; i < tc.numberOfAcceptNodes; i++ {
@@ -148,7 +148,7 @@ func (suite *DescribeSuite) TestDescribeJobIncludeEvents() {
 		func() {
 			var submittedJob *model.Job
 			ctx := context.Background()
-			c, cm := publicapi.SetupRequesterNodeForTests(suite.T())
+			c, cm := publicapi.SetupRequesterNodeForTests(suite.T(), false)
 			defer cm.Cleanup()
 
 			j := publicapi.MakeNoopJob()
@@ -208,7 +208,7 @@ func (s *DescribeSuite) TestDescribeJobEdgeCases() {
 
 				var submittedJob *model.Job
 				ctx := context.Background()
-				c, cm := publicapi.SetupRequesterNodeForTests(s.T())
+				c, cm := publicapi.SetupRequesterNodeForTests(s.T(), false)
 				defer cm.Cleanup()
 
 				for i := 0; i < n.numOfJobs; i++ {

--- a/cmd/bacalhau/list_test.go
+++ b/cmd/bacalhau/list_test.go
@@ -61,7 +61,7 @@ func (suite *ListSuite) TestList_NumberOfJobs() {
 	for _, tc := range tests {
 		func() {
 			ctx := context.Background()
-			c, cm := publicapi.SetupRequesterNodeForTests(suite.T())
+			c, cm := publicapi.SetupRequesterNodeForTests(suite.T(), false)
 			defer cm.Cleanup()
 
 			*OL = *NewListOptions()
@@ -91,7 +91,7 @@ func (suite *ListSuite) TestList_NumberOfJobs() {
 
 func (suite *ListSuite) TestList_IdFilter() {
 	ctx := context.Background()
-	c, cm := publicapi.SetupRequesterNodeForTests(suite.T())
+	c, cm := publicapi.SetupRequesterNodeForTests(suite.T(), false)
 	defer cm.Cleanup()
 
 	*OL = *NewListOptions()
@@ -191,7 +191,7 @@ func (suite *ListSuite) TestList_SortFlags() {
 		for _, sortFlags := range sortFlagsToTest {
 			func() {
 				ctx := context.Background()
-				c, cm := publicapi.SetupRequesterNodeForTests(suite.T())
+				c, cm := publicapi.SetupRequesterNodeForTests(suite.T(), false)
 				defer cm.Cleanup()
 
 				*OL = *NewListOptions()

--- a/cmd/bacalhau/validate_test.go
+++ b/cmd/bacalhau/validate_test.go
@@ -46,7 +46,7 @@ func (s *ValidateSuite) TestValidate() {
 		func() {
 			Fatal = FakeFatalErrorHandler
 
-			c, cm := publicapi.SetupRequesterNodeForTests(s.T())
+			c, cm := publicapi.SetupRequesterNodeForTests(s.T(), false)
 			defer cm.Cleanup()
 
 			*OV = *NewValidateOptions()

--- a/cmd/bacalhau/version_test.go
+++ b/cmd/bacalhau/version_test.go
@@ -46,7 +46,7 @@ func (suite *VersionSuite) SetupTest() {
 }
 
 func (suite *VersionSuite) Test_Version() {
-	c, cm := publicapi.SetupRequesterNodeForTests(suite.T())
+	c, cm := publicapi.SetupRequesterNodeForTests(suite.T(), false)
 	defer cm.Cleanup()
 
 	parsedBasedURI, _ := url.Parse(c.BaseURI)
@@ -62,7 +62,7 @@ func (suite *VersionSuite) Test_Version() {
 }
 
 func (suite *VersionSuite) Test_VersionOutputs() {
-	c, cm := publicapi.SetupRequesterNodeForTests(suite.T())
+	c, cm := publicapi.SetupRequesterNodeForTests(suite.T(), false)
 	defer cm.Cleanup()
 
 	parsedBasedURI, _ := url.Parse(c.BaseURI)

--- a/pkg/localdb/eventhandler.go
+++ b/pkg/localdb/eventhandler.go
@@ -5,6 +5,7 @@ import (
 
 	jobutils "github.com/filecoin-project/bacalhau/pkg/job"
 	"github.com/filecoin-project/bacalhau/pkg/model"
+	"github.com/rs/zerolog/log"
 )
 
 // An event handler that listens to both job and local events, and updates the LocalDB instance accordingly
@@ -43,6 +44,7 @@ func (h *LocalDBEventHandler) HandleJobEvent(ctx context.Context, event model.Jo
 	if err != nil {
 		return err
 	}
+	log.Debug().Msgf("JobID = %s", event.JobID)
 
 	err = h.localDB.AddEvent(ctx, event.JobID, event)
 	if err != nil {

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -193,6 +193,8 @@ func NewNode(
 		requesterNode,
 		// handles job execution
 		computeNode,
+		// dispatches events to listening websockets
+		apiServer,
 	)
 	jobEventPublisher.AddHandlers(
 		// publish events to the network

--- a/pkg/publicapi/client_test.go
+++ b/pkg/publicapi/client_test.go
@@ -15,7 +15,7 @@ import (
 func TestGet(t *testing.T) {
 	logger.ConfigureTestLogging(t)
 
-	c, cm := SetupRequesterNodeForTests(t)
+	c, cm := SetupRequesterNodeForTests(t, false)
 	defer cm.Cleanup()
 
 	ctx, span := system.Span(context.Background(),

--- a/pkg/publicapi/endpoints_websockets.go
+++ b/pkg/publicapi/endpoints_websockets.go
@@ -1,0 +1,89 @@
+package publicapi
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/filecoin-project/bacalhau/pkg/model"
+	"github.com/gorilla/websocket"
+	"github.com/rs/zerolog/log"
+)
+
+var upgrader = websocket.Upgrader{
+	ReadBufferSize:  1024,
+	WriteBufferSize: 1024,
+}
+
+// TODO: Godoc
+func (apiServer *APIServer) websockets(res http.ResponseWriter, req *http.Request) {
+
+	conn, err := upgrader.Upgrade(res, req, nil)
+	if err != nil {
+		http.Error(res, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	log.Debug().Msgf("New websocket connection.")
+	defer conn.Close()
+
+	// NB: jobId == "" is the case for subscriptions to "all events"
+	jobId := req.URL.Query().Get("job_id")
+
+	apiServer.WebsocketsMutex.Lock()
+	defer apiServer.WebsocketsMutex.Unlock()
+
+	sockets, ok := apiServer.Websockets[jobId]
+	if !ok {
+		sockets = []*websocket.Conn{}
+		apiServer.Websockets[jobId] = sockets
+	}
+	apiServer.Websockets[jobId] = append(sockets, conn)
+
+	if jobId != "" {
+		// list events for job out of localDB and send them to the client
+		events, err := apiServer.localdb.GetJobEvents(context.Background(), jobId)
+		if err != nil {
+			log.Error().Msgf("error listing job events: %s\n", err.Error())
+			return
+		}
+		for _, event := range events {
+			err := conn.WriteJSON(event)
+			if err != nil {
+				log.Error().Msgf("error writing event JSON: %s\n", err.Error())
+			}
+		}
+	}
+
+}
+
+func (apiServer *APIServer) HandleJobEvent(ctx context.Context, event model.JobEvent) (err error) {
+
+	apiServer.WebsocketsMutex.RLock()
+	defer apiServer.WebsocketsMutex.RUnlock()
+
+	dispatchAndCleanup := func(jobId string) {
+		connections, ok := apiServer.Websockets[jobId]
+		if !ok {
+			return
+		}
+		errIdxs := []int{}
+		for idx, connection := range connections {
+			log.Debug().Msgf("sending %+v to %s/%d", event, jobId, idx)
+			err := connection.WriteJSON(event)
+			if err != nil {
+				errIdxs = append(errIdxs, idx)
+			}
+		}
+		// reverse errIdxs and clean up dud indexes
+		for i := len(errIdxs)/2 - 1; i >= 0; i-- {
+			opp := len(errIdxs) - 1 - i
+			errIdxs[i], errIdxs[opp] = errIdxs[opp], errIdxs[i]
+		}
+		for _, idx := range errIdxs {
+			connections = append(connections[:idx], connections[idx+1:]...)
+		}
+		apiServer.Websockets[jobId] = connections
+	}
+	dispatchAndCleanup("")
+	dispatchAndCleanup(event.JobID)
+	return nil
+}

--- a/pkg/publicapi/server.go
+++ b/pkg/publicapi/server.go
@@ -174,7 +174,7 @@ func (apiServer *APIServer) ListenAndServe(ctx context.Context, cm *system.Clean
 	sm.Handle(apiServer.chainHandlers("/livez", apiServer.livez))
 	sm.Handle(apiServer.chainHandlers("/readyz", apiServer.readyz))
 	sm.Handle(apiServer.chainHandlers("/debug", apiServer.debug))
-	sm.HandleFunc("/websockets", apiServer.websockets)
+	sm.HandleFunc("/websocket", apiServer.websocket)
 	sm.Handle("/metrics", promhttp.Handler())
 	sm.Handle("/swagger/", httpSwagger.WrapHandler)
 

--- a/pkg/publicapi/server_test.go
+++ b/pkg/publicapi/server_test.go
@@ -115,7 +115,11 @@ func (s *ServerSuite) TestTimeout() {
 	defer res.Body.Close()
 }
 func (s *ServerSuite) TestMaxBodyReader() {
+	prev := MaxBytesToReadInBody
 	MaxBytesToReadInBody = 500
+	defer func() {
+		MaxBytesToReadInBody = prev
+	}()
 
 	c, cm := SetupRequesterNodeForTests(s.T(), false)
 	defer cm.Cleanup()

--- a/pkg/publicapi/server_test.go
+++ b/pkg/publicapi/server_test.go
@@ -37,7 +37,7 @@ func (s *ServerSuite) SetupTest() {
 
 func (s *ServerSuite) TestList() {
 	ctx := context.Background()
-	c, cm := SetupRequesterNodeForTests(s.T())
+	c, cm := SetupRequesterNodeForTests(s.T(), false)
 	defer cm.Cleanup()
 
 	// Should have no jobs initially:
@@ -99,7 +99,7 @@ func (s *ServerSuite) TestTimeout() {
 			"/logz": 10 * time.Nanosecond,
 		},
 	}
-	c, cm := SetupRequesterNodeForTestsWithConfig(s.T(), config)
+	c, cm := SetupRequesterNodeForTestsWithConfig(s.T(), config, false)
 	defer cm.Cleanup()
 
 	endpoint := "/logz"
@@ -117,7 +117,7 @@ func (s *ServerSuite) TestTimeout() {
 func (s *ServerSuite) TestMaxBodyReader() {
 	MaxBytesToReadInBody = 500
 
-	c, cm := SetupRequesterNodeForTests(s.T())
+	c, cm := SetupRequesterNodeForTests(s.T(), false)
 	defer cm.Cleanup()
 
 	// Due to headers we need MaxBytes minus 163
@@ -147,7 +147,7 @@ func (s *ServerSuite) TestMaxBodyReader() {
 }
 
 func testEndpoint(t *testing.T, endpoint string, contentToCheck string) []byte {
-	c, cm := SetupRequesterNodeForTests(t)
+	c, cm := SetupRequesterNodeForTests(t, false)
 	defer cm.Cleanup()
 
 	res, err := http.Get(c.BaseURI + endpoint)

--- a/pkg/publicapi/util.go
+++ b/pkg/publicapi/util.go
@@ -33,27 +33,27 @@ const TimeToWaitForServerReply = 10
 const TimeToWaitForHealthy = 50
 
 // SetupRequesterNodeForTests sets up a client for a requester node's API server, for testing.
-func SetupRequesterNodeForTests(t *testing.T) (*APIClient, *system.CleanupManager) {
+func SetupRequesterNodeForTests(t *testing.T, hairpin bool) (*APIClient, *system.CleanupManager) {
 	port, err := freeport.GetFreePort()
 	require.NoError(t, err)
-	return SetupRequesterNodeForTestWithPort(t, port)
+	return SetupRequesterNodeForTestWithPort(t, port, hairpin)
 }
 
-func SetupRequesterNodeForTestWithPort(t *testing.T, port int) (*APIClient, *system.CleanupManager) {
-	return SetupRequesterNodeForTestsWithPortAndConfig(t, port, DefaultAPIServerConfig)
+func SetupRequesterNodeForTestWithPort(t *testing.T, port int, hairpin bool) (*APIClient, *system.CleanupManager) {
+	return SetupRequesterNodeForTestsWithPortAndConfig(t, port, DefaultAPIServerConfig, hairpin)
 }
 
-func SetupRequesterNodeForTestsWithConfig(t *testing.T, config *APIServerConfig) (*APIClient, *system.CleanupManager) {
+func SetupRequesterNodeForTestsWithConfig(t *testing.T, config *APIServerConfig, hairpin bool) (*APIClient, *system.CleanupManager) {
 	port, err := freeport.GetFreePort()
 	require.NoError(t, err)
-	return SetupRequesterNodeForTestsWithPortAndConfig(t, port, config)
+	return SetupRequesterNodeForTestsWithPortAndConfig(t, port, config, hairpin)
 }
 
 // TODO: we are almost establishing a full node to test the API. Most of these tests should be move to test package,
 // and only keep simple unit tests here.
 //
 //nolint:funlen
-func SetupRequesterNodeForTestsWithPortAndConfig(t *testing.T, port int, config *APIServerConfig) (*APIClient, *system.CleanupManager) {
+func SetupRequesterNodeForTestsWithPortAndConfig(t *testing.T, port int, config *APIServerConfig, hairpin bool) (*APIClient, *system.CleanupManager) {
 	// Setup the system
 	err := system.InitConfigForTesting(t)
 	require.NoError(t, err)
@@ -129,11 +129,16 @@ func SetupRequesterNodeForTestsWithPortAndConfig(t *testing.T, port int, config 
 
 	localDBEventHandler := localdb.NewLocalDBEventHandler(inmemoryDatastore)
 
+	host := "0.0.0.0"
+	s := NewServerWithConfig(ctx, host, port, inmemoryDatastore, inprocessTransport,
+		requesterNode, computeNode, noopPublishers, noopStorageProviders, config)
+
 	// order of event handlers is important as triggering some handlers should depend on the state of others.
 	jobEventConsumer.AddHandlers(
 		tracerContextProvider,
 		localDBEventHandler,
 		requesterNode,
+		s, // websockets
 	)
 
 	jobEventPublisher.AddHandlers(
@@ -144,10 +149,12 @@ func SetupRequesterNodeForTestsWithPortAndConfig(t *testing.T, port int, config 
 		localDBEventHandler,
 	)
 
-	host := "0.0.0.0"
+	// Do we send events that we emit back to ourselves? Needed for test
+	// compatibility. This _does_ happen in production. See node.go
+	if hairpin {
+		inprocessTransport.Subscribe(ctx, jobEventConsumer.HandleJobEvent)
+	}
 
-	s := NewServerWithConfig(ctx, host, port, inmemoryDatastore, inprocessTransport,
-		requesterNode, computeNode, noopPublishers, noopStorageProviders, config)
 	cl := NewAPIClient(s.GetURI())
 	wait := make(chan struct{})
 	go func() {


### PR DESCRIPTION
Add websocket endpoint so frontend can subscribe to backend to learn about:
a) all events from now on, or
b) all events for a specific job id, including previous ones which are replayed on demand!
Thanks to @binocarlos for the pairing and design.