### PR TITLE
Include CID returned from Estuary in job results

### DIFF
--- a/pkg/publisher/estuary/endpoints.go
+++ b/pkg/publisher/estuary/endpoints.go
@@ -7,7 +7,6 @@ import (
 )
 
 const gatewayEndpoint string = "https://api.estuary.tech"
-const uploadEndpoint string = "https://upload.estuary.tech"
 
 func getAPIConfig(baseURL string, apiKey string) *estuary_client.Configuration {
 	config := estuary_client.NewConfiguration()
@@ -16,14 +15,7 @@ func getAPIConfig(baseURL string, apiKey string) *estuary_client.Configuration {
 	return config
 }
 
-// We need 2 different API endpoints because uploading via the main API URL
-// gives a 404 and trying to read via the Upload URL gives a 404 :-(
-func GetGatewayClient(ctx context.Context, apiKey string) *estuary_client.APIClient {
+func GetClient(ctx context.Context, apiKey string) *estuary_client.APIClient {
 	gatewayConfig := getAPIConfig(gatewayEndpoint, apiKey)
 	return estuary_client.NewAPIClient(gatewayConfig)
-}
-
-func GetUploadClient(ctx context.Context, apiKey string) *estuary_client.APIClient {
-	config := getAPIConfig(uploadEndpoint, apiKey)
-	return estuary_client.NewAPIClient(config)
 }

--- a/pkg/publisher/estuary/publisher.go
+++ b/pkg/publisher/estuary/publisher.go
@@ -33,7 +33,7 @@ func NewEstuaryPublisher(config EstuaryPublisherConfig) publisher.Publisher {
 
 // IsInstalled implements publisher.Publisher
 func (e *estuaryPublisher) IsInstalled(ctx context.Context) (bool, error) {
-	client := GetGatewayClient(ctx, e.config.APIKey)
+	client := GetClient(ctx, e.config.APIKey)
 	_, response, err := client.CollectionsApi.CollectionsGet(ctx) //nolint:bodyclose // golangcilint is dumb - this is closed
 	if response != nil {
 		defer closer.DrainAndCloseWithLogOnError(ctx, "estuary-response", response.Body)
@@ -72,7 +72,7 @@ func (e *estuaryPublisher) PublishShardResult(
 		return model.StorageSpec{}, errors.Wrap(err, "error reading CAR data")
 	}
 
-	client := GetUploadClient(ctx, e.config.APIKey)
+	client := GetClient(ctx, e.config.APIKey)
 	timeout, cancel := context.WithTimeout(ctx, publisherTimeout)
 	defer cancel()
 

--- a/pkg/publisher/estuary/publisher_test.go
+++ b/pkg/publisher/estuary/publisher_test.go
@@ -23,7 +23,7 @@ func getPublisherWithGoodConfig(t *testing.T) publisher.Publisher {
 }
 
 func getPublisherWithErrorConfig(*testing.T) publisher.Publisher {
-	return NewEstuaryPublisher(EstuaryPublisherConfig{APIKey: ""})
+	return NewEstuaryPublisher(EstuaryPublisherConfig{APIKey: "TEST"})
 }
 
 func TestIsInstalled(t *testing.T) {
@@ -57,9 +57,5 @@ func TestUpload(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Equal(t, spec.StorageSource, model.StorageSourceEstuary)
-	// TODO: Estuary doesn't seem to write content-headers properly so we aren't
-	// able to include CIDs in the return spec until
-	// https://github.com/application-research/estuary/issues/540 is fixed
-	//
-	// require.NotEmpty(t, spec.CID)
+	require.NotEmpty(t, spec.CID)
 }


### PR DESCRIPTION
Since https://github.com/application-research/estuary/pull/562, we no longer need to use a specific upload endpoint. The normal endpoint also returns the correct content type, so we can now include CIDs for results published to Estuary!

Fixes: https://filecoinproject.slack.com/archives/C02RLM3JHUY/p1669637040070429