### PR TITLE
Hide profiling issues unless the user is in debug mode

### DIFF
--- a/pkg/devstack/profiler.go
+++ b/pkg/devstack/profiler.go
@@ -1,0 +1,66 @@
+package devstack
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/pprof"
+
+	"github.com/filecoin-project/bacalhau/pkg/util/closer"
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	cpuProfile string = "bacalhau-devstack-cpu.prof"
+	memProfile string = "bacalhau-devstack-mem.prof"
+)
+
+type profiler struct {
+	cpuFile *os.File
+}
+
+func StartProfiling() io.Closer {
+	// do a GC before we start profiling
+	runtime.GC()
+
+	log.Trace().Msg("============= STARTING PROFILING ============")
+	// devstack always records a cpu profile, it will be generally useful.
+	cpuprofile := filepath.Join(os.TempDir(), cpuProfile)
+	f, err := os.Create(cpuprofile)
+	if err != nil {
+		log.Debug().Err(err).Str("Path", cpuprofile).Msg("could not create CPU profile")
+		return nil
+	}
+	if err := pprof.StartCPUProfile(f); err != nil {
+		closer.CloseWithLogOnError(cpuprofile, f)
+		log.Debug().Err(err).Msg("could not start CPU profile")
+		return nil
+	}
+
+	closer := profiler{cpuFile: f}
+	return &closer
+}
+
+func (p *profiler) Close() error {
+	// stop profiling now, just before we clean up, if we're profiling.
+	log.Trace().Msg("============= STOPPING PROFILING ============")
+	pprof.StopCPUProfile()
+	closer.CloseWithLogOnError(p.cpuFile.Name(), p.cpuFile)
+
+	memprofile := filepath.Join(os.TempDir(), memProfile)
+	f, err := os.Create(memprofile)
+	if err != nil {
+		log.Debug().Err(err).Str("Path", memprofile).Msg("could not create memory profile")
+		return nil
+	}
+	defer closer.CloseWithLogOnError(memprofile, f) // error handling omitted for example
+
+	runtime.GC() // get up-to-date statistics
+	if err := pprof.WriteHeapProfile(f); err != nil {
+		log.Debug().Err(err).Msg("could not write memory profile")
+	}
+	return nil
+}
+
+var _ io.Closer = (*profiler)(nil)

--- a/pkg/system/cleanup.go
+++ b/pkg/system/cleanup.go
@@ -3,15 +3,10 @@ package system
 import (
 	"context"
 	"errors"
-	"os"
-	"path"
-	"runtime"
-	"runtime/pprof"
 	"time"
 
 	realsync "sync"
 
-	"github.com/filecoin-project/bacalhau/pkg/util/closer"
 	sync "github.com/lukemarsden/golang-mutex-tracer"
 
 	"github.com/rs/zerolog/log"
@@ -62,22 +57,6 @@ func (cm *CleanupManager) Cleanup() {
 	// after we have been called
 	time.Sleep(SleepBeforeCleanup)
 
-	// stop profiling now, just before we clean up, if we're profiling.
-	log.Trace().Msg("============= STOPPING PROFILING ============")
-	pprof.StopCPUProfile()
-	memprofile := path.Join(os.TempDir(), "bacalhau-devstack-mem.prof")
-	f, err := os.Create(memprofile)
-	if err != nil {
-		log.Info().Err(err).Msg("could not create memory profile")
-	} else {
-		defer closer.CloseWithLogOnError("mem.prof", f) // error handling omitted for example
-
-		runtime.GC() // get up-to-date statistics
-		if err := pprof.WriteHeapProfile(f); err != nil {
-			log.Err(err).Msg("could not write memory profile")
-		}
-	}
-
 	cm.fnsMutex.Lock()
 	defer cm.fnsMutex.Unlock()
 
@@ -92,7 +71,7 @@ func (cm *CleanupManager) Cleanup() {
 
 			if err := fn(); err != nil {
 				if !errors.Is(err, context.Canceled) {
-					log.Error().Msgf("Error during clean-up callback: %v", err)
+					log.Error().Err(err).Msg("Error during clean-up callback")
 				}
 			}
 		}(cm.fns[i])


### PR DESCRIPTION
If the user doesn't have debug logging turned on, they also probably don't care about issues generating CPU and memory profiles. So write these messages at a Debug log level.

Also abstracts the profiling away from the CleanupManager which is used in many more places than just the devstack.

Resolves #1444.