### PR TITLE
Make sure HTTP client responses are drained

### DIFF
--- a/pkg/publicapi/client.go
+++ b/pkg/publicapi/client.go
@@ -16,6 +16,7 @@ import (
 	"github.com/filecoin-project/bacalhau/pkg/job"
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/filecoin-project/bacalhau/pkg/system"
+	"github.com/filecoin-project/bacalhau/pkg/util/closer"
 	"github.com/rs/zerolog/log"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/attribute"
@@ -57,11 +58,11 @@ func (apiClient *APIClient) Alive(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, nil
 	}
-	res, err := apiClient.client.Do(req)
+	res, err := apiClient.client.Do(req) //nolint:bodyclose // golangcilint is dumb - this is closed
 	if err != nil {
 		return false, nil
 	}
-	defer res.Body.Close()
+	defer closer.DrainAndCloseWithLogOnError(ctx, "apiClient response", res.Body)
 
 	return res.StatusCode == http.StatusOK, nil
 }

--- a/pkg/util/closer/closer.go
+++ b/pkg/util/closer/closer.go
@@ -1,6 +1,7 @@
 package closer
 
 import (
+	"context"
 	"errors"
 	"io"
 	"net"
@@ -11,11 +12,29 @@ import (
 
 // CloseWithLogOnError will close the given resource and log any relevant failure
 func CloseWithLogOnError(name string, c io.Closer) {
+	closeCloser(name, c)
+}
+
+// DrainAndCloseWithLogOnError will first ensure the contents of the reader has been read before being closed. This is
+// useful when dealing with HTTP response bodies which need to be drained and closed so that the connection may be
+// re-used by the OS.
+func DrainAndCloseWithLogOnError(ctx context.Context, name string, c io.ReadCloser) {
+	if _, err := io.Copy(io.Discard, c); err != nil {
+		l := log.Ctx(ctx).With().CallerWithSkipFrameCount(3).Logger()
+		l.Err(err).Msgf("Failed to drain %s", name)
+	}
+
+	closeCloser(name, c)
+}
+
+func closeCloser(name string, c io.Closer) {
 	err := c.Close()
 	if err == nil || errors.Is(err, os.ErrClosed) || errors.Is(err, net.ErrClosed) {
 		return
 	}
 
-	l := log.With().CallerWithSkipFrameCount(3).Logger()
+	l := log.With().CallerWithSkipFrameCount(framesFromCaller).Logger()
 	l.Err(err).Msgf("Failed to close %s", name)
 }
+
+const framesFromCaller = 4

--- a/pkg/util/closer/closer_test.go
+++ b/pkg/util/closer/closer_test.go
@@ -4,6 +4,7 @@ package closer
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -12,64 +13,115 @@ import (
 	"testing"
 
 	"github.com/filecoin-project/bacalhau/pkg/model"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestCloseWithLogOnError_noErrors(t *testing.T) {
-	old := log.Logger
-	t.Cleanup(func() {
-		log.Logger = old
-	})
+	logOutput := testLogger(t)
 
-	var sb strings.Builder
-	CloseWithLogOnError(t.Name(), closer{nil})
-	assert.Equal(t, "", sb.String())
+	CloseWithLogOnError(t.Name(), closer{nil, strings.NewReader("")})
+	assert.Equal(t, "", logOutput.String())
 }
 
 func TestCloseWithLogOnError_logsErrors(t *testing.T) {
-	old := log.Logger
-	t.Cleanup(func() {
-		log.Logger = old
+	logOutput := testLogger(t, func(context zerolog.Context) zerolog.Context {
+		return context.Str("foo", "bar")
 	})
 
-	var b bytes.Buffer
-	log.Logger = log.With().Str("foo", "bar").Logger().Output(&b)
-
-	CloseWithLogOnError(t.Name(), closer{fmt.Errorf("error message")})
+	CloseWithLogOnError(t.Name(), closer{fmt.Errorf("error message"), strings.NewReader("")})
 
 	var content map[string]string
-	require.NoError(t, model.JSONUnmarshalWithMax(b.Bytes(), &content))
+	require.NoError(t, model.JSONUnmarshalWithMax(logOutput.Bytes(), &content))
 
 	assert.Equal(t, "bar", content["foo"])
 	assert.NotEmpty(t, content["message"])
 	assert.NotEmpty(t, content["caller"])
-	// assert.True(t, strings.HasSuffix(content["caller"], "closer/closer_test.go:38"), "%s should point to the function call", content["caller"])
+	assert.True(t, strings.HasSuffix(content["caller"], "closer/closer_test.go:34"), "%s should point to the CloseWithLogOnError function call in this test", content["caller"])
 }
 
 func TestCloseWithLogOnError_ignoresAlreadyClosed(t *testing.T) {
 	tests := []error{os.ErrClosed, net.ErrClosed}
 	for _, test := range tests {
 		t.Run(test.Error(), func(t *testing.T) {
-			old := log.Logger
-			t.Cleanup(func() {
-				log.Logger = old
-			})
+			logOutput := testLogger(t)
 
-			var sb strings.Builder
-			CloseWithLogOnError(t.Name(), closer{test})
-			assert.Equal(t, "", sb.String())
+			CloseWithLogOnError(t.Name(), closer{test, strings.NewReader("")})
+			assert.Equal(t, "", logOutput.String())
 		})
 	}
 }
 
+func TestDrainAndCloseWithLogOnError_noErrors(t *testing.T) {
+	logOutput := testLogger(t)
+
+	reader := strings.NewReader("")
+	DrainAndCloseWithLogOnError(context.Background(), "example", closer{nil, reader})
+	assert.Equal(t, "", logOutput.String())
+	_, err := reader.ReadByte()
+	assert.Equal(t, io.EOF, err)
+}
+
+func TestDrainAndCloseWithLogOnError_logsDrainError(t *testing.T) {
+	logOutput := testLogger(t, func(context zerolog.Context) zerolog.Context {
+		return context.Str("foo", "marker")
+	})
+
+	DrainAndCloseWithLogOnError(context.Background(), "example", closer{nil, failingReader{fmt.Errorf("error message")}})
+
+	var content map[string]string
+	require.NoError(t, model.JSONUnmarshalWithMax(logOutput.Bytes(), &content))
+
+	assert.Equal(t, "marker", content["foo"])
+	assert.NotEmpty(t, content["message"])
+	assert.NotEmpty(t, content["caller"])
+	assert.True(t, strings.HasSuffix(content["caller"], "closer/closer_test.go:72"), "%s should point to the DrainAndCloseWithLogOnError function call in this test", content["caller"])
+}
+
+func testLogger(t *testing.T, mods ...func(context zerolog.Context) zerolog.Context) *bytes.Buffer {
+	old := log.Logger
+	oldContext := zerolog.DefaultContextLogger
+	t.Cleanup(func() {
+		log.Logger = old
+		zerolog.DefaultContextLogger = oldContext
+	})
+
+	l := log.With()
+	for _, mod := range mods {
+		l = mod(l)
+	}
+
+	var b bytes.Buffer
+	log.Logger = l.Logger().Output(&b)
+	zerolog.DefaultContextLogger = &log.Logger
+
+	return &b
+}
+
 var _ io.Closer = closer{}
+var _ io.Reader = closer{}
 
 type closer struct {
-	err error
+	closeErr error
+	reader   io.Reader
+}
+
+func (c closer) Read(p []byte) (int, error) {
+	return c.reader.Read(p)
 }
 
 func (c closer) Close() error {
-	return c.err
+	return c.closeErr
+}
+
+var _ io.Reader = failingReader{}
+
+type failingReader struct {
+	err error
+}
+
+func (f failingReader) Read([]byte) (int, error) {
+	return 0, f.err
 }


### PR DESCRIPTION
The documentation for `response.Body` states:

> It is the caller's responsibility to close Body. The default HTTP
> client's Transport may not reuse HTTP/1.x "keep-alive" TCP connections
> if the Body is not read to completion and closed.

This change adds a helper function to make it easy to drain and close the HTTP connections so that they can be reused by the OS if possible.