### PR TITLE
Fix Python WASM tests

### DIFF
--- a/cmd/bacalhau/create.go
+++ b/cmd/bacalhau/create.go
@@ -33,11 +33,6 @@ var (
 
 		# Create a new job from an already executed job
 		bacalhau describe 6e51df50 | bacalhau create -`))
-
-	// Set Defaults (probably a better way to do this)
-	OC = NewCreateOptions()
-
-	// For the -f flag
 )
 
 type CreateOptions struct {
@@ -46,6 +41,7 @@ type CreateOptions struct {
 	Confidence      int                       // Minimum number of nodes that must agree on a verification result
 	RunTimeSettings RunTimeSettings           // Run time settings for execution (e.g. wait, get, etc after submission)
 	DownloadFlags   ipfs.IPFSDownloadSettings // Settings for running Download
+	DryRun          bool
 }
 
 func NewCreateOptions() *CreateOptions {
@@ -58,185 +54,196 @@ func NewCreateOptions() *CreateOptions {
 	}
 }
 
-func init() { //nolint:gochecknoinits
+func newCreateCmd() *cobra.Command {
+	OC := NewCreateOptions()
+
+	createCmd := &cobra.Command{
+		Use:     "create",
+		Short:   "Create a job using a json or yaml file.",
+		Long:    createLong,
+		Example: createExample,
+		Args:    cobra.MinimumNArgs(0),
+		PreRun:  applyPorcelainLogLevel,
+		RunE: func(cmd *cobra.Command, cmdArgs []string) error {
+			return create(cmd, cmdArgs, OC)
+		},
+	}
+
 	createCmd.Flags().AddFlagSet(NewIPFSDownloadFlags(&OC.DownloadFlags))
 	createCmd.Flags().AddFlagSet(NewRunTimeSettingsFlags(&OC.RunTimeSettings))
+	createCmd.PersistentFlags().BoolVar(
+		&OC.DryRun, "dry-run", OC.DryRun,
+		`Do not submit the job, but instead print out what will be submitted`,
+	)
+
+	return createCmd
 }
 
-var createCmd = &cobra.Command{
-	Use:     "create",
-	Short:   "Create a job using a json or yaml file.",
-	Long:    createLong,
-	Example: createExample,
-	Args:    cobra.MinimumNArgs(0),
-	PreRun:  applyPorcelainLogLevel,
-	RunE: func(cmd *cobra.Command, cmdArgs []string) error { //nolint:unparam // incorrect that cmd is unused.
-		cm := system.NewCleanupManager()
-		defer cm.Cleanup()
-		ctx := cmd.Context()
+func create(cmd *cobra.Command, cmdArgs []string, OC *CreateOptions) error { //nolint:funlen,gocyclo
+	cm := system.NewCleanupManager()
+	defer cm.Cleanup()
+	ctx := cmd.Context()
 
-		ctx, rootSpan := system.NewRootSpan(ctx, system.GetTracer(), "cmd/bacalhau/create")
-		defer rootSpan.End()
-		cm.RegisterCallback(system.CleanupTraceProvider)
+	ctx, rootSpan := system.NewRootSpan(ctx, system.GetTracer(), "cmd/bacalhau/create")
+	defer rootSpan.End()
+	cm.RegisterCallback(system.CleanupTraceProvider)
 
-		// Custom unmarshaller
-		// https://stackoverflow.com/questions/70635636/unmarshaling-yaml-into-different-struct-based-off-yaml-field?rq=1
-		var jwi model.JobWithInfo
-		var j *model.Job
-		var err error
-		var byteResult []byte
-		var rawMap map[string]interface{}
+	// Custom unmarshaller
+	// https://stackoverflow.com/questions/70635636/unmarshaling-yaml-into-different-struct-based-off-yaml-field?rq=1
+	var jwi model.JobWithInfo
+	var j *model.Job
+	var err error
+	var byteResult []byte
+	var rawMap map[string]interface{}
 
-		j, err = model.NewJobWithSaneProductionDefaults()
+	j, err = model.NewJobWithSaneProductionDefaults()
+	if err != nil {
+		return err
+	}
+
+	if len(cmdArgs) == 0 {
+		byteResult, err = ReadFromStdinIfAvailable(cmd, cmdArgs)
 		if err != nil {
+			Fatal(cmd, fmt.Sprintf("Unknown error reading from file or stdin: %s\n", err), 1)
+			return err
+		}
+	} else {
+		OC.Filename = cmdArgs[0]
+
+		var fileContent *os.File
+		fileContent, err = os.Open(OC.Filename)
+
+		if err != nil {
+			Fatal(cmd, fmt.Sprintf("Error opening file: %s", err), 1)
 			return err
 		}
 
-		if len(cmdArgs) == 0 {
-			byteResult, err = ReadFromStdinIfAvailable(cmd, cmdArgs)
-			if err != nil {
-				Fatal(fmt.Sprintf("Unknown error reading from file or stdin: %s\n", err), 1)
-				return err
-			}
+		byteResult, err = io.ReadAll(fileContent)
+		if err != nil {
+			Fatal(cmd, fmt.Sprintf("Error reading file: %s", err), 1)
+			return err
+		}
+	}
+
+	// Do a first pass for parsing to see if it's a Job or JobWithInfo
+	err = model.YAMLUnmarshalWithMax(byteResult, &rawMap)
+	if err != nil {
+		Fatal(cmd, fmt.Sprintf("Error parsing file: %s", err), 1)
+		return err
+	}
+
+	// If it's a JobWithInfo, we need to convert it to a Job
+	if _, isJobWithInfo := rawMap["Job"]; isJobWithInfo {
+		err = model.YAMLUnmarshalWithMax(byteResult, &jwi)
+		if err != nil {
+			Fatal(cmd, userstrings.JobSpecBad, 1)
+			return err
+		}
+		byteResult, err = model.YAMLMarshalWithMax(jwi.Job)
+		if err != nil {
+			Fatal(cmd, userstrings.JobSpecBad, 1)
+			return err
+		}
+	}
+
+	if len(byteResult) == 0 {
+		Fatal(cmd, userstrings.JobSpecBad, 1)
+		return err
+	}
+
+	// Turns out the yaml parser supports both yaml & json (because json is a subset of yaml)
+	// so we can just use that
+	err = model.YAMLUnmarshalWithMax(byteResult, &j)
+	if err != nil {
+		Fatal(cmd, userstrings.JobSpecBad, 1)
+		return err
+	}
+
+	// See if the job spec is empty
+	if j == nil || reflect.DeepEqual(j.Spec, &model.Job{}) {
+		Fatal(cmd, userstrings.JobSpecBad, 1)
+		return err
+	}
+
+	// Warn on fields with data that will be ignored
+	var unusedFieldList []string
+	if j.ClientID != "" {
+		unusedFieldList = append(unusedFieldList, "ClientID")
+		j.ClientID = ""
+	}
+	if !reflect.DeepEqual(j.CreatedAt, time.Time{}) {
+		unusedFieldList = append(unusedFieldList, "CreatedAt")
+		j.CreatedAt = time.Time{}
+	}
+	if !reflect.DeepEqual(j.ExecutionPlan, model.JobExecutionPlan{}) {
+		unusedFieldList = append(unusedFieldList, "Verification")
+		j.ExecutionPlan = model.JobExecutionPlan{}
+	}
+	if len(j.Events) != 0 {
+		unusedFieldList = append(unusedFieldList, "Events")
+		j.Events = nil
+	}
+	if j.ID != "" {
+		unusedFieldList = append(unusedFieldList, "ID")
+		j.ID = ""
+	}
+	if len(j.LocalEvents) != 0 {
+		unusedFieldList = append(unusedFieldList, "LocalEvents")
+		j.LocalEvents = nil
+	}
+	if j.RequesterNodeID != "" {
+		unusedFieldList = append(unusedFieldList, "RequesterNodeID")
+		j.RequesterNodeID = ""
+	}
+	if len(j.RequesterPublicKey) != 0 {
+		unusedFieldList = append(unusedFieldList, "RequesterPublicKey")
+		j.RequesterPublicKey = nil
+	}
+	if !reflect.DeepEqual(j.State, model.JobState{}) {
+		unusedFieldList = append(unusedFieldList, "State")
+		j.State = model.JobState{}
+	}
+
+	// Warn on fields with data that will be ignored
+	if len(unusedFieldList) > 0 {
+		cmd.Printf("WARNING: The following fields have data in them and will be ignored on creation: %s\n", strings.Join(unusedFieldList, ", "))
+	}
+
+	err = jobutils.VerifyJob(ctx, j)
+	if err != nil {
+		if _, ok := err.(*bacerrors.ImageNotFound); ok {
+			Fatal(cmd, fmt.Sprintf("Docker image '%s' not found in the registry, or needs authorization.", j.Spec.Docker.Image), 1)
+			return err
 		} else {
-			OC.Filename = cmdArgs[0]
-
-			var fileContent *os.File
-			fileContent, err = os.Open(OC.Filename)
-
-			if err != nil {
-				Fatal(fmt.Sprintf("Error opening file: %s", err), 1)
-				return err
-			}
-
-			byteResult, err = io.ReadAll(fileContent)
-			if err != nil {
-				Fatal(fmt.Sprintf("Error reading file: %s", err), 1)
-				return err
-			}
+			Fatal(cmd, fmt.Sprintf("Error verifying job: %s", err), 1)
+			return err
 		}
-
-		// Do a first pass for parsing to see if it's a Job or JobWithInfo
-		err = model.YAMLUnmarshalWithMax(byteResult, &rawMap)
+	}
+	if OC.DryRun {
+		// Converting job to yaml
+		var yamlBytes []byte
+		yamlBytes, err = yaml.Marshal(j)
 		if err != nil {
-			Fatal(fmt.Sprintf("Error parsing file: %s", err), 1)
+			Fatal(cmd, fmt.Sprintf("Error converting job to yaml: %s", err), 1)
 			return err
 		}
-
-		// If it's a JobWithInfo, we need to convert it to a Job
-		if _, isJobWithInfo := rawMap["Job"]; isJobWithInfo {
-			err = model.YAMLUnmarshalWithMax(byteResult, &jwi)
-			if err != nil {
-				Fatal(userstrings.JobSpecBad, 1)
-				return err
-			}
-			byteResult, err = model.YAMLMarshalWithMax(jwi.Job)
-			if err != nil {
-				Fatal(userstrings.JobSpecBad, 1)
-				return err
-			}
-		}
-
-		if len(byteResult) == 0 {
-			Fatal(userstrings.JobSpecBad, 1)
-			return err
-		}
-
-		// Turns out the yaml parser supports both yaml & json (because json is a subset of yaml)
-		// so we can just use that
-		err = model.YAMLUnmarshalWithMax(byteResult, &j)
-		if err != nil {
-			Fatal(userstrings.JobSpecBad, 1)
-			return err
-		}
-
-		// See if the job spec is empty
-		if j == nil || reflect.DeepEqual(j.Spec, &model.Job{}) {
-			Fatal(userstrings.JobSpecBad, 1)
-			return err
-		}
-
-		// Warn on fields with data that will be ignored
-		var unusedFieldList []string
-		if j.ClientID != "" {
-			unusedFieldList = append(unusedFieldList, "ClientID")
-			j.ClientID = ""
-		}
-		if !reflect.DeepEqual(j.CreatedAt, time.Time{}) {
-			unusedFieldList = append(unusedFieldList, "CreatedAt")
-			j.CreatedAt = time.Time{}
-		}
-		if !reflect.DeepEqual(j.ExecutionPlan, model.JobExecutionPlan{}) {
-			unusedFieldList = append(unusedFieldList, "Verification")
-			j.ExecutionPlan = model.JobExecutionPlan{}
-		}
-		if len(j.Events) != 0 {
-			unusedFieldList = append(unusedFieldList, "Events")
-			j.Events = nil
-		}
-		if j.ID != "" {
-			unusedFieldList = append(unusedFieldList, "ID")
-			j.ID = ""
-		}
-		if len(j.LocalEvents) != 0 {
-			unusedFieldList = append(unusedFieldList, "LocalEvents")
-			j.LocalEvents = nil
-		}
-		if j.RequesterNodeID != "" {
-			unusedFieldList = append(unusedFieldList, "RequesterNodeID")
-			j.RequesterNodeID = ""
-		}
-		if len(j.RequesterPublicKey) != 0 {
-			unusedFieldList = append(unusedFieldList, "RequesterPublicKey")
-			j.RequesterPublicKey = nil
-		}
-		if !reflect.DeepEqual(j.State, model.JobState{}) {
-			unusedFieldList = append(unusedFieldList, "State")
-			j.State = model.JobState{}
-		}
-
-		// Warn on fields with data that will be ignored
-		if len(unusedFieldList) > 0 {
-			cmd.Printf("WARNING: The following fields have data in them and will be ignored on creation: %s\n", strings.Join(unusedFieldList, ", "))
-		}
-
-		err = jobutils.VerifyJob(ctx, j)
-		if err != nil {
-			if _, ok := err.(*bacerrors.ImageNotFound); ok {
-				Fatal(fmt.Sprintf("Docker image '%s' not found in the registry, or needs authorization.", j.Spec.Docker.Image), 1)
-				return err
-			} else {
-				Fatal(fmt.Sprintf("Error verifying job: %s", err), 1)
-				return err
-			}
-		}
-		if ODR.DryRun {
-			// Converting job to yaml
-			var yamlBytes []byte
-			yamlBytes, err = yaml.Marshal(j)
-			if err != nil {
-				Fatal(fmt.Sprintf("Error converting job to yaml: %s", err), 1)
-				return err
-			}
-			cmd.Print(string(yamlBytes))
-			return nil
-		}
-
-		err = ExecuteJob(ctx,
-			cm,
-			cmd,
-			j,
-			OC.RunTimeSettings,
-			OC.DownloadFlags,
-			nil,
-		)
-
-		if err != nil {
-			Fatal(fmt.Sprintf("Error executing job: %s", err), 1)
-			return err
-		}
-
+		cmd.Print(string(yamlBytes))
 		return nil
+	}
 
-	},
+	err = ExecuteJob(ctx,
+		cm,
+		cmd,
+		j,
+		OC.RunTimeSettings,
+		OC.DownloadFlags,
+		nil,
+	)
+
+	if err != nil {
+		Fatal(cmd, fmt.Sprintf("Error executing job: %s", err), 1)
+		return err
+	}
+
+	return nil
 }

--- a/cmd/bacalhau/create_test.go
+++ b/cmd/bacalhau/create_test.go
@@ -24,7 +24,6 @@ import (
 
 type CreateSuite struct {
 	suite.Suite
-	rootCmd *cobra.Command
 }
 
 func TestCreateSuite(t *testing.T) {
@@ -35,7 +34,6 @@ func TestCreateSuite(t *testing.T) {
 func (s *CreateSuite) SetupTest() {
 	logger.ConfigureTestLogging(s.T())
 	require.NoError(s.T(), system.InitConfigForTesting(s.T()))
-	s.rootCmd = RootCmd
 }
 
 func (s *CreateSuite) TestCreateJSON_GenericSubmit() {
@@ -54,13 +52,11 @@ func (s *CreateSuite) TestCreateJSON_GenericSubmit() {
 			c, cm := publicapi.SetupRequesterNodeForTests(s.T(), false)
 			defer cm.Cleanup()
 
-			*OC = *NewCreateOptions()
-
 			parsedBasedURI, err := url.Parse(c.BaseURI)
 			require.NoError(s.T(), err)
 
 			host, port, _ := net.SplitHostPort(parsedBasedURI.Host)
-			_, out, err := ExecuteTestCobraCommand(s.T(), s.rootCmd, "create",
+			_, out, err := ExecuteTestCobraCommand(s.T(), "create",
 				"--api-host", host,
 				"--api-port", port,
 				"../../testdata/job.json",
@@ -91,13 +87,11 @@ func (s *CreateSuite) TestCreateYAML_GenericSubmit() {
 				c, cm := publicapi.SetupRequesterNodeForTests(s.T(), false)
 				defer cm.Cleanup()
 
-				*OC = *NewCreateOptions()
-
 				parsedBasedURI, err := url.Parse(c.BaseURI)
 				require.NoError(s.T(), err)
 
 				host, port, _ := net.SplitHostPort(parsedBasedURI.Host)
-				_, out, err := ExecuteTestCobraCommand(s.T(), s.rootCmd, "create",
+				_, out, err := ExecuteTestCobraCommand(s.T(), "create",
 					"--api-host", host,
 					"--api-port", port,
 					testFile,
@@ -119,8 +113,6 @@ func (s *CreateSuite) TestCreateFromStdin() {
 	c, cm := publicapi.SetupRequesterNodeForTests(s.T(), false)
 	defer cm.Cleanup()
 
-	*OC = *NewCreateOptions()
-
 	parsedBasedURI, err := url.Parse(c.BaseURI)
 	require.NoError(s.T(), err)
 
@@ -128,7 +120,7 @@ func (s *CreateSuite) TestCreateFromStdin() {
 	require.NoError(s.T(), err)
 
 	host, port, _ := net.SplitHostPort(parsedBasedURI.Host)
-	_, out, err := ExecuteTestCobraCommandWithStdin(s.T(), s.rootCmd, testSpec, "create",
+	_, out, err := ExecuteTestCobraCommandWithStdin(s.T(), testSpec, "create",
 		"--api-host", host,
 		"--api-port", port,
 	)
@@ -137,7 +129,7 @@ func (s *CreateSuite) TestCreateFromStdin() {
 
 	// Now run describe on the ID we got back
 	job := testutils.GetJobFromTestOutput(context.Background(), s.T(), c, out)
-	_, out, err = ExecuteTestCobraCommand(s.T(), s.rootCmd, "describe",
+	_, out, err = ExecuteTestCobraCommand(s.T(), "describe",
 		"--api-host", host,
 		"--api-port", port,
 		job.ID,
@@ -158,7 +150,7 @@ func (s *CreateSuite) TestCreateDontPanicOnNoInput() {
 	commandChan := make(chan commandReturn, 1)
 
 	go func() {
-		c, out, err := ExecuteTestCobraCommand(s.T(), RootCmd, "create")
+		c, out, err := ExecuteTestCobraCommand(s.T(), "create")
 
 		commandChan <- commandReturn{c: c, out: out, err: err}
 	}()
@@ -198,7 +190,7 @@ func (s *CreateSuite) TestCreateDontPanicOnEmptyFile() {
 	commandChan := make(chan commandReturn, 1)
 
 	go func() {
-		c, out, err := ExecuteTestCobraCommand(s.T(), RootCmd, "create", "../../testdata/empty.yaml")
+		c, out, err := ExecuteTestCobraCommand(s.T(), "create", "../../testdata/empty.yaml")
 
 		commandChan <- commandReturn{c: c, out: out, err: err}
 	}()

--- a/cmd/bacalhau/describe_test.go
+++ b/cmd/bacalhau/describe_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/filecoin-project/bacalhau/pkg/publicapi"
 	"github.com/filecoin-project/bacalhau/pkg/system"
 	"github.com/google/uuid"
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -25,14 +24,12 @@ import (
 // returns the current testing context
 type DescribeSuite struct {
 	suite.Suite
-	rootCmd *cobra.Command
 }
 
 // Before each test
 func (suite *DescribeSuite) SetupTest() {
 	logger.ConfigureTestLogging(suite.T())
 	require.NoError(suite.T(), system.InitConfigForTesting(suite.T()))
-	suite.rootCmd = RootCmd
 }
 
 func (suite *DescribeSuite) TestDescribeJob() {
@@ -76,14 +73,14 @@ func (suite *DescribeSuite) TestDescribeJob() {
 				returnedJob := &model.Job{}
 
 				// No job id (should error)
-				_, out, err := ExecuteTestCobraCommand(suite.T(), suite.rootCmd, "describe",
+				_, out, err := ExecuteTestCobraCommand(suite.T(), "describe",
 					"--api-host", host,
 					"--api-port", port,
 				)
 				require.Error(suite.T(), err, "Submitting a describe request with no id should error.")
 
 				// Job Id at the end
-				_, out, err = ExecuteTestCobraCommand(suite.T(), suite.rootCmd, "describe",
+				_, out, err = ExecuteTestCobraCommand(suite.T(), "describe",
 					"--api-host", host,
 					"--api-port", port,
 					submittedJob.ID,
@@ -99,7 +96,7 @@ func (suite *DescribeSuite) TestDescribeJob() {
 					fmt.Sprintf("Submitted job entrypoints not the same as the description. %d - %d - %s - %d", tc.numberOfAcceptNodes, tc.numberOfRejectNodes, tc.jobState, n.numOfJobs))
 
 				// Job Id in the middle
-				_, out, err = ExecuteTestCobraCommand(suite.T(), suite.rootCmd, "describe",
+				_, out, err = ExecuteTestCobraCommand(suite.T(), "describe",
 					"--api-host", host,
 					submittedJob.ID,
 					"--api-port", port,
@@ -115,7 +112,7 @@ func (suite *DescribeSuite) TestDescribeJob() {
 					fmt.Sprintf("Submitted job entrypoints not the same as the description. %d - %d - %s - %d", tc.numberOfAcceptNodes, tc.numberOfRejectNodes, tc.jobState, n.numOfJobs))
 
 				// Short job id
-				_, out, err = ExecuteTestCobraCommand(suite.T(), suite.rootCmd, "describe",
+				_, out, err = ExecuteTestCobraCommand(suite.T(), "describe",
 					"--api-host", host,
 					submittedJob.ID[0:model.ShortIDLength],
 					"--api-port", port,
@@ -168,7 +165,7 @@ func (suite *DescribeSuite) TestDescribeJobIncludeEvents() {
 			}
 
 			// Job Id at the end
-			_, out, err := ExecuteTestCobraCommand(suite.T(), suite.rootCmd, args...)
+			_, out, err := ExecuteTestCobraCommand(suite.T(), args...)
 			require.NoError(suite.T(), err, "Error in describing job: %+v", err)
 
 			err = model.YAMLUnmarshalWithMax([]byte(out), &returnedJob)
@@ -233,7 +230,7 @@ func (s *DescribeSuite) TestDescribeJobEdgeCases() {
 					jobID = tc.describeIDEdgecase
 				}
 
-				_, out, err = ExecuteTestCobraCommand(s.T(), s.rootCmd, "describe",
+				_, out, err = ExecuteTestCobraCommand(s.T(), "describe",
 					"--api-host", host,
 					"--api-port", port,
 					jobID,

--- a/cmd/bacalhau/devstack.go
+++ b/cmd/bacalhau/devstack.go
@@ -27,13 +27,6 @@ var (
 		# Create a devstack cluster.
 		bacalhau devstack
 `))
-
-	// Set Defaults (probably a better way to do this)
-	ODs = newDevStackOptions()
-
-	IsNoop = false
-
-	// For the -f flag
 )
 
 func newDevStackOptions() *devstack.DevStackOptions {
@@ -48,7 +41,21 @@ func newDevStackOptions() *devstack.DevStackOptions {
 	}
 }
 
-func init() { //nolint:gochecknoinits // Using init in cobra command is idomatic
+func newDevStackCmd() *cobra.Command {
+	ODs := newDevStackOptions()
+	OS := NewServeOptions()
+	IsNoop := false
+
+	devstackCmd := &cobra.Command{
+		Use:     "devstack",
+		Short:   "Start a cluster of bacalhau nodes for testing and development",
+		Long:    devStackLong,
+		Example: devstackExample,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runDevstack(cmd, ODs, OS, IsNoop)
+		},
+	}
+
 	devstackCmd.PersistentFlags().IntVar(
 		&ODs.NumberOfNodes, "nodes", ODs.NumberOfNodes,
 		`How many nodes should be started in the cluster`,
@@ -74,97 +81,93 @@ func init() { //nolint:gochecknoinits // Using init in cobra command is idomatic
 		`Use the simulator transport at the given URL`,
 	)
 
-	setupJobSelectionCLIFlags(devstackCmd)
-	setupCapacityManagerCLIFlags(devstackCmd)
+	setupJobSelectionCLIFlags(devstackCmd, OS)
+	setupCapacityManagerCLIFlags(devstackCmd, OS)
+
+	return devstackCmd
 }
 
-var devstackCmd = &cobra.Command{
-	Use:     "devstack",
-	Short:   "Start a cluster of bacalhau nodes for testing and development",
-	Long:    devStackLong,
-	Example: devstackExample,
-	RunE: func(cmd *cobra.Command, _ []string) error {
-		cm := system.NewCleanupManager()
-		defer cm.Cleanup()
-		ctx := cmd.Context()
+func runDevstack(cmd *cobra.Command, ODs *devstack.DevStackOptions, OS *ServeOptions, IsNoop bool) error {
+	cm := system.NewCleanupManager()
+	defer cm.Cleanup()
+	ctx := cmd.Context()
 
-		ctx, rootSpan := system.NewRootSpan(ctx, system.GetTracer(), "cmd/bacalhau/devstack")
-		defer rootSpan.End()
+	ctx, rootSpan := system.NewRootSpan(ctx, system.GetTracer(), "cmd/bacalhau/devstack")
+	defer rootSpan.End()
 
-		cm.RegisterCallback(system.CleanupTraceProvider)
+	cm.RegisterCallback(system.CleanupTraceProvider)
 
-		config.DevstackSetShouldPrintInfo()
+	config.DevstackSetShouldPrintInfo()
 
-		if ODs.NumberOfBadActors >= ODs.NumberOfNodes {
-			Fatal(fmt.Sprintf("You cannot have more bad actors (%d) than there are nodes (%d).",
-				ODs.NumberOfBadActors, ODs.NumberOfNodes), 1)
+	if ODs.NumberOfBadActors >= ODs.NumberOfNodes {
+		Fatal(cmd, fmt.Sprintf("You cannot have more bad actors (%d) than there are nodes (%d).",
+			ODs.NumberOfBadActors, ODs.NumberOfNodes), 1)
+	}
+
+	// Context ensures main goroutine waits until killed with ctrl+c:
+	ctx, cancel := system.WithSignalShutdown(ctx)
+	defer cancel()
+
+	portFileName := filepath.Join(os.TempDir(), "bacalhau-devstack.port")
+	pidFileName := filepath.Join(os.TempDir(), "bacalhau-devstack.pid")
+
+	if _, ignore := os.LookupEnv("IGNORE_PID_AND_PORT_FILES"); !ignore {
+		_, err := os.Stat(portFileName)
+		if err == nil {
+			Fatal(cmd, fmt.Sprintf("Found file %s - Devstack likely already running", portFileName), 1)
 		}
-
-		// Context ensures main goroutine waits until killed with ctrl+c:
-		ctx, cancel := system.WithSignalShutdown(ctx)
-		defer cancel()
-
-		portFileName := filepath.Join(os.TempDir(), "bacalhau-devstack.port")
-		pidFileName := filepath.Join(os.TempDir(), "bacalhau-devstack.pid")
-
-		if _, ignore := os.LookupEnv("IGNORE_PID_AND_PORT_FILES"); !ignore {
-			_, err := os.Stat(portFileName)
-			if err == nil {
-				Fatal(fmt.Sprintf("Found file %s - Devstack likely already running", portFileName), 1)
-			}
-			_, err = os.Stat(pidFileName)
-			if err == nil {
-				Fatal(fmt.Sprintf("Found file %s - Devstack likely already running", pidFileName), 1)
-			}
+		_, err = os.Stat(pidFileName)
+		if err == nil {
+			Fatal(cmd, fmt.Sprintf("Found file %s - Devstack likely already running", pidFileName), 1)
 		}
+	}
 
-		computeConfig := getComputeConfig()
-		if ODs.LocalNetworkLotus {
-			cmd.Println("Note that starting up the Lotus node can take many minutes!")
-		}
+	computeConfig := getComputeConfig(OS)
+	if ODs.LocalNetworkLotus {
+		cmd.Println("Note that starting up the Lotus node can take many minutes!")
+	}
 
-		var stack *devstack.DevStack
-		var stackErr error
-		if IsNoop {
-			stack, stackErr = devstack.NewNoopDevStack(ctx, cm, *ODs, computeConfig, requesternode.NewDefaultRequesterNodeConfig())
-		} else {
-			stack, stackErr = devstack.NewStandardDevStack(ctx, cm, *ODs, computeConfig, requesternode.NewDefaultRequesterNodeConfig())
-		}
-		if stackErr != nil {
-			return stackErr
-		}
+	var stack *devstack.DevStack
+	var stackErr error
+	if IsNoop {
+		stack, stackErr = devstack.NewNoopDevStack(ctx, cm, *ODs, computeConfig, requesternode.NewDefaultRequesterNodeConfig())
+	} else {
+		stack, stackErr = devstack.NewStandardDevStack(ctx, cm, *ODs, computeConfig, requesternode.NewDefaultRequesterNodeConfig())
+	}
+	if stackErr != nil {
+		return stackErr
+	}
 
-		nodeInfoOutput, err := stack.PrintNodeInfo(ctx)
-		if err != nil {
-			Fatal(fmt.Sprintf("Failed to print node info: %s", err.Error()), 1)
-		}
-		cmd.Println(nodeInfoOutput)
+	nodeInfoOutput, err := stack.PrintNodeInfo(ctx)
+	if err != nil {
+		Fatal(cmd, fmt.Sprintf("Failed to print node info: %s", err.Error()), 1)
+	}
+	cmd.Println(nodeInfoOutput)
 
-		f, err := os.Create(portFileName)
-		if err != nil {
-			Fatal(fmt.Sprintf("Error writing out port file to %v", portFileName), 1)
-		}
-		defer os.Remove(portFileName)
-		firstNode := stack.Nodes[0]
-		_, err = f.WriteString(strconv.Itoa(firstNode.APIServer.Port))
-		if err != nil {
-			Fatal(fmt.Sprintf("Error writing out port file: %v", portFileName), 1)
-		}
+	f, err := os.Create(portFileName)
+	if err != nil {
+		Fatal(cmd, fmt.Sprintf("Error writing out port file to %v", portFileName), 1)
+	}
+	defer os.Remove(portFileName)
+	firstNode := stack.Nodes[0]
+	_, err = f.WriteString(strconv.Itoa(firstNode.APIServer.Port))
+	if err != nil {
+		Fatal(cmd, fmt.Sprintf("Error writing out port file: %v", portFileName), 1)
+	}
 
-		fPid, err := os.Create(pidFileName)
-		if err != nil {
-			Fatal(fmt.Sprintf("Error writing out pid file to %v", pidFileName), 1)
-		}
-		defer os.Remove(pidFileName)
+	fPid, err := os.Create(pidFileName)
+	if err != nil {
+		Fatal(cmd, fmt.Sprintf("Error writing out pid file to %v", pidFileName), 1)
+	}
+	defer os.Remove(pidFileName)
 
-		_, err = fPid.WriteString(strconv.Itoa(os.Getpid()))
-		if err != nil {
-			Fatal(fmt.Sprintf("Error writing out pid file: %v", pidFileName), 1)
-		}
+	_, err = fPid.WriteString(strconv.Itoa(os.Getpid()))
+	if err != nil {
+		Fatal(cmd, fmt.Sprintf("Error writing out pid file: %v", pidFileName), 1)
+	}
 
-		<-ctx.Done() // block until killed
+	<-ctx.Done() // block until killed
 
-		cmd.Println("Shutting down devstack")
-		return nil
-	},
+	cmd.Println("Shutting down devstack")
+	return nil
 }

--- a/cmd/bacalhau/docker_run_test.go
+++ b/cmd/bacalhau/docker_run_test.go
@@ -34,7 +34,6 @@ import (
 	devstack_tests "github.com/filecoin-project/bacalhau/pkg/test/devstack"
 	testutils "github.com/filecoin-project/bacalhau/pkg/test/utils"
 	"github.com/rs/zerolog/log"
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -45,7 +44,6 @@ import (
 // returns the current testing context
 type DockerRunSuite struct {
 	suite.Suite
-	rootCmd *cobra.Command
 }
 
 // In order for 'go test' to run this suite, we need to create
@@ -61,7 +59,6 @@ func (s *DockerRunSuite) SetupTest() {
 
 	logger.ConfigureTestLogging(s.T())
 	require.NoError(s.T(), system.InitConfigForTesting(s.T()))
-	s.rootCmd = RootCmd
 }
 
 // TODO: #471 Refactor all of these tests to use common functionality; they're all very similar
@@ -79,12 +76,10 @@ func (s *DockerRunSuite) TestRun_GenericSubmit() {
 			c, cm := publicapi.SetupRequesterNodeForTests(s.T(), false)
 			defer cm.Cleanup()
 
-			*ODR = *NewDockerRunOptions()
-
 			randomUUID := uuid.New()
 			parsedBasedURI, _ := url.Parse(c.BaseURI)
 			host, port, _ := net.SplitHostPort(parsedBasedURI.Host)
-			_, out, err := ExecuteTestCobraCommand(s.T(), s.rootCmd, "docker", "run",
+			_, out, err := ExecuteTestCobraCommand(s.T(), "docker", "run",
 				"--api-host", host,
 				"--api-port", port,
 				fmt.Sprintf("ubuntu echo %s", randomUUID.String()),
@@ -108,14 +103,12 @@ func (s *DockerRunSuite) TestRun_DryRun() {
 			c, cm := publicapi.SetupRequesterNodeForTests(s.T(), false)
 			defer cm.Cleanup()
 
-			*ODR = *NewDockerRunOptions()
-
 			randomUUID := uuid.New()
 			entrypointCommand := fmt.Sprintf("echo %s", randomUUID.String())
 
 			parsedBasedURI, _ := url.Parse(c.BaseURI)
 			host, port, _ := net.SplitHostPort(parsedBasedURI.Host)
-			_, out, err := ExecuteTestCobraCommand(s.T(), s.rootCmd, "docker", "run",
+			_, out, err := ExecuteTestCobraCommand(s.T(), "docker", "run",
 				"--api-host", host,
 				"--api-port", port,
 				"ubuntu",
@@ -159,13 +152,11 @@ func (s *DockerRunSuite) TestRun_GPURequests() {
 			c, cm := publicapi.SetupRequesterNodeForTests(s.T(), false)
 			defer cm.Cleanup()
 
-			*ODR = *NewDockerRunOptions()
-
 			parsedBasedURI, _ := url.Parse(c.BaseURI)
 			host, port, _ := net.SplitHostPort(parsedBasedURI.Host)
 			allArgs := []string{"docker", "run", "--api-host", host, "--api-port", port}
 			allArgs = append(allArgs, tc.submitArgs...)
-			_, out, submitErr := ExecuteTestCobraCommand(s.T(), s.rootCmd, allArgs...)
+			_, out, submitErr := ExecuteTestCobraCommand(s.T(), allArgs...)
 
 			if tc.fatalErr {
 				require.Contains(s.T(), out, tc.errString, "Did not find expected error message for fatalError in error string.\nExpected: %s\nActual: %s", tc.errString, out)
@@ -202,12 +193,10 @@ func (s *DockerRunSuite) TestRun_GenericSubmitWait() {
 				requesternode.NewDefaultRequesterNodeConfig(),
 			)
 
-			*ODR = *NewDockerRunOptions()
-
 			swarmAddresses, err := devstack.Nodes[0].IPFSClient.SwarmAddresses(ctx)
 			require.NoError(s.T(), err)
 
-			_, out, err := ExecuteTestCobraCommand(s.T(), s.rootCmd, "docker", "run",
+			_, out, err := ExecuteTestCobraCommand(s.T(), "docker", "run",
 				"--api-host", devstack.Nodes[0].APIServer.Host,
 				"--api-port", fmt.Sprintf("%d", devstack.Nodes[0].APIServer.Port),
 				"--ipfs-swarm-addrs", strings.Join(swarmAddresses, ","),
@@ -263,8 +252,6 @@ func (s *DockerRunSuite) TestRun_SubmitInputs() {
 				c, cm := publicapi.SetupRequesterNodeForTests(s.T(), false)
 				defer cm.Cleanup()
 
-				*ODR = *NewDockerRunOptions()
-
 				parsedBasedURI, _ := url.Parse(c.BaseURI)
 				host, port, _ := net.SplitHostPort(parsedBasedURI.Host)
 				flagsArray := []string{"docker", "run",
@@ -279,9 +266,7 @@ func (s *DockerRunSuite) TestRun_SubmitInputs() {
 				}
 				flagsArray = append(flagsArray, "ubuntu cat /inputs/foo.txt") // This doesn't exist, but shouldn't error
 
-				_, out, err := ExecuteTestCobraCommand(s.T(), s.rootCmd,
-					flagsArray...,
-				)
+				_, out, err := ExecuteTestCobraCommand(s.T(), flagsArray...)
 				require.NoError(s.T(), err, "Error submitting job. Run - Number of Jobs: %s. Job number: %s", tc.numberOfJobs, i)
 
 				j := testutils.GetJobFromTestOutput(ctx, s.T(), c, out)
@@ -344,8 +329,6 @@ func (s *DockerRunSuite) TestRun_SubmitUrlInputs() {
 				c, cm := publicapi.SetupRequesterNodeForTests(s.T(), false)
 				defer cm.Cleanup()
 
-				*ODR = *NewDockerRunOptions()
-
 				parsedBasedURI, _ := url.Parse(c.BaseURI)
 				host, port, _ := net.SplitHostPort(parsedBasedURI.Host)
 				flagsArray := []string{"docker", "run",
@@ -358,9 +341,7 @@ func (s *DockerRunSuite) TestRun_SubmitUrlInputs() {
 				}
 				flagsArray = append(flagsArray, "ubuntu cat /app/foo_data.txt")
 
-				_, out, err := ExecuteTestCobraCommand(s.T(), s.rootCmd,
-					flagsArray...,
-				)
+				_, out, err := ExecuteTestCobraCommand(s.T(), flagsArray...)
 				require.NoError(s.T(), err, "Error submitting job. Run - Number of Jobs: %s. Job number: %s", tc.numberOfJobs, i)
 
 				j := testutils.GetJobFromTestOutput(ctx, s.T(), c, out)
@@ -418,8 +399,6 @@ func (s *DockerRunSuite) TestRun_SubmitOutputs() {
 				c, cm := publicapi.SetupRequesterNodeForTests(s.T(), false)
 				defer cm.Cleanup()
 
-				*ODR = *NewDockerRunOptions()
-
 				parsedBasedURI, _ := url.Parse(c.BaseURI)
 				host, port, _ := net.SplitHostPort(parsedBasedURI.Host)
 				flagsArray := []string{"docker", "run",
@@ -439,9 +418,7 @@ func (s *DockerRunSuite) TestRun_SubmitOutputs() {
 				}
 				flagsArray = append(flagsArray, "ubuntu echo 'hello world'")
 
-				_, out, err := ExecuteTestCobraCommand(s.T(), s.rootCmd,
-					flagsArray...,
-				)
+				_, out, err := ExecuteTestCobraCommand(s.T(), flagsArray...)
 
 				if tcids.err != "" {
 					firstFatalError, err := testutils.FirstFatalError(s.T(), out)
@@ -500,15 +477,13 @@ func (s *DockerRunSuite) TestRun_CreatedAt() {
 
 	for i, tc := range tests {
 		func() {
-			*ODR = *NewDockerRunOptions()
-
 			ctx := context.Background()
 			c, cm := publicapi.SetupRequesterNodeForTests(s.T(), false)
 			defer cm.Cleanup()
 
 			parsedBasedURI, _ := url.Parse(c.BaseURI)
 			host, port, _ := net.SplitHostPort(parsedBasedURI.Host)
-			_, out, err := ExecuteTestCobraCommand(s.T(), s.rootCmd, "docker", "run",
+			_, out, err := ExecuteTestCobraCommand(s.T(), "docker", "run",
 				"--api-host", host,
 				"--api-port", port,
 				"ubuntu",
@@ -570,8 +545,6 @@ func (s *DockerRunSuite) TestRun_Annotations() {
 			defer cm.Cleanup()
 
 			for _, labelTest := range annotationsToTest {
-				*ODR = *NewDockerRunOptions()
-
 				// log.Warn().Msgf("%s - Args: %+v", labelTest.Name, os.Args)
 				parsedBasedURI, err := url.Parse(c.BaseURI)
 				require.NoError(s.T(), err)
@@ -589,7 +562,7 @@ func (s *DockerRunSuite) TestRun_Annotations() {
 				randNum, _ := crand.Int(crand.Reader, big.NewInt(10000))
 				args = append(args, fmt.Sprintf("ubuntu echo 'hello world - %s'", randNum.String()))
 
-				_, out, err := ExecuteTestCobraCommand(s.T(), s.rootCmd, args...)
+				_, out, err := ExecuteTestCobraCommand(s.T(), args...)
 				require.NoError(s.T(), err, "Error submitting job. Run - Number of Jobs: %d. Job number: %d", tc.numberOfJobs, i)
 
 				j := testutils.GetJobFromTestOutput(ctx, s.T(), c, out)
@@ -640,13 +613,11 @@ func (s *DockerRunSuite) TestRun_EdgeCaseCLI() {
 			c, cm := publicapi.SetupRequesterNodeForTests(s.T(), false)
 			defer cm.Cleanup()
 
-			*ODR = *NewDockerRunOptions()
-
 			parsedBasedURI, _ := url.Parse(c.BaseURI)
 			host, port, _ := net.SplitHostPort(parsedBasedURI.Host)
 			allArgs := []string{"docker", "run", "--api-host", host, "--api-port", port}
 			allArgs = append(allArgs, tc.submitArgs...)
-			_, out, submitErr := ExecuteTestCobraCommand(s.T(), s.rootCmd, allArgs...)
+			_, out, submitErr := ExecuteTestCobraCommand(s.T(), allArgs...)
 
 			if tc.fatalErr {
 				require.Contains(s.T(), out, tc.errString, "Did not find expected error message for fatalError in error string.\nExpected: %s\nActual: %s", tc.errString, out)
@@ -689,8 +660,6 @@ func (s *DockerRunSuite) TestRun_SubmitWorkdir() {
 			c, cm := publicapi.SetupRequesterNodeForTests(s.T(), false)
 			defer cm.Cleanup()
 
-			*ODR = *NewDockerRunOptions()
-
 			parsedBasedURI, _ := url.Parse(c.BaseURI)
 			host, port, _ := net.SplitHostPort(parsedBasedURI.Host)
 			flagsArray := []string{"docker", "run",
@@ -699,9 +668,7 @@ func (s *DockerRunSuite) TestRun_SubmitWorkdir() {
 			flagsArray = append(flagsArray, "-w", tc.workdir)
 			flagsArray = append(flagsArray, "ubuntu pwd")
 
-			_, out, err := ExecuteTestCobraCommand(s.T(), s.rootCmd,
-				flagsArray...,
-			)
+			_, out, err := ExecuteTestCobraCommand(s.T(), flagsArray...)
 
 			if tc.error_code != 0 {
 				fatalError, err := testutils.FirstFatalError(s.T(), out)
@@ -740,8 +707,6 @@ func (s *DockerRunSuite) TestRun_ExplodeVideos() {
 		requesternode.NewDefaultRequesterNodeConfig(),
 	)
 
-	*ODR = *NewDockerRunOptions()
-
 	dirPath := s.T().TempDir()
 
 	for _, video := range videos {
@@ -771,7 +736,7 @@ func (s *DockerRunSuite) TestRun_ExplodeVideos() {
 		"ubuntu", "echo", "hello",
 	}
 
-	_, _, submitErr := ExecuteTestCobraCommand(s.T(), s.rootCmd, allArgs...)
+	_, _, submitErr := ExecuteTestCobraCommand(s.T(), allArgs...)
 	require.NoError(s.T(), submitErr)
 }
 
@@ -786,10 +751,7 @@ func (s *DockerRunSuite) TestRun_Deterministic_Verifier() {
 		parsedBasedURI, _ := url.Parse(apiClient.BaseURI)
 		host, port, _ := net.SplitHostPort(parsedBasedURI.Host)
 
-		ODR.Inputs = make([]string, 0)
-		ODR.InputVolumes = make([]string, 0)
-
-		_, out, err := ExecuteTestCobraCommand(s.T(), s.rootCmd,
+		_, out, err := ExecuteTestCobraCommand(s.T(),
 			"docker", "run",
 			"--api-host", host,
 			"--api-port", port,
@@ -909,8 +871,6 @@ func (s *DockerRunSuite) TestTruncateReturn() {
 			c, cm := publicapi.SetupRequesterNodeForTests(s.T(), false)
 			defer cm.Cleanup()
 
-			*ODR = *NewDockerRunOptions()
-
 			parsedBasedURI, _ := url.Parse(c.BaseURI)
 			host, port, _ := net.SplitHostPort(parsedBasedURI.Host)
 			flagsArray := []string{"docker", "run",
@@ -919,9 +879,7 @@ func (s *DockerRunSuite) TestTruncateReturn() {
 
 			flagsArray = append(flagsArray, fmt.Sprintf(`ubuntu perl -e "print \"=\" x %d"`, tc.inputLength))
 
-			_, out, err := ExecuteTestCobraCommand(s.T(), s.rootCmd,
-				flagsArray...,
-			)
+			_, out, err := ExecuteTestCobraCommand(s.T(), flagsArray...)
 			require.NoError(s.T(), err, "Error submitting job. Name: %s. Expected Length: %s", name, tc.expectedLength)
 
 			_ = testutils.GetJobFromTestOutput(ctx, s.T(), c, out)
@@ -967,8 +925,6 @@ func (s *DockerRunSuite) TestRun_MutlipleURLs() {
 		c, cm := publicapi.SetupRequesterNodeForTests(s.T(), false)
 		defer cm.Cleanup()
 
-		*ODR = *NewDockerRunOptions()
-
 		parsedBasedURI, _ := url.Parse(c.BaseURI)
 		host, port, _ := net.SplitHostPort(parsedBasedURI.Host)
 
@@ -981,7 +937,7 @@ func (s *DockerRunSuite) TestRun_MutlipleURLs() {
 		args = append(args, tc.inputFlags...)
 		args = append(args, "ubuntu", "--", "ls", "/input")
 
-		_, out, err := ExecuteTestCobraCommand(s.T(), s.rootCmd, args...)
+		_, out, err := ExecuteTestCobraCommand(s.T(), args...)
 		require.NoError(s.T(), err, "Error submitting job")
 
 		j := testutils.GetJobFromTestOutput(ctx, s.T(), c, out)
@@ -1032,7 +988,6 @@ func (s *DockerRunSuite) TestRun_BadExecutables() {
 				node.NewComputeConfigWithDefaults(),
 				requesternode.NewDefaultRequesterNodeConfig(),
 			)
-			*ODR = *NewDockerRunOptions()
 
 			parsedBasedURI, _ := url.Parse(stack.Nodes[0].APIServer.GetURI())
 			host, port, _ := net.SplitHostPort(parsedBasedURI.Host)
@@ -1045,7 +1000,7 @@ func (s *DockerRunSuite) TestRun_BadExecutables() {
 			)
 			args = append(args, tc.imageName, "--", tc.executable)
 
-			_, out, err := ExecuteTestCobraCommand(s.T(), s.rootCmd, args...)
+			_, out, err := ExecuteTestCobraCommand(s.T(), args...)
 			require.NoError(s.T(), err, "Error submitting job")
 
 			if !tc.isValid {
@@ -1058,15 +1013,13 @@ func (s *DockerRunSuite) TestRun_BadExecutables() {
 }
 
 func (s *DockerRunSuite) TestRun_Timeout_DefaultValue() {
-	*ODR = *NewDockerRunOptions()
-
 	ctx := context.Background()
 	c, cm := publicapi.SetupRequesterNodeForTests(s.T(), false)
 	defer cm.Cleanup()
 
 	parsedBasedURI, _ := url.Parse(c.BaseURI)
 	host, port, _ := net.SplitHostPort(parsedBasedURI.Host)
-	_, out, err := ExecuteTestCobraCommand(s.T(), s.rootCmd, "docker", "run",
+	_, out, err := ExecuteTestCobraCommand(s.T(), "docker", "run",
 		"--api-host", host,
 		"--api-port", port,
 		"ubuntu",
@@ -1080,7 +1033,6 @@ func (s *DockerRunSuite) TestRun_Timeout_DefaultValue() {
 }
 
 func (s *DockerRunSuite) TestRun_Timeout_DefinedValue() {
-	*ODR = *NewDockerRunOptions()
 	var expectedTimeout float64 = 999
 
 	ctx := context.Background()
@@ -1089,7 +1041,7 @@ func (s *DockerRunSuite) TestRun_Timeout_DefinedValue() {
 
 	parsedBasedURI, _ := url.Parse(c.BaseURI)
 	host, port, _ := net.SplitHostPort(parsedBasedURI.Host)
-	_, out, err := ExecuteTestCobraCommand(s.T(), s.rootCmd, "docker", "run",
+	_, out, err := ExecuteTestCobraCommand(s.T(), "docker", "run",
 		"--api-host", host,
 		"--api-port", port,
 		"--timeout", fmt.Sprintf("%f", expectedTimeout),

--- a/cmd/bacalhau/flags.go
+++ b/cmd/bacalhau/flags.go
@@ -169,15 +169,6 @@ func storageSpecToIPFSMount(input *model.StorageSpec) string {
 	return fmt.Sprintf("%s:%s", input.CID, input.Path)
 }
 
-func NewIPFSStorageSpecFlag(value *model.StorageSpec) *ValueFlag[model.StorageSpec] {
-	return &ValueFlag[model.StorageSpec]{
-		value:    value,
-		parser:   parseIPFSStorageSpec,
-		stringer: storageSpecToIPFSMount,
-		typeStr:  "cid:path",
-	}
-}
-
 func NewIPFSStorageSpecArrayFlag(value *[]model.StorageSpec) *ArrayValueFlag[model.StorageSpec] {
 	return &ArrayValueFlag[model.StorageSpec]{
 		value:    value,
@@ -197,15 +188,6 @@ func parseURLStorageSpec(inputURL string) (model.StorageSpec, error) {
 		URL:           u.String(),
 		Path:          "/inputs",
 	}, nil
-}
-
-func NewURLStorageSpecFlag(value *model.StorageSpec) *ValueFlag[model.StorageSpec] {
-	return &ValueFlag[model.StorageSpec]{
-		value:    value,
-		parser:   parseURLStorageSpec,
-		stringer: func(s *model.StorageSpec) string { return s.URL },
-		typeStr:  "url",
-	}
 }
 
 func NewURLStorageSpecArrayFlag(value *[]model.StorageSpec) *ArrayValueFlag[model.StorageSpec] {

--- a/cmd/bacalhau/get_test.go
+++ b/cmd/bacalhau/get_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/system"
 	testutils "github.com/filecoin-project/bacalhau/pkg/test/utils"
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -34,7 +33,6 @@ func TestGetSuite(t *testing.T) {
 // returns the current testing context
 type GetSuite struct {
 	suite.Suite
-	rootCmd *cobra.Command
 }
 
 // Before each test
@@ -43,7 +41,6 @@ func (suite *GetSuite) SetupTest() {
 
 	logger.ConfigureTestLogging(suite.T())
 	require.NoError(suite.T(), system.InitConfigForTesting(suite.T()))
-	suite.rootCmd = RootCmd
 }
 
 func testResultsFolderStructure(t *testing.T, baseFolder, hostID string) {
@@ -159,7 +156,6 @@ func (s *GetSuite) TestDockerRunWriteToJobFolderAutoDownload() {
 		node.NewComputeConfigWithDefaults(),
 		requesternode.NewDefaultRequesterNodeConfig(),
 	)
-	*ODR = *NewDockerRunOptions()
 
 	tempDir, cleanup := setupTempWorkingDir(s.T())
 	defer cleanup()
@@ -168,7 +164,7 @@ func (s *GetSuite) TestDockerRunWriteToJobFolderAutoDownload() {
 		"--wait",
 		"--download",
 	})
-	_, runOutput, err := ExecuteTestCobraCommand(s.T(), s.rootCmd, args...)
+	_, runOutput, err := ExecuteTestCobraCommand(s.T(), args...)
 	require.NoError(s.T(), err, "Error submitting job")
 	jobID := system.FindJobIDInTestOutput(runOutput)
 	hostID := stack.Nodes[0].HostID
@@ -186,7 +182,6 @@ func (s *GetSuite) TestDockerRunWriteToJobFolderNamedDownload() {
 		node.NewComputeConfigWithDefaults(),
 		requesternode.NewDefaultRequesterNodeConfig(),
 	)
-	*ODR = *NewDockerRunOptions()
 
 	tempDir, err := os.MkdirTemp("", "docker-run-download-test")
 	require.NoError(s.T(), err)
@@ -196,7 +191,7 @@ func (s *GetSuite) TestDockerRunWriteToJobFolderNamedDownload() {
 		"--download",
 		"--output-dir", tempDir,
 	})
-	_, runOutput, err := ExecuteTestCobraCommand(s.T(), s.rootCmd, args...)
+	_, runOutput, err := ExecuteTestCobraCommand(s.T(), args...)
 	require.NoError(s.T(), err, "Error submitting job")
 	jobID := system.FindJobIDInTestOutput(runOutput)
 	hostID := stack.Nodes[0].HostID
@@ -213,8 +208,6 @@ func (s *GetSuite) TestGetWriteToJobFolderAutoDownload() {
 		node.NewComputeConfigWithDefaults(),
 		requesternode.NewDefaultRequesterNodeConfig(),
 	)
-	*ODR = *NewDockerRunOptions()
-	*OG = *NewGetOptions()
 
 	swarmAddresses, err := stack.Nodes[0].IPFSClient.SwarmAddresses(context.Background())
 	require.NoError(s.T(), err)
@@ -224,12 +217,12 @@ func (s *GetSuite) TestGetWriteToJobFolderAutoDownload() {
 	args := getDockerRunArgs(s.T(), stack, []string{
 		"--wait",
 	})
-	_, out, err := ExecuteTestCobraCommand(s.T(), s.rootCmd, args...)
+	_, out, err := ExecuteTestCobraCommand(s.T(), args...)
 	require.NoError(s.T(), err, "Error submitting job")
 	jobID := system.FindJobIDInTestOutput(out)
 	hostID := stack.Nodes[0].HostID
 
-	_, getOutput, err := ExecuteTestCobraCommand(s.T(), s.rootCmd, "get",
+	_, getOutput, err := ExecuteTestCobraCommand(s.T(), "get",
 		"--api-host", stack.Nodes[0].APIServer.Host,
 		"--api-port", fmt.Sprintf("%d", stack.Nodes[0].APIServer.Port),
 		"--ipfs-swarm-addrs", strings.Join(swarmAddresses, ","),
@@ -249,8 +242,6 @@ func (s *GetSuite) TestGetWriteToJobFolderNamedDownload() {
 		node.NewComputeConfigWithDefaults(),
 		requesternode.NewDefaultRequesterNodeConfig(),
 	)
-	*ODR = *NewDockerRunOptions()
-	*OG = *NewGetOptions()
 
 	swarmAddresses, err := stack.Nodes[0].IPFSClient.SwarmAddresses(ctx)
 	require.NoError(s.T(), err)
@@ -261,13 +252,13 @@ func (s *GetSuite) TestGetWriteToJobFolderNamedDownload() {
 	args := getDockerRunArgs(s.T(), stack, []string{
 		"--wait",
 	})
-	_, out, err := ExecuteTestCobraCommand(s.T(), s.rootCmd, args...)
+	_, out, err := ExecuteTestCobraCommand(s.T(), args...)
 
 	require.NoError(s.T(), err, "Error submitting job")
 	jobID := system.FindJobIDInTestOutput(out)
 	hostID := stack.Nodes[0].HostID
 
-	_, getOutput, err := ExecuteTestCobraCommand(s.T(), s.rootCmd, "get",
+	_, getOutput, err := ExecuteTestCobraCommand(s.T(), "get",
 		"--api-host", stack.Nodes[0].APIServer.Host,
 		"--api-port", fmt.Sprintf("%d", stack.Nodes[0].APIServer.Port),
 		"--ipfs-swarm-addrs", strings.Join(swarmAddresses, ","),

--- a/cmd/bacalhau/id.go
+++ b/cmd/bacalhau/id.go
@@ -15,35 +15,43 @@ type IDInfo struct {
 	ID string `json:"ID"`
 }
 
-func init() { //nolint:gochecknoinits // Using init in cobra command is idomatic
-	setupLibp2pCLIFlags(idCmd)
+func newIDCmd() *cobra.Command {
+	OS := NewServeOptions()
+
+	idCmd := &cobra.Command{
+		Use:   "id",
+		Short: "Show bacalhau node id info",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return id(cmd, OS)
+		},
+	}
+
+	setupLibp2pCLIFlags(idCmd, OS)
+
+	return idCmd
 }
 
-var idCmd = &cobra.Command{
-	Use:   "id",
-	Short: "Show bacalhau node id info",
-	RunE: func(cmd *cobra.Command, _ []string) error {
-		// Cleanup manager ensures that resources are freed before exiting:
-		cm := system.NewCleanupManager()
-		cm.RegisterCallback(system.CleanupTraceProvider)
-		defer cm.Cleanup()
-		ctx := cmd.Context()
+func id(cmd *cobra.Command, OS *ServeOptions) error {
+	// Cleanup manager ensures that resources are freed before exiting:
+	cm := system.NewCleanupManager()
+	cm.RegisterCallback(system.CleanupTraceProvider)
+	defer cm.Cleanup()
+	ctx := cmd.Context()
 
-		transport, err := libp2p.NewTransport(ctx, cm, OS.SwarmPort, []multiaddr.Multiaddr{})
-		if err != nil {
-			return err
-		}
+	transport, err := libp2p.NewTransport(ctx, cm, OS.SwarmPort, []multiaddr.Multiaddr{})
+	if err != nil {
+		return err
+	}
 
-		info := IDInfo{
-			ID: transport.HostID(),
-		}
+	info := IDInfo{
+		ID: transport.HostID(),
+	}
 
-		enc := json.NewEncoder(os.Stdout)
-		enc.SetIndent("", "    ")
-		if err := enc.Encode(info); err != nil {
-			return err
-		}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "    ")
+	if err := enc.Encode(info); err != nil {
+		return err
+	}
 
-		return nil
-	},
+	return nil
 }

--- a/cmd/bacalhau/list.go
+++ b/cmd/bacalhau/list.go
@@ -28,11 +28,6 @@ var (
 
 		# List jobs and output as json
 		bacalhau list --output json`))
-
-	// Set Defaults (probably a better way to do this)
-	OL = NewListOptions()
-
-	// For the -f flag
 )
 
 type ListOptions struct {
@@ -61,7 +56,20 @@ func NewListOptions() *ListOptions {
 	}
 }
 
-func init() { //nolint:gochecknoinits // Using init in cobra command is idomatic
+func newListCmd() *cobra.Command {
+	OL := NewListOptions()
+
+	listCmd := &cobra.Command{
+		Use:     "list",
+		Short:   "List jobs on the network",
+		Long:    listLong,
+		Example: listExample,
+		PreRun:  applyPorcelainLogLevel,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return list(cmd, OL)
+		},
+	}
+
 	listCmd.PersistentFlags().BoolVar(&OL.HideHeader, "hide-header", OL.HideHeader,
 		`do not print the column headers.`)
 	listCmd.PersistentFlags().StringVar(&OL.IDFilter, "id-filter", OL.IDFilter, `filter by Job List to IDs matching substring.`)
@@ -94,6 +102,8 @@ func init() { //nolint:gochecknoinits // Using init in cobra command is idomatic
 		//nolint:lll // Documentation
 		`Fetch all jobs from the network (default is to filter those belonging to the user). This option may take a long time to return, please use with caution.`,
 	)
+
+	return listCmd
 }
 
 // From: https://stackoverflow.com/questions/50824554/permitted-flag-values-for-cobra
@@ -124,98 +134,91 @@ func (c *ColumnEnum) Set(v string) error {
 	}
 }
 
-var listCmd = &cobra.Command{
-	Use:     "list",
-	Short:   "List jobs on the network",
-	Long:    listLong,
-	Example: listExample,
-	PreRun:  applyPorcelainLogLevel,
-	RunE: func(cmd *cobra.Command, _ []string) error {
-		cm := system.NewCleanupManager()
-		defer cm.Cleanup()
-		ctx := cmd.Context()
+func list(cmd *cobra.Command, OL *ListOptions) error {
+	cm := system.NewCleanupManager()
+	defer cm.Cleanup()
+	ctx := cmd.Context()
 
-		ctx, rootSpan := system.NewRootSpan(ctx, system.GetTracer(), "cmd/bacalhau/list")
-		defer rootSpan.End()
-		cm.RegisterCallback(system.CleanupTraceProvider)
+	ctx, rootSpan := system.NewRootSpan(ctx, system.GetTracer(), "cmd/bacalhau/list")
+	defer rootSpan.End()
+	cm.RegisterCallback(system.CleanupTraceProvider)
 
-		log.Debug().Msgf("Table filter flag set to: %s", OL.IDFilter)
-		log.Debug().Msgf("Table limit flag set to: %d", OL.MaxJobs)
-		log.Debug().Msgf("Table output format flag set to: %s", OL.OutputFormat)
-		log.Debug().Msgf("Table reverse flag set to: %t", OL.SortReverse)
-		log.Debug().Msgf("Found return all flag: %t", OL.ReturnAll)
-		log.Debug().Msgf("Found sort flag: %s", OL.SortBy)
-		log.Debug().Msgf("Found hide header flag set to: %t", OL.HideHeader)
-		log.Debug().Msgf("Found no-style header flag set to: %t", OL.NoStyle)
-		log.Debug().Msgf("Found output wide flag set to: %t", OL.OutputWide)
+	log.Debug().Msgf("Table filter flag set to: %s", OL.IDFilter)
+	log.Debug().Msgf("Table limit flag set to: %d", OL.MaxJobs)
+	log.Debug().Msgf("Table output format flag set to: %s", OL.OutputFormat)
+	log.Debug().Msgf("Table reverse flag set to: %t", OL.SortReverse)
+	log.Debug().Msgf("Found return all flag: %t", OL.ReturnAll)
+	log.Debug().Msgf("Found sort flag: %s", OL.SortBy)
+	log.Debug().Msgf("Found hide header flag set to: %t", OL.HideHeader)
+	log.Debug().Msgf("Found no-style header flag set to: %t", OL.NoStyle)
+	log.Debug().Msgf("Found output wide flag set to: %t", OL.OutputWide)
 
-		jobs, err := GetAPIClient().List(ctx, OL.IDFilter, OL.MaxJobs, OL.ReturnAll, OL.SortBy.String(), OL.SortReverse)
+	jobs, err := GetAPIClient().List(ctx, OL.IDFilter, OL.MaxJobs, OL.ReturnAll, OL.SortBy.String(), OL.SortReverse)
+	if err != nil {
+		Fatal(cmd, fmt.Sprintf("Error listing jobs: %s", err), 1)
+	}
+
+	numberInTable := system.Min(OL.MaxJobs, len(jobs))
+	log.Debug().Msgf("Number of jobs printing: %d", numberInTable)
+
+	var msgBytes []byte
+	if OL.OutputFormat == JSONFormat {
+		msgBytes, err = model.JSONMarshalWithMax(jobs)
 		if err != nil {
-			Fatal(fmt.Sprintf("Error listing jobs: %s", err), 1)
+			Fatal(cmd, fmt.Sprintf("Error marshaling jobs to JSON: %s", err), 1)
 		}
+		cmd.Printf("%s\n", msgBytes)
+	} else {
+		tw := table.NewWriter()
+		tw.SetOutputMirror(cmd.OutOrStderr())
+		if !OL.HideHeader {
+			tw.AppendHeader(table.Row{"created", "id", "job", "state", "verified", "published"})
+		}
+		columnConfig := []table.ColumnConfig{}
+		tw.SetColumnConfigs(columnConfig)
 
-		numberInTable := system.Min(OL.MaxJobs, len(jobs))
-		log.Debug().Msgf("Number of jobs printing: %d", numberInTable)
-
-		var msgBytes []byte
-		if OL.OutputFormat == JSONFormat {
-			msgBytes, err = model.JSONMarshalWithMax(jobs)
+		var rows []table.Row
+		for _, j := range jobs {
+			var summaryRow table.Row
+			summaryRow, err = summarizeJob(ctx, j, OL)
 			if err != nil {
-				Fatal(fmt.Sprintf("Error marshaling jobs to JSON: %s", err), 1)
+				Fatal(cmd, fmt.Sprintf("Error summarizing job: %s", err), 1)
 			}
-			cmd.Printf("%s\n", msgBytes)
+			rows = append(rows, summaryRow)
+		}
+		if err != nil {
+			return err
+		}
+		tw.AppendRows(rows)
+
+		if OL.NoStyle {
+			tw.SetStyle(table.Style{
+				Name:   "StyleDefault",
+				Box:    table.StyleBoxDefault,
+				Color:  table.ColorOptionsDefault,
+				Format: table.FormatOptionsDefault,
+				HTML:   table.DefaultHTMLOptions,
+				Options: table.Options{
+					DrawBorder:      false,
+					SeparateColumns: false,
+					SeparateFooter:  false,
+					SeparateHeader:  false,
+					SeparateRows:    false,
+				},
+				Title: table.TitleOptionsDefault,
+			})
 		} else {
-			tw := table.NewWriter()
-			tw.SetOutputMirror(cmd.OutOrStderr())
-			if !OL.HideHeader {
-				tw.AppendHeader(table.Row{"created", "id", "job", "state", "verified", "published"})
-			}
-			columnConfig := []table.ColumnConfig{}
-			tw.SetColumnConfigs(columnConfig)
-
-			rows := []table.Row{}
-			for _, j := range jobs {
-				var summaryRow table.Row
-				summaryRow, err = summarizeJob(ctx, j)
-				if err != nil {
-					Fatal(fmt.Sprintf("Error summarizing job: %s", err), 1)
-				}
-				rows = append(rows, summaryRow)
-			}
-			if err != nil {
-				return err
-			}
-			tw.AppendRows(rows)
-
-			if OL.NoStyle {
-				tw.SetStyle(table.Style{
-					Name:   "StyleDefault",
-					Box:    table.StyleBoxDefault,
-					Color:  table.ColorOptionsDefault,
-					Format: table.FormatOptionsDefault,
-					HTML:   table.DefaultHTMLOptions,
-					Options: table.Options{
-						DrawBorder:      false,
-						SeparateColumns: false,
-						SeparateFooter:  false,
-						SeparateHeader:  false,
-						SeparateRows:    false,
-					},
-					Title: table.TitleOptionsDefault,
-				})
-			} else {
-				tw.SetStyle(table.StyleColoredGreenWhiteOnBlack)
-			}
-
-			tw.Render()
+			tw.SetStyle(table.StyleColoredGreenWhiteOnBlack)
 		}
 
-		return nil
-	},
+		tw.Render()
+	}
+
+	return nil
 }
 
 // Renders job details into a table row
-func summarizeJob(ctx context.Context, j *model.Job) (table.Row, error) {
+func summarizeJob(ctx context.Context, j *model.Job, OL *ListOptions) (table.Row, error) {
 	//nolint:ineffassign,staticcheck // For tracing
 	ctx, span := system.GetTracer().Start(ctx, "cmd/bacalhau/list.summarizeJob")
 	defer span.End()

--- a/cmd/bacalhau/list_test.go
+++ b/cmd/bacalhau/list_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/filecoin-project/bacalhau/pkg/publicapi"
 	"github.com/filecoin-project/bacalhau/pkg/system"
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -27,7 +26,6 @@ import (
 // returns the current testing context
 type ListSuite struct {
 	suite.Suite
-	rootCmd *cobra.Command
 }
 
 // In order for 'go test' to run this suite, we need to create
@@ -38,7 +36,6 @@ func TestListSuite(t *testing.T) {
 
 // Before each test
 func (suite *ListSuite) SetupTest() {
-	suite.rootCmd = RootCmd
 	logger.ConfigureTestLogging(suite.T())
 }
 
@@ -64,10 +61,6 @@ func (suite *ListSuite) TestList_NumberOfJobs() {
 			c, cm := publicapi.SetupRequesterNodeForTests(suite.T(), false)
 			defer cm.Cleanup()
 
-			*OL = *NewListOptions()
-			OL.IDFilter = ""
-			OL.SortReverse = false
-
 			for i := 0; i < tc.numberOfJobs; i++ {
 				j := publicapi.MakeNoopJob()
 				_, err := c.Submit(ctx, j, nil)
@@ -76,11 +69,12 @@ func (suite *ListSuite) TestList_NumberOfJobs() {
 
 			parsedBasedURI, _ := url.Parse(c.BaseURI)
 			host, port, _ := net.SplitHostPort(parsedBasedURI.Host)
-			_, out, err := ExecuteTestCobraCommand(suite.T(), suite.rootCmd, "list",
+			_, out, err := ExecuteTestCobraCommand(suite.T(), "list",
 				"--hide-header",
 				"--api-host", host,
 				"--api-port", port,
 				"--number", fmt.Sprintf("%d", tc.numberOfJobsOutput),
+				"--reverse", "false",
 			)
 			require.NoError(suite.T(), err)
 
@@ -94,8 +88,6 @@ func (suite *ListSuite) TestList_IdFilter() {
 	c, cm := publicapi.SetupRequesterNodeForTests(suite.T(), false)
 	defer cm.Cleanup()
 
-	*OL = *NewListOptions()
-
 	// submit 10 jobs
 	jobIds := []string{}
 	jobLongIds := []string{}
@@ -103,14 +95,14 @@ func (suite *ListSuite) TestList_IdFilter() {
 		var err error
 		j := publicapi.MakeNoopJob()
 		j, err = c.Submit(ctx, j, nil)
-		jobIds = append(jobIds, shortID(OL.OutputWide, j.ID))
+		jobIds = append(jobIds, shortID(false, j.ID))
 		jobLongIds = append(jobIds, j.ID)
 		require.NoError(suite.T(), err)
 	}
 
 	parsedBasedURI, _ := url.Parse(c.BaseURI)
 	host, port, _ := net.SplitHostPort(parsedBasedURI.Host)
-	_, out, err := ExecuteTestCobraCommand(suite.T(), suite.rootCmd, "list",
+	_, out, err := ExecuteTestCobraCommand(suite.T(), "list",
 		"--hide-header",
 		"--api-host", host,
 		"--api-port", port,
@@ -133,7 +125,7 @@ func (suite *ListSuite) TestList_IdFilter() {
 	//// Test --output json
 
 	// _, out, err = ExecuteTestCobraCommand(suite.T(), suite.rootCmd, "list",
-	_, out, err = ExecuteTestCobraCommand(suite.T(), suite.rootCmd, "list",
+	_, out, err = ExecuteTestCobraCommand(suite.T(), "list",
 		"--hide-header",
 		"--api-host", host,
 		"--api-port", port,
@@ -189,22 +181,18 @@ func (suite *ListSuite) TestList_SortFlags() {
 
 	for _, tc := range combinationOfJobSizes {
 		for _, sortFlags := range sortFlagsToTest {
-			func() {
+			suite.Run(fmt.Sprintf("%#v/%#v", tc, sortFlags), func() {
 				ctx := context.Background()
 				c, cm := publicapi.SetupRequesterNodeForTests(suite.T(), false)
 				defer cm.Cleanup()
 
-				*OL = *NewListOptions()
-				OL.IDFilter = ""
-				OL.SortReverse = false
-
-				jobIDs := []string{}
+				var jobIDs []string
 				for i := 0; i < tc.numberOfJobs; i++ {
 					var err error
 					j := publicapi.MakeNoopJob()
 					j, err = c.Submit(ctx, j, nil)
 					require.NoError(suite.T(), err)
-					jobIDs = append(jobIDs, shortID(OL.OutputWide, j.ID))
+					jobIDs = append(jobIDs, shortID(false, j.ID))
 
 					// all the middle jobs can have the same timestamp
 					// but we need the first and last to differ
@@ -220,12 +208,12 @@ func (suite *ListSuite) TestList_SortFlags() {
 				host, port, err := net.SplitHostPort(parsedBasedURI.Host)
 				require.NoError(suite.T(), err)
 
-				reverseString := ""
+				reverseString := "--reverse=false"
 				if sortFlags.reverseFlag {
 					reverseString = "--reverse"
 				}
 
-				_, out, err := ExecuteTestCobraCommand(suite.T(), suite.rootCmd,
+				_, out, err := ExecuteTestCobraCommand(suite.T(),
 					"list",
 					"--hide-header",
 					"--no-style",
@@ -291,7 +279,7 @@ Compare Ids:
 						}
 					}
 				}
-			}()
+			})
 		}
 	}
 }

--- a/cmd/bacalhau/run.go
+++ b/cmd/bacalhau/run.go
@@ -7,23 +7,22 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//nolint:gochecknoinits
-func init() {
-	runCmd.AddCommand(runPythonCmd)
-}
+func newRunCmd() *cobra.Command {
+	runCmd := &cobra.Command{
+		Use:    "run",
+		Short:  "Run a job on the network (see subcommands for supported flavors)",
+		PreRun: applyPorcelainLogLevel,
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			// Check that the server version is compatible with the client version
+			serverVersion, _ := GetAPIClient().Version(cmd.Context()) // Ok if this fails, version validation will skip
+			if err := ensureValidVersion(cmd.Context(), version.Get(), serverVersion); err != nil {
+				Fatal(cmd, fmt.Sprintf("version validation failed: %s", err), 1)
+				return err
+			}
 
-var runCmd = &cobra.Command{
-	Use:    "run",
-	Short:  "Run a job on the network (see subcommands for supported flavors)",
-	PreRun: applyPorcelainLogLevel,
-	PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
-		// Check that the server version is compatible with the client version
-		serverVersion, _ := GetAPIClient().Version(cmd.Context()) // Ok if this fails, version validation will skip
-		if err := ensureValidVersion(cmd.Context(), version.Get(), serverVersion); err != nil {
-			Fatal(fmt.Sprintf("version validation failed: %s", err), 1)
-			return err
-		}
-
-		return nil
-	},
+			return nil
+		},
+	}
+	runCmd.AddCommand(newRunPythonCmd())
+	return runCmd
 }

--- a/cmd/bacalhau/serve.go
+++ b/cmd/bacalhau/serve.go
@@ -41,8 +41,6 @@ var (
 
 	serveExample = templates.Examples(i18n.T(`
 		TBD`))
-
-	OS = NewServeOptions()
 )
 
 type ServeOptions struct {
@@ -93,7 +91,7 @@ func NewServeOptions() *ServeOptions {
 	}
 }
 
-func setupJobSelectionCLIFlags(cmd *cobra.Command) {
+func setupJobSelectionCLIFlags(cmd *cobra.Command, OS *ServeOptions) {
 	cmd.PersistentFlags().StringVar(
 		&OS.JobSelectionDataLocality, "job-selection-data-locality", OS.JobSelectionDataLocality,
 		`Only accept jobs that reference data we have locally ("local") or anywhere ("anywhere").`,
@@ -112,7 +110,7 @@ func setupJobSelectionCLIFlags(cmd *cobra.Command) {
 	)
 }
 
-func setupCapacityManagerCLIFlags(cmd *cobra.Command) {
+func setupCapacityManagerCLIFlags(cmd *cobra.Command, OS *ServeOptions) {
 	cmd.PersistentFlags().StringVar(
 		&OS.LimitTotalCPU, "limit-total-cpu", OS.LimitTotalCPU,
 		`Total CPU core limit to run all jobs (e.g. 500m, 2, 8).`,
@@ -139,7 +137,7 @@ func setupCapacityManagerCLIFlags(cmd *cobra.Command) {
 	)
 }
 
-func setupLibp2pCLIFlags(cmd *cobra.Command) {
+func setupLibp2pCLIFlags(cmd *cobra.Command, OS *ServeOptions) {
 	cmd.PersistentFlags().StringVar(
 		&OS.PeerConnect, "peer", OS.PeerConnect,
 		`The libp2p multiaddress to connect to.`,
@@ -154,7 +152,7 @@ func setupLibp2pCLIFlags(cmd *cobra.Command) {
 	)
 }
 
-func getPeers() []multiaddr.Multiaddr {
+func getPeers(OS *ServeOptions) []multiaddr.Multiaddr {
 	var peersStrings []string
 	if OS.PeerConnect == "none" {
 		peersStrings = []string{}
@@ -171,7 +169,7 @@ func getPeers() []multiaddr.Multiaddr {
 	return peers
 }
 
-func getJobSelectionConfig() model.JobSelectionPolicy {
+func getJobSelectionConfig(OS *ServeOptions) model.JobSelectionPolicy {
 	// construct the job selection policy from the CLI args
 	typedJobSelectionDataLocality := model.Anywhere
 
@@ -189,9 +187,9 @@ func getJobSelectionConfig() model.JobSelectionPolicy {
 	return jobSelectionPolicy
 }
 
-func getComputeConfig() node.ComputeConfig {
+func getComputeConfig(OS *ServeOptions) node.ComputeConfig {
 	return node.NewComputeConfigWith(node.ComputeConfigParams{
-		JobSelectionPolicy: getJobSelectionConfig(),
+		JobSelectionPolicy: getJobSelectionConfig(OS),
 		TotalResourceLimits: capacity.ParseResourceUsageConfig(model.ResourceUsageConfig{
 			CPU:    OS.LimitTotalCPU,
 			Memory: OS.LimitTotalMemory,
@@ -206,7 +204,19 @@ func getComputeConfig() node.ComputeConfig {
 	})
 }
 
-func init() { //nolint:gochecknoinits // Using init in cobra command is idomatic
+func newServeCmd() *cobra.Command {
+	OS := NewServeOptions()
+
+	serveCmd := &cobra.Command{
+		Use:     "serve",
+		Short:   "Start the bacalhau compute node",
+		Long:    serveLong,
+		Example: serveExample,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return serve(cmd, OS)
+		},
+	}
+
 	serveCmd.PersistentFlags().StringVar(
 		&OS.IPFSConnect, "ipfs-connect", OS.IPFSConnect,
 		`The ipfs host multiaddress to connect to.`,
@@ -240,108 +250,104 @@ func init() { //nolint:gochecknoinits // Using init in cobra command is idomatic
 		"The highest ping a Filecoin miner could have when selecting.",
 	)
 
-	setupLibp2pCLIFlags(serveCmd)
-	setupJobSelectionCLIFlags(serveCmd)
-	setupCapacityManagerCLIFlags(serveCmd)
+	setupLibp2pCLIFlags(serveCmd, OS)
+	setupJobSelectionCLIFlags(serveCmd, OS)
+	setupCapacityManagerCLIFlags(serveCmd, OS)
+
+	return serveCmd
 }
 
-var serveCmd = &cobra.Command{
-	Use:     "serve",
-	Short:   "Start the bacalhau compute node",
-	Long:    serveLong,
-	Example: serveExample,
-	RunE: func(cmd *cobra.Command, _ []string) error {
-		// Cleanup manager ensures that resources are freed before exiting:
-		cm := system.NewCleanupManager()
-		cm.RegisterCallback(system.CleanupTraceProvider)
-		defer cm.Cleanup()
+func serve(cmd *cobra.Command, OS *ServeOptions) error {
+	// Cleanup manager ensures that resources are freed before exiting:
+	cm := system.NewCleanupManager()
+	cm.RegisterCallback(system.CleanupTraceProvider)
+	defer cm.Cleanup()
 
-		ctx := cmd.Context()
+	ctx := cmd.Context()
 
-		// Context ensures main goroutine waits until killed with ctrl+c:
-		ctx, cancel := system.WithSignalShutdown(ctx)
-		defer cancel()
+	// Context ensures main goroutine waits until killed with ctrl+c:
+	ctx, cancel := system.WithSignalShutdown(ctx)
+	defer cancel()
 
-		ctx, rootSpan := system.NewRootSpan(ctx, system.GetTracer(), "cmd/bacalhau/serve")
-		defer rootSpan.End()
-		cm.RegisterCallback(system.CleanupTraceProvider)
+	ctx, rootSpan := system.NewRootSpan(ctx, system.GetTracer(), "cmd/bacalhau/serve")
+	defer rootSpan.End()
+	cm.RegisterCallback(system.CleanupTraceProvider)
 
-		if OS.IPFSConnect == "" {
-			Fatal("You must specify --ipfs-connect.", 1)
+	if OS.IPFSConnect == "" {
+		Fatal(cmd, "You must specify --ipfs-connect.", 1)
+	}
+
+	if OS.JobSelectionDataLocality != "local" && OS.JobSelectionDataLocality != "anywhere" {
+		Fatal(cmd, "--job-selection-data-locality must be either 'local' or 'anywhere'", 1)
+	}
+
+	// Establishing p2p connection
+	peers := getPeers(OS)
+	log.Debug().Msgf("libp2p connecting to: %s", peers)
+
+	transport, err := libp2p.NewTransport(ctx, cm, OS.SwarmPort, peers)
+	if err != nil {
+		Fatal(cmd, fmt.Sprintf("Error creating libp2p transport: %s", err), 1)
+	}
+
+	// add nodeID to logging context
+	ctx = logger.ContextWithNodeIDLogger(ctx, transport.HostID())
+
+	// Establishing IPFS connection
+	ipfs, err := ipfs.NewClient(OS.IPFSConnect)
+	if err != nil {
+		Fatal(cmd, fmt.Sprintf("Error creating IPFS client: %s", err), 1)
+	}
+
+	datastore, err := inmemory.NewInMemoryDatastore()
+	if err != nil {
+		Fatal(cmd, fmt.Sprintf("Error creating in memory datastore: %s", err), 1)
+	}
+
+	// Create node config from cmd arguments
+	nodeConfig := node.NodeConfig{
+		IPFSClient:           ipfs,
+		CleanupManager:       cm,
+		LocalDB:              datastore,
+		Transport:            transport,
+		FilecoinUnsealedPath: OS.FilecoinUnsealedPath,
+		EstuaryAPIKey:        OS.EstuaryAPIKey,
+		HostAddress:          OS.HostAddress,
+		APIPort:              apiPort,
+		MetricsPort:          OS.MetricsPort,
+		ComputeConfig:        getComputeConfig(OS),
+		RequesterNodeConfig:  requesternode.NewDefaultRequesterNodeConfig(),
+	}
+
+	if OS.LotusFilecoinStorageDuration != time.Duration(0) &&
+		OS.LotusFilecoinPathDirectory != "" &&
+		OS.LotusFilecoinMaximumPing != time.Duration(0) {
+		nodeConfig.LotusConfig = &filecoinlotus.PublisherConfig{
+			StorageDuration: OS.LotusFilecoinStorageDuration,
+			PathDir:         OS.LotusFilecoinPathDirectory,
+			UploadDir:       OS.LotusFilecoinUploadDirectory,
+			MaximumPing:     OS.LotusFilecoinMaximumPing,
 		}
+	}
 
-		if OS.JobSelectionDataLocality != "local" && OS.JobSelectionDataLocality != "anywhere" {
-			Fatal("--job-selection-data-locality must be either 'local' or 'anywhere'", 1)
-		}
+	// Create node
+	node, err := node.NewStandardNode(ctx, nodeConfig)
+	if err != nil {
+		Fatal(cmd, fmt.Sprintf("Error creating node: %s", err), 1)
+	}
 
-		// Establishing p2p connection
-		peers := getPeers()
-		log.Debug().Msgf("libp2p connecting to: %s", peers)
+	// Start transport layer
+	err = transport.Start(ctx)
+	if err != nil {
+		Fatal(cmd, fmt.Sprintf("Error starting transport layer: %s", err), 1)
+	}
 
-		transport, err := libp2p.NewTransport(ctx, cm, OS.SwarmPort, peers)
-		if err != nil {
-			Fatal(fmt.Sprintf("Error creating libp2p transport: %s", err), 1)
-		}
+	// Start node
+	err = node.Start(ctx)
+	if err != nil {
+		Fatal(cmd, fmt.Sprintf("Error starting node: %s", err), 1)
+	}
 
-		// add nodeID to logging context
-		ctx = logger.ContextWithNodeIDLogger(ctx, transport.HostID())
-
-		// Establishing IPFS connection
-		ipfs, err := ipfs.NewClient(OS.IPFSConnect)
-		if err != nil {
-			Fatal(fmt.Sprintf("Error creating IPFS client: %s", err), 1)
-		}
-
-		datastore, err := inmemory.NewInMemoryDatastore()
-		if err != nil {
-			Fatal(fmt.Sprintf("Error creating in memory datastore: %s", err), 1)
-		}
-
-		// Create node config from cmd arguments
-		nodeConfig := node.NodeConfig{
-			IPFSClient:           ipfs,
-			CleanupManager:       cm,
-			LocalDB:              datastore,
-			Transport:            transport,
-			FilecoinUnsealedPath: OS.FilecoinUnsealedPath,
-			EstuaryAPIKey:        OS.EstuaryAPIKey,
-			HostAddress:          OS.HostAddress,
-			APIPort:              apiPort,
-			MetricsPort:          OS.MetricsPort,
-			ComputeConfig:        getComputeConfig(),
-			RequesterNodeConfig:  requesternode.NewDefaultRequesterNodeConfig(),
-		}
-
-		if OS.LotusFilecoinStorageDuration != time.Duration(0) &&
-			OS.LotusFilecoinPathDirectory != "" &&
-			OS.LotusFilecoinMaximumPing != time.Duration(0) {
-			nodeConfig.LotusConfig = &filecoinlotus.PublisherConfig{
-				StorageDuration: OS.LotusFilecoinStorageDuration,
-				PathDir:         OS.LotusFilecoinPathDirectory,
-				UploadDir:       OS.LotusFilecoinUploadDirectory,
-				MaximumPing:     OS.LotusFilecoinMaximumPing,
-			}
-		}
-
-		// Create node
-		node, err := node.NewStandardNode(ctx, nodeConfig)
-		if err != nil {
-			Fatal(fmt.Sprintf("Error creating node: %s", err), 1)
-		}
-
-		// Start transport layer
-		err = transport.Start(ctx)
-		if err != nil {
-			Fatal(fmt.Sprintf("Error starting transport layer: %s", err), 1)
-		}
-
-		// Start node
-		err = node.Start(ctx)
-		if err != nil {
-			Fatal(fmt.Sprintf("Error starting node: %s", err), 1)
-		}
-
-		<-ctx.Done() // block until killed
-		return nil
-	},
+	<-ctx.Done() // block until killed
+	return nil
 }

--- a/cmd/bacalhau/serve_test.go
+++ b/cmd/bacalhau/serve_test.go
@@ -29,7 +29,6 @@ import (
 // returns the current testing context
 type ServeSuite struct {
 	suite.Suite
-	rootCmd *cobra.Command
 }
 
 // In order for 'go test' to run this suite, we need to create
@@ -42,7 +41,6 @@ func TestServeSuite(t *testing.T) {
 func (suite *ServeSuite) SetupTest() {
 	logger.ConfigureTestLogging(suite.T())
 	require.NoError(suite.T(), system.InitConfigForTesting(suite.T()))
-	suite.rootCmd = RootCmd
 }
 
 func writeToServeChannel(rootCmd *cobra.Command, port int, wg *sync.WaitGroup) {
@@ -57,7 +55,8 @@ func writeToServeChannel(rootCmd *cobra.Command, port int, wg *sync.WaitGroup) {
 
 	ipfsPort, _ := freeport.GetFreePort()
 
-	args := []string{"serve", "--ipfs-connect", fmt.Sprintf("/ip4/127.0.0.1/tcp/%d", ipfsPort), "--api-port", fmt.Sprintf("%d", port)}
+	// peer set to none to avoid accidentally talking to production endpoints
+	args := []string{"serve", "--peer", "none", "--ipfs-connect", fmt.Sprintf("/ip4/127.0.0.1/tcp/%d", ipfsPort), "--api-port", fmt.Sprintf("%d", port)}
 
 	rootCmd.SetArgs(args)
 
@@ -88,10 +87,6 @@ func curlEndpoint(URL string) (string, error) {
 }
 
 func (suite *ServeSuite) TestRun_GenericServe() {
-
-	*OS = *NewServeOptions()
-	OS.PeerConnect = "none" // avoid accidentally talking to production endpoints
-
 	port, err := freeport.GetFreePort()
 
 	require.NoError(suite.T(), err, "Error getting free port.")
@@ -99,7 +94,7 @@ func (suite *ServeSuite) TestRun_GenericServe() {
 	var wg sync.WaitGroup
 	wg.Add(2)
 
-	go writeToServeChannel(suite.rootCmd, port, &wg)
+	go writeToServeChannel(NewRootCmd(), port, &wg)
 
 	timeoutInMilliseconds := 20 * 1000
 	currentTime := 0

--- a/cmd/bacalhau/simulator.go
+++ b/cmd/bacalhau/simulator.go
@@ -7,29 +7,31 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() { //nolint:gochecknoinits // Using init in cobra command is idomatic
-
+func newSimulatorCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "simulator",
+		Short: "Run the bacalhau simulator",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSimulator(cmd)
+		},
+	}
 }
 
-var simulatorCmd = &cobra.Command{
-	Use:   "simulator",
-	Short: "Run the bacalhau simulator",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		// Cleanup manager ensures that resources are freed before exiting:
-		cm := system.NewCleanupManager()
-		cm.RegisterCallback(system.CleanupTraceProvider)
-		defer cm.Cleanup()
-		ctx := cmd.Context()
-		localDB, err := inmemory.NewInMemoryDatastore()
-		if err != nil {
-			return err
-		}
-		server := simulator.NewServer(ctx, "0.0.0.0", 9075, localDB) //nolint:gomnd
-		err = server.ListenAndServe(ctx, cm)
-		if err != nil {
-			return err
-		}
-		<-ctx.Done()
-		return nil
-	},
+func runSimulator(cmd *cobra.Command) error {
+	// Cleanup manager ensures that resources are freed before exiting:
+	cm := system.NewCleanupManager()
+	cm.RegisterCallback(system.CleanupTraceProvider)
+	defer cm.Cleanup()
+	ctx := cmd.Context()
+	localDB, err := inmemory.NewInMemoryDatastore()
+	if err != nil {
+		return err
+	}
+	server := simulator.NewServer(ctx, "0.0.0.0", 9075, localDB) //nolint:gomnd
+	err = server.ListenAndServe(ctx, cm)
+	if err != nil {
+		return err
+	}
+	<-ctx.Done()
+	return nil
 }

--- a/cmd/bacalhau/utils.go
+++ b/cmd/bacalhau/utils.go
@@ -164,20 +164,18 @@ curl -sL https://get.bacalhau.org/install.sh | bash`,
 	return nil
 }
 
-func ExecuteTestCobraCommand(t *testing.T, root *cobra.Command, args ...string) (
-	c *cobra.Command, output string, err error,
-) {
-	return ExecuteTestCobraCommandWithStdin(t, root, nil, args...)
+func ExecuteTestCobraCommand(t *testing.T, args ...string) (c *cobra.Command, output string, err error) {
+	return ExecuteTestCobraCommandWithStdin(t, nil, args...)
 }
 
-func ExecuteTestCobraCommandWithStdin(_ *testing.T, root *cobra.Command, stdin io.Reader, args ...string) (
+func ExecuteTestCobraCommandWithStdin(_ *testing.T, stdin io.Reader, args ...string) (
 	c *cobra.Command, output string, err error,
 ) { //nolint:unparam // use of t is valuable here
 	buf := new(bytes.Buffer)
+	root := NewRootCmd()
 	root.SetOut(buf)
 	root.SetErr(buf)
 	root.SetIn(stdin)
-	root.SetArgs([]string{})
 	root.SetArgs(args)
 
 	// Need to check if we're running in debug mode for VSCode
@@ -191,44 +189,6 @@ func ExecuteTestCobraCommandWithStdin(_ *testing.T, root *cobra.Command, stdin i
 
 	c, err = root.ExecuteC()
 	return c, buf.String(), err
-}
-
-// this function captures the output of all functions running in it between capture() and done()
-// example:
-// 	done := capture()
-//	fmt.Println("hello")
-//	s, _ := done()
-// after trimming str := strings.TrimSpace(s) it will return "hello"
-// so if we want to compare the output in the console with a expected output like "hello" we could do that
-// this is mainly used in testing --local
-// go playground link https://go.dev/play/p/cuGIaIorWfD
-
-//nolint:unused
-func capture() func() (string, error) {
-	r, w, err := os.Pipe()
-	if err != nil {
-		panic(err)
-	}
-
-	done := make(chan error, 1)
-
-	save := os.Stdout
-	os.Stdout = w
-
-	var buf strings.Builder
-
-	go func() {
-		_, err := io.Copy(&buf, r)
-		r.Close()
-		done <- err
-	}()
-
-	return func() (string, error) {
-		os.Stdout = save
-		w.Close()
-		err := <-done
-		return buf.String(), err
-	}
 }
 
 func NewIPFSDownloadFlags(settings *ipfs.IPFSDownloadSettings) *pflag.FlagSet {
@@ -370,26 +330,26 @@ func ExecuteJob(ctx context.Context,
 	// i.e. don't print
 	quiet := runtimeSettings.PrintJobIDOnly
 
-	err = WaitAndPrintResultsToUser(ctx, j, quiet)
+	err = WaitAndPrintResultsToUser(ctx, cmd, j, quiet)
 	if err != nil {
 		if err.Error() == PrintoutCanceledButRunningNormally {
-			Fatal("", 0)
+			Fatal(cmd, "", 0)
 		} else {
-			Fatal(fmt.Sprintf("Error submitting job: %s", err), 1)
+			Fatal(cmd, fmt.Sprintf("Error submitting job: %s", err), 1)
 		}
 	}
 
 	jobReturn, found, err := apiClient.Get(ctx, j.ID)
 	if err != nil {
-		Fatal(fmt.Sprintf("Error getting job: %s", err), 1)
+		Fatal(cmd, fmt.Sprintf("Error getting job: %s", err), 1)
 	}
 	if !found {
-		Fatal(fmt.Sprintf("Weird. Just ran the job, but we couldn't find it. Should be impossible. ID: %s", j.ID), 1)
+		Fatal(cmd, fmt.Sprintf("Weird. Just ran the job, but we couldn't find it. Should be impossible. ID: %s", j.ID), 1)
 	}
 
 	js, err := apiClient.GetJobState(ctx, jobReturn.ID)
 	if err != nil {
-		Fatal(fmt.Sprintf("Error getting job state: %s", err), 1)
+		Fatal(cmd, fmt.Sprintf("Error getting job state: %s", err), 1)
 	}
 
 	// Need to create index because map ordering are not guaranteed
@@ -451,7 +411,7 @@ To get more details about the run, execute:
 		resultsCID = fmt.Sprintf("Results CID: %s\n", resultsCID)
 	}
 	if !quiet {
-		RootCmd.Print(fmt.Sprintf(printOut, resultsCID))
+		cmd.Print(fmt.Sprintf(printOut, resultsCID))
 	}
 
 	if runtimeSettings.AutoDownloadResults {
@@ -483,7 +443,7 @@ func downloadResultsHandler(
 		if _, ok := err.(*bacerrors.JobNotFound); ok {
 			return err
 		} else {
-			Fatal(fmt.Sprintf("Unknown error trying to get job (ID: %s): %+v", jobID, err), 1)
+			Fatal(cmd, fmt.Sprintf("Unknown error trying to get job (ID: %s): %+v", jobID, err), 1)
 		}
 	}
 
@@ -534,9 +494,9 @@ func submitJob(ctx context.Context,
 	return j, err
 }
 
-func ReadFromStdinIfAvailable(_ *cobra.Command, args []string) ([]byte, error) {
+func ReadFromStdinIfAvailable(cmd *cobra.Command, args []string) ([]byte, error) {
 	if len(args) == 0 {
-		r := bufio.NewReader(RootCmd.InOrStdin())
+		r := bufio.NewReader(cmd.InOrStdin())
 		reader := bufio.NewReader(r)
 
 		// buffered channel of dataStream
@@ -570,7 +530,7 @@ func ReadFromStdinIfAvailable(_ *cobra.Command, args []string) ([]byte, error) {
 		}
 
 		if timedOut {
-			RootCmd.Println("No input provided, waiting ... (Ctrl+D to complete)")
+			cmd.Println("No input provided, waiting ... (Ctrl+D to complete)")
 		}
 
 		for read := range dataStream {
@@ -583,7 +543,7 @@ func ReadFromStdinIfAvailable(_ *cobra.Command, args []string) ([]byte, error) {
 }
 
 //nolint:gocyclo,funlen // Better way to do this, Go doesn't have a switch on type
-func WaitAndPrintResultsToUser(ctx context.Context, j *model.Job, quiet bool) error {
+func WaitAndPrintResultsToUser(ctx context.Context, cmd *cobra.Command, j *model.Job, quiet bool) error {
 	if j == nil || j.ID == "" {
 		return errors.New("No job returned from the server.")
 	}
@@ -592,8 +552,8 @@ To get more information at any time, run:
    bacalhau describe %s`, j.ID)
 
 	if !quiet {
-		RootCmd.Printf("Job successfully submitted. Job ID: %s\n", j.ID)
-		RootCmd.Printf("Checking job status... (Enter Ctrl+C to exit at any time, your job will continue running):\n\n")
+		cmd.Printf("Job successfully submitted. Job ID: %s\n", j.ID)
+		cmd.Printf("Checking job status... (Enter Ctrl+C to exit at any time, your job will continue running):\n\n")
 	}
 
 	// Create a map of job state types to printed structs
@@ -609,7 +569,7 @@ To get more information at any time, run:
 
 	jobEvents, err := GetAPIClient().GetEvents(ctx, j.ID)
 	if err != nil {
-		Fatal(fmt.Sprintf("Failure retrieving job events '%s': %s\n", j.ID, err), 1)
+		Fatal(cmd, fmt.Sprintf("Failure retrieving job events '%s': %s\n", j.ID, err), 1)
 	}
 
 	// Capture Ctrl+C if the user wants to finish early the job
@@ -634,13 +594,13 @@ To get more information at any time, run:
 				// because the loop finished normally.
 				if !finishedRunning {
 					if !quiet {
-						RootCmd.Println("\n\n\rPrintout canceled (the job is still running).")
-						RootCmd.Println(getMoreInfoString)
+						cmd.Println("\n\n\rPrintout canceled (the job is still running).")
+						cmd.Println(getMoreInfoString)
 					}
 					returnError = fmt.Errorf(PrintoutCanceledButRunningNormally)
 				}
 			} else {
-				RootCmd.Println("Unexpected signal received. Exiting.")
+				cmd.Println("Unexpected signal received. Exiting.")
 			}
 			cancel()
 		case <-ctx.Done():
@@ -661,15 +621,15 @@ To get more information at any time, run:
 
 			if err != nil {
 				if _, ok := err.(*bacerrors.JobNotFound); ok {
-					Fatal(fmt.Sprintf("Somehow even though we submitted a job successfully, we were not able to get its status. ID: %s", j.ID), 1)
+					Fatal(cmd, fmt.Sprintf("Somehow even though we submitted a job successfully, we were not able to get its status. ID: %s", j.ID), 1)
 				} else {
-					Fatal(fmt.Sprintf("Unknown error trying to get job (ID: %s): %+v", j.ID, err), 1)
+					Fatal(cmd, fmt.Sprintf("Unknown error trying to get job (ID: %s): %+v", j.ID, err), 1)
 				}
 			}
 
 			if !quiet {
 				for i := range jobEvents {
-					printingUpdateForEvent(printedEventsTracker, jobEvents[i].EventName)
+					printingUpdateForEvent(cmd, printedEventsTracker, jobEvents[i].EventName)
 				}
 			}
 
@@ -706,7 +666,7 @@ To get more information at any time, run:
 	return returnError
 }
 
-func printingUpdateForEvent(pe map[model.JobEventType]*printedEvents, jet model.JobEventType) {
+func printingUpdateForEvent(cmd *cobra.Command, pe map[model.JobEventType]*printedEvents, jet model.JobEventType) {
 	maxLength := 0
 	for _, v := range eventsWorthPrinting {
 		if len(v.Message) > maxLength {
@@ -723,27 +683,27 @@ func printingUpdateForEvent(pe map[model.JobEventType]*printedEvents, jet model.
 			firstLine = firstLine && !pe[v].printed
 		}
 		if !firstLine {
-			RootCmd.Println("done ✅")
+			cmd.Println("done ✅")
 		}
 
-		RootCmd.Printf("\t%s%s",
+		cmd.Printf("\t%s%s",
 			strings.Repeat(" ", maxLength-len(eventsWorthPrinting[jet].Message)+2),
 			eventsWorthPrinting[jet].Message)
 		if !eventsWorthPrinting[jet].IsTerminal {
-			RootCmd.Print(" ... ")
+			cmd.Print(" ... ")
 		} else {
-			RootCmd.Println()
+			cmd.Println()
 		}
 		pe[jet].printed = true
 	}
 }
-func FatalErrorHandler(msg string, code int) {
+func FatalErrorHandler(cmd *cobra.Command, msg string, code int) {
 	if len(msg) > 0 {
 		// add newline if needed
 		if !strings.HasSuffix(msg, "\n") {
 			msg += "\n"
 		}
-		RootCmd.Print(msg)
+		cmd.Print(msg)
 	}
 	os.Exit(code)
 }
@@ -752,10 +712,10 @@ func FatalErrorHandler(msg string, code int) {
 // NOTE: If your test is not idempotent, you can cause side effects
 // (the underlying function will continue to run)
 // Returned as text JSON to wherever RootCmd is printing.
-func FakeFatalErrorHandler(msg string, code int) {
+func FakeFatalErrorHandler(cmd *cobra.Command, msg string, code int) {
 	c := model.TestFatalErrorHandlerContents{Message: msg, Code: code}
 	b, _ := model.JSONMarshalWithMax(c)
-	RootCmd.Println(string(b))
+	cmd.Println(string(b))
 }
 
 // applyPorcelainLogLevel sets the log level of loggers running on user-facing

--- a/cmd/bacalhau/utils_test.go
+++ b/cmd/bacalhau/utils_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/filecoin-project/bacalhau/pkg/system"
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -24,12 +23,10 @@ func TestUtilsSuite(t *testing.T) {
 // returns the current testing context
 type UtilsSuite struct {
 	suite.Suite
-	rootCmd *cobra.Command
 }
 
 // Before each test
 func (s *UtilsSuite) SetupTest() {
-	s.rootCmd = RootCmd
 	logger.ConfigureTestLogging(s.T())
 }
 

--- a/cmd/bacalhau/validate_test.go
+++ b/cmd/bacalhau/validate_test.go
@@ -12,14 +12,12 @@ import (
 	"github.com/filecoin-project/bacalhau/pkg/publicapi"
 	"github.com/filecoin-project/bacalhau/pkg/system"
 	testutils "github.com/filecoin-project/bacalhau/pkg/test/utils"
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
 type ValidateSuite struct {
 	suite.Suite
-	rootCmd *cobra.Command
 }
 
 func TestValidateSuite(t *testing.T) {
@@ -30,7 +28,6 @@ func TestValidateSuite(t *testing.T) {
 func (s *ValidateSuite) SetupTest() {
 	logger.ConfigureTestLogging(s.T())
 	require.NoError(s.T(), system.InitConfigForTesting(s.T()))
-	s.rootCmd = RootCmd
 }
 
 func (s *ValidateSuite) TestValidate() {
@@ -49,13 +46,11 @@ func (s *ValidateSuite) TestValidate() {
 			c, cm := publicapi.SetupRequesterNodeForTests(s.T(), false)
 			defer cm.Cleanup()
 
-			*OV = *NewValidateOptions()
-
 			parsedBasedURI, err := url.Parse(c.BaseURI)
 			require.NoError(s.T(), err)
 
 			host, port, _ := net.SplitHostPort(parsedBasedURI.Host)
-			_, out, err := ExecuteTestCobraCommand(s.T(), s.rootCmd, "validate",
+			_, out, err := ExecuteTestCobraCommand(s.T(), "validate",
 				"--api-host", host,
 				"--api-port", port,
 				test.testFile,

--- a/cmd/bacalhau/version_test.go
+++ b/cmd/bacalhau/version_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/filecoin-project/bacalhau/pkg/publicapi"
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -36,12 +35,10 @@ func TestVersionSuite(t *testing.T) {
 
 type VersionSuite struct {
 	suite.Suite
-	rootCmd *cobra.Command
 }
 
 // Before each test
 func (suite *VersionSuite) SetupTest() {
-	suite.rootCmd = RootCmd
 	logger.ConfigureTestLogging(suite.T())
 }
 
@@ -51,7 +48,7 @@ func (suite *VersionSuite) Test_Version() {
 
 	parsedBasedURI, _ := url.Parse(c.BaseURI)
 	host, port, _ := net.SplitHostPort(parsedBasedURI.Host)
-	_, out, err := ExecuteTestCobraCommand(suite.T(), suite.rootCmd, "version",
+	_, out, err := ExecuteTestCobraCommand(suite.T(), "version",
 		"--api-host", host,
 		"--api-port", port,
 	)
@@ -67,7 +64,7 @@ func (suite *VersionSuite) Test_VersionOutputs() {
 
 	parsedBasedURI, _ := url.Parse(c.BaseURI)
 	host, port, _ := net.SplitHostPort(parsedBasedURI.Host)
-	_, out, err := ExecuteTestCobraCommand(suite.T(), suite.rootCmd, "version",
+	_, out, err := ExecuteTestCobraCommand(suite.T(), "version",
 		"--api-host", host,
 		"--api-port", port,
 		"--output", JSONFormat,
@@ -79,7 +76,7 @@ func (suite *VersionSuite) Test_VersionOutputs() {
 	require.NoError(suite.T(), err, "Could not unmarshall the output into json - %+v", err)
 	require.Equal(suite.T(), jsonDoc.ClientVersion.GitCommit, jsonDoc.ServerVersion.GitCommit, "Client and Server do not match in json.")
 
-	_, out, err = ExecuteTestCobraCommand(suite.T(), suite.rootCmd, "version",
+	_, out, err = ExecuteTestCobraCommand(suite.T(), "version",
 		"--api-host", host,
 		"--api-port", port,
 		"--output", YAMLFormat,

--- a/cmd/bacalhau/wasm_run.go
+++ b/cmd/bacalhau/wasm_run.go
@@ -22,13 +22,8 @@ import (
 
 const null rune = 0
 
-var wasmJob *model.Job
-
-var runtimeSettings *RunTimeSettings
-var downloadSettings *ipfs.IPFSDownloadSettings
-
-func init() { //nolint:gochecknoinits // idiomatic for cobra commands
-	wasmJob, _ = model.NewJobWithSaneProductionDefaults()
+func defaultWasmJobSpec() *model.Job {
+	wasmJob, _ := model.NewJobWithSaneProductionDefaults()
 	wasmJob.Spec.Engine = model.EngineWasm
 	wasmJob.Spec.Verifier = model.VerifierDeterministic
 	wasmJob.Spec.Timeout = DefaultTimeout.Seconds()
@@ -41,16 +36,53 @@ func init() { //nolint:gochecknoinits // idiomatic for cobra commands
 		},
 	}
 
+	return wasmJob
+}
+
+func newWasmCmd() *cobra.Command {
+	wasmCmd := &cobra.Command{
+		Use:   "wasm",
+		Short: "Run and prepare WASM jobs on the network",
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			// Check that the server version is compatible with the client version
+			serverVersion, _ := GetAPIClient().Version(cmd.Context()) // Ok if this fails, version validation will skip
+			if err := ensureValidVersion(cmd.Context(), version.Get(), serverVersion); err != nil {
+				Fatal(cmd, fmt.Sprintf("version validation failed: %s", err), 1)
+				return err
+			}
+
+			return nil
+		},
+	}
+
 	wasmCmd.AddCommand(
-		runWasmCommand,
-		validateWasmCommand,
+		newRunWasmCmd(),
+		newValidateWasmCmd(),
 	)
 
-	runtimeSettings = NewRunTimeSettings()
+	return wasmCmd
+}
+
+func newRunWasmCmd() *cobra.Command {
+	wasmJob := defaultWasmJobSpec()
+	runtimeSettings := NewRunTimeSettings()
+	downloadSettings := ipfs.NewIPFSDownloadSettings()
+
+	runWasmCommand := &cobra.Command{
+		Use:     "run {cid-of-wasm | <local.wasm>} [--entry-point <string>] [wasm-args ...]",
+		Short:   "Run a WASM job on the network",
+		Long:    languageRunLong,
+		Example: languageRunExample,
+		Args:    cobra.MinimumNArgs(1),
+		PreRun:  applyPorcelainLogLevel,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runWasm(cmd, args, wasmJob, runtimeSettings, downloadSettings)
+		},
+	}
+
 	settingsFlags := NewRunTimeSettingsFlags(runtimeSettings)
 	runWasmCommand.Flags().AddFlagSet(settingsFlags)
 
-	downloadSettings = ipfs.NewIPFSDownloadSettings()
 	downloadFlags := NewIPFSDownloadFlags(downloadSettings)
 	runWasmCommand.Flags().AddFlagSet(downloadFlags)
 
@@ -78,7 +110,7 @@ func init() { //nolint:gochecknoinits // idiomatic for cobra commands
 		&wasmJob.Spec.Timeout, "timeout", wasmJob.Spec.Timeout,
 		`Job execution timeout in seconds (e.g. 300 for 5 minutes and 0.1 for 100ms)`,
 	)
-	wasmCmd.PersistentFlags().StringVar(
+	runWasmCommand.PersistentFlags().StringVar(
 		&wasmJob.Spec.Wasm.EntryPoint, "entry-point", wasmJob.Spec.Wasm.EntryPoint,
 		`The name of the WASM function in the entry module to call. This should be a zero-parameter zero-result function that 
 		will execute the job.`,
@@ -106,140 +138,141 @@ func init() { //nolint:gochecknoinits // idiomatic for cobra commands
 		NewIPFSStorageSpecArrayFlag(&wasmJob.Spec.Wasm.ImportModules), "import-module-volumes", "I",
 		`CID:path of the WASM modules to import from IPFS, if you need to set the path of the mounted data.`,
 	)
+
+	return runWasmCommand
 }
 
-var wasmCmd = &cobra.Command{
-	Use:   "wasm",
-	Short: "Run and prepare WASM jobs on the network",
-	PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
-		// Check that the server version is compatible with the client version
-		serverVersion, _ := GetAPIClient().Version(cmd.Context()) // Ok if this fails, version validation will skip
-		if err := ensureValidVersion(cmd.Context(), version.Get(), serverVersion); err != nil {
-			Fatal(fmt.Sprintf("version validation failed: %s", err), 1)
-			return err
-		}
+func runWasm(
+	cmd *cobra.Command,
+	args []string,
+	wasmJob *model.Job,
+	runtimeSettings *RunTimeSettings,
+	downloadSettings *ipfs.IPFSDownloadSettings,
+) error {
+	cm := system.NewCleanupManager()
+	defer cm.Cleanup()
 
-		return nil
-	},
-}
+	ctx, rootSpan := system.NewRootSpan(cmd.Context(), system.GetTracer(), "cmd/bacalhau/wasm_run.runWasmCommand")
+	defer rootSpan.End()
+	cm.RegisterCallback(system.CleanupTraceProvider)
 
-var runWasmCommand = &cobra.Command{
-	Use:     "run {cid-of-wasm | <local.wasm>} [--entry-point <string>] [wasm-args ...]",
-	Short:   "Run a WASM job on the network",
-	Long:    languageRunLong,
-	Example: languageRunExample,
-	Args:    cobra.MinimumNArgs(1),
-	PreRun:  applyPorcelainLogLevel,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		cm := system.NewCleanupManager()
-		defer cm.Cleanup()
+	var buf bytes.Buffer
+	wasmCidOrPath := args[0]
+	wasmJob.Spec.Wasm.Parameters = args[1:]
 
-		ctx, rootSpan := system.NewRootSpan(cmd.Context(), system.GetTracer(), "cmd/bacalhau/wasm_run.runWasmCommand")
-		defer rootSpan.End()
-		cm.RegisterCallback(system.CleanupTraceProvider)
-
-		var buf bytes.Buffer
-		wasmCidOrPath := args[0]
-		wasmJob.Spec.Wasm.Parameters = args[1:]
-
-		// Try interpreting this as a CID.
-		wasmCid, err := cid.Parse(wasmCidOrPath)
-		if err == nil {
-			// It is a valid CID – proceed to create IPFS context.
-			wasmJob.Spec.Contexts = append(wasmJob.Spec.Contexts, model.StorageSpec{
-				StorageSource: model.StorageSourceIPFS,
-				CID:           wasmCid.String(),
-				Path:          "/job",
-			})
-		} else {
-			// Try interpreting this as a path.
-			info, err := os.Stat(wasmCidOrPath)
-			if err != nil {
-				if os.IsNotExist(err) {
-					return fmt.Errorf("%q is not a valid CID or local file: %s", wasmCidOrPath, err.Error())
-				} else {
-					return err
-				}
-			}
-
-			if !info.Mode().IsRegular() {
-				return fmt.Errorf("%s should point to a single file", wasmCidOrPath)
-			}
-
-			err = os.Chdir(filepath.Dir(wasmCidOrPath))
-			if err != nil {
-				return err
-			}
-
-			cmd.Printf("Uploading %q to server to execute command in context, press Ctrl+C to cancel\n", wasmCidOrPath)
-			time.Sleep(1 * time.Second)
-			err = targzip.Compress(ctx, filepath.Base(wasmCidOrPath), &buf)
-			if err != nil {
+	// Try interpreting this as a CID.
+	wasmCid, err := cid.Parse(wasmCidOrPath)
+	if err == nil {
+		// It is a valid CID – proceed to create IPFS context.
+		wasmJob.Spec.Contexts = append(wasmJob.Spec.Contexts, model.StorageSpec{
+			StorageSource: model.StorageSourceIPFS,
+			CID:           wasmCid.String(),
+			Path:          "/job",
+		})
+	} else {
+		// Try interpreting this as a path.
+		info, err := os.Stat(wasmCidOrPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return fmt.Errorf("%q is not a valid CID or local file: %s", wasmCidOrPath, err.Error())
+			} else {
 				return err
 			}
 		}
 
-		// We can only use a Deterministic verifier if we have multiple nodes running the job
-		// If the user has selected a Deterministic verifier (or we are using it by default)
-		// then switch back to a Noop Verifier if the concurrency is too low.
-		if wasmJob.Deal.Concurrency <= 1 && wasmJob.Spec.Verifier == model.VerifierDeterministic {
-			wasmJob.Spec.Verifier = model.VerifierNoop
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("%s should point to a single file", wasmCidOrPath)
 		}
 
-		// See wazero.ModuleConfig.WithEnv
-		for key, value := range wasmJob.Spec.Wasm.EnvironmentVariables {
-			for _, str := range []string{key, value} {
-				if str == "" || strings.ContainsRune(str, null) {
-					return fmt.Errorf("invalid environment variable %s=%s", key, value)
-				}
+		err = os.Chdir(filepath.Dir(wasmCidOrPath))
+		if err != nil {
+			return err
+		}
+
+		cmd.Printf("Uploading %q to server to execute command in context, press Ctrl+C to cancel\n", wasmCidOrPath)
+		time.Sleep(1 * time.Second)
+		err = targzip.Compress(ctx, filepath.Base(wasmCidOrPath), &buf)
+		if err != nil {
+			return err
+		}
+	}
+
+	// We can only use a Deterministic verifier if we have multiple nodes running the job
+	// If the user has selected a Deterministic verifier (or we are using it by default)
+	// then switch back to a Noop Verifier if the concurrency is too low.
+	if wasmJob.Deal.Concurrency <= 1 && wasmJob.Spec.Verifier == model.VerifierDeterministic {
+		wasmJob.Spec.Verifier = model.VerifierNoop
+	}
+
+	// See wazero.ModuleConfig.WithEnv
+	for key, value := range wasmJob.Spec.Wasm.EnvironmentVariables {
+		for _, str := range []string{key, value} {
+			if str == "" || strings.ContainsRune(str, null) {
+				return fmt.Errorf("invalid environment variable %s=%s", key, value)
 			}
 		}
+	}
 
-		return ExecuteJob(ctx, cm, cmd, wasmJob, *runtimeSettings, *downloadSettings, &buf)
-	},
+	return ExecuteJob(ctx, cm, cmd, wasmJob, *runtimeSettings, *downloadSettings, &buf)
 }
 
-var validateWasmCommand = &cobra.Command{
-	Use:   "validate <local.wasm> [--entry-point <string>]",
-	Short: "Check that a WASM program is runnable on the network",
-	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		cm := system.NewCleanupManager()
-		defer cm.Cleanup()
+func newValidateWasmCmd() *cobra.Command {
+	wasmJob := defaultWasmJobSpec()
 
-		ctx, rootSpan := system.NewRootSpan(cmd.Context(), system.GetTracer(), "cmd/bacalhau/wasm_run.validateWasmCommand")
-		defer rootSpan.End()
-		cm.RegisterCallback(system.CleanupTraceProvider)
+	validateWasmCommand := &cobra.Command{
+		Use:   "validate <local.wasm> [--entry-point <string>]",
+		Short: "Check that a WASM program is runnable on the network",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return validateWasm(cmd, args, wasmJob)
+		},
+	}
 
-		programPath := args[0]
-		entryPoint := wasmJob.Spec.Wasm.EntryPoint
+	validateWasmCommand.PersistentFlags().StringVar(
+		&wasmJob.Spec.Wasm.EntryPoint, "entry-point", wasmJob.Spec.Wasm.EntryPoint,
+		`The name of the WASM function in the entry module to call. This should be a zero-parameter zero-result function that 
+		will execute the job.`,
+	)
 
-		engine := wazero.NewRuntime(ctx)
-		module, err := wasm.LoadModule(ctx, engine, programPath)
-		if err != nil {
-			Fatal(err.Error(), 1)
-			return err
-		}
+	return validateWasmCommand
+}
 
-		wasi, err := wasi_snapshot_preview1.NewBuilder(engine).Compile(ctx)
-		if err != nil {
-			Fatal(err.Error(), 3)
-			return err
-		}
+func validateWasm(cmd *cobra.Command, args []string, wasmJob *model.Job) error {
+	cm := system.NewCleanupManager()
+	defer cm.Cleanup()
 
-		err = wasm.ValidateModuleImports(module, wasi)
-		if err != nil {
-			Fatal(err.Error(), 2)
-			return err
-		}
+	ctx, rootSpan := system.NewRootSpan(cmd.Context(), system.GetTracer(), "cmd/bacalhau/wasm_run.validateWasmCommand")
+	defer rootSpan.End()
+	cm.RegisterCallback(system.CleanupTraceProvider)
 
-		err = wasm.ValidateModuleAsEntryPoint(module, entryPoint)
-		if err != nil {
-			Fatal(err.Error(), 2)
-			return err
-		}
+	programPath := args[0]
+	entryPoint := wasmJob.Spec.Wasm.EntryPoint
 
-		cmd.Println("OK")
-		return nil
-	},
+	engine := wazero.NewRuntime(ctx)
+	module, err := wasm.LoadModule(ctx, engine, programPath)
+	if err != nil {
+		Fatal(cmd, err.Error(), 1)
+		return err
+	}
+
+	wasi, err := wasi_snapshot_preview1.NewBuilder(engine).Compile(ctx)
+	if err != nil {
+		Fatal(cmd, err.Error(), 3)
+		return err
+	}
+
+	err = wasm.ValidateModuleImports(module, wasi)
+	if err != nil {
+		Fatal(cmd, err.Error(), 2)
+		return err
+	}
+
+	err = wasm.ValidateModuleAsEntryPoint(module, entryPoint)
+	if err != nil {
+		Fatal(cmd, err.Error(), 2)
+		return err
+	}
+
+	cmd.Println("OK")
+	return nil
 }

--- a/ops/aws/canary/lambda/pkg/test/scenarios_test.go
+++ b/ops/aws/canary/lambda/pkg/test/scenarios_test.go
@@ -10,15 +10,20 @@ import (
 	"github.com/filecoin-project/bacalhau/ops/aws/canary/pkg/router"
 	"github.com/filecoin-project/bacalhau/pkg/node"
 	"github.com/filecoin-project/bacalhau/pkg/requesternode"
-	"github.com/filecoin-project/bacalhau/pkg/test/utils"
+	testutils "github.com/filecoin-project/bacalhau/pkg/test/utils"
 	"github.com/stretchr/testify/require"
 )
 
 func TestScenarios(t *testing.T) {
 	stack, _ := testutils.SetupTest(context.Background(), t, 1, 0, false, node.NewComputeConfigWithDefaults(), requesternode.NewDefaultRequesterNodeConfig())
 
-	os.Setenv("BACALHAU_HOST", stack.Nodes[0].APIServer.Host)
-	os.Setenv("BACALHAU_PORT", fmt.Sprint(stack.Nodes[0].APIServer.Port))
+	host := stack.Nodes[0].APIServer.Host
+	port := stack.Nodes[0].APIServer.Port
+	t.Log("Host set to", host)
+	t.Log("Port set to", port)
+
+	os.Setenv("BACALHAU_HOST", host)
+	os.Setenv("BACALHAU_PORT", fmt.Sprint(port))
 
 	for name := range router.TestcasesMap {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/executor/util/utils.go
+++ b/pkg/executor/util/utils.go
@@ -143,7 +143,7 @@ func NewStandardExecutorProvider(
 		return nil, err
 	}
 
-	exPythonWasm, err := pythonwasm.NewExecutor(ctx, cm, executors)
+	exPythonWasm, err := pythonwasm.NewExecutor(executors)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/job/state.go
+++ b/pkg/job/state.go
@@ -400,6 +400,11 @@ func WaitThrowErrors(errorStates []model.JobStateType) CheckStatesFunction {
 		for _, shard := range allShardStates { //nolint:gocritic
 			for _, errorState := range errorStates {
 				if shard.State == errorState {
+					e := log.Debug()
+					if shard.RunOutput != nil {
+						e = e.Str("stdout", shard.RunOutput.STDOUT).Str("stderr", shard.RunOutput.STDERR)
+					}
+					e.Msg("Shard failed")
 					return false, fmt.Errorf("job has error state %s on node %s (%s)", shard.State.String(), shard.NodeID, shard.Status)
 				}
 			}

--- a/pkg/test/devstack/pythonwasm_test.go
+++ b/pkg/test/devstack/pythonwasm_test.go
@@ -102,7 +102,7 @@ func (s *DevstackPythonWASMSuite) TestPythonWasmVolumes() {
 	err = os.WriteFile("main.py", mainPy, 0644)
 	require.NoError(s.T(), err)
 
-	_, out, err := cmd.ExecuteTestCobraCommand(s.T(), cmd.RootCmd,
+	_, out, err := cmd.ExecuteTestCobraCommand(s.T(),
 		fmt.Sprintf("--api-port=%d", stack.Nodes[0].APIServer.Port),
 		"--api-host=localhost",
 		"run",
@@ -163,7 +163,8 @@ func (s *DevstackPythonWASMSuite) TestPythonWasmVolumes() {
 	require.Equal(s.T(), fileContents, strings.TrimSpace(string(outputData)))
 }
 func (s *DevstackPythonWASMSuite) TestSimplestPythonWasmDashC() {
-	s.T().Skip("This test fails when run directly after TestPythonWasmVolumes :-(")
+	testutils.SkipIfArm(s.T(), "https://github.com/filecoin-project/bacalhau/issues/1268")
+	cmd.Fatal = cmd.FakeFatalErrorHandler
 
 	ctx := context.Background()
 	stack, cm := testutils.SetupTest(ctx, s.T(), 1, 0, false,
@@ -177,7 +178,7 @@ func (s *DevstackPythonWASMSuite) TestSimplestPythonWasmDashC() {
 
 	// TODO: see also list_test.go, maybe factor out a common way to do this cli
 	// setup
-	_, out, err := cmd.ExecuteTestCobraCommand(s.T(), cmd.RootCmd,
+	_, out, err := cmd.ExecuteTestCobraCommand(s.T(),
 		fmt.Sprintf("--api-port=%d", stack.Nodes[0].APIServer.Port),
 		"--api-host=localhost",
 		"run",
@@ -188,8 +189,10 @@ func (s *DevstackPythonWASMSuite) TestSimplestPythonWasmDashC() {
 	)
 	require.NoError(s.T(), err)
 
-	jobId := strings.TrimSpace(out)
+	jobId := system.FindJobIDInTestOutput(out)
+	require.NoError(s.T(), err)
 	log.Debug().Msgf("jobId=%s", jobId)
+	time.Sleep(time.Second * 5)
 
 	node := stack.Nodes[0]
 	apiUri := node.APIServer.GetURI()
@@ -204,7 +207,8 @@ func (s *DevstackPythonWASMSuite) TestSimplestPythonWasmDashC() {
 // TODO: test that > 10MB context is rejected
 
 func (s *DevstackPythonWASMSuite) TestSimplePythonWasm() {
-	s.T().Skip("This test fails when run directly after TestPythonWasmVolumes :-(")
+	testutils.SkipIfArm(s.T(), "https://github.com/filecoin-project/bacalhau/issues/1268")
+	cmd.Fatal = cmd.FakeFatalErrorHandler
 
 	ctx := context.Background()
 	stack, cm := testutils.SetupTest(ctx, s.T(), 1, 0, false,
@@ -228,11 +232,11 @@ func (s *DevstackPythonWASMSuite) TestSimplePythonWasm() {
 	}()
 
 	// write bytes to main.py
-	mainPy := []byte("print(1+1)")
+	mainPy := []byte("print(1+1)\n")
 	err = os.WriteFile("main.py", mainPy, 0644)
 	require.NoError(s.T(), err)
 
-	_, out, err := cmd.ExecuteTestCobraCommand(s.T(), cmd.RootCmd,
+	_, out, err := cmd.ExecuteTestCobraCommand(s.T(),
 		fmt.Sprintf("--api-port=%d", stack.Nodes[0].APIServer.Port),
 		"--api-host=localhost",
 		"run",
@@ -241,7 +245,9 @@ func (s *DevstackPythonWASMSuite) TestSimplePythonWasm() {
 		"main.py",
 	)
 	require.NoError(s.T(), err)
-	jobId := strings.TrimSpace(out)
+
+	jobId := system.FindJobIDInTestOutput(out)
+	require.NotEmpty(s.T(), jobId, "Unable to find Job ID in", out)
 	log.Debug().Msgf("jobId=%s", jobId)
 	time.Sleep(time.Second * 5)
 


### PR DESCRIPTION
This fixes the stability of the Python WASM tests so that they can be enabled and run as part of the integration tests. The issues that had to be fixed were:

* Bit rot in the tests from not being enabled for a while, such as the output no longer just having the job ID
* Bug in the pyodide image which assumed `inputs` was always defined for a Job spec
* Removing a workaround, adding an invalid dummy IPFS volume, for the above bug which no longer worked and caused the job to fail
* Change how cobra commands are constructed to avoid global variables. This caused issues in a number of places where the contents of the struct used to collect the command line flags, as the struct was never reset between test runs.

The bulk of the PR is changing from using `init` functions to build up the `cobra.Command` values to using a 'constructor' function. This means that tests can be assured they are using a 'fresh' command every time and exposes some copy/paste errors where a global variable was being used in the wrong command, such as the dry-run flag in `create`.

Fixes #765
Fixes #382