### PR TITLE
Avoid Python install to fix performance job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -373,27 +373,26 @@ jobs:
       - run:
           name: Run Perf and Upload Results
           command: |
-            export PATH="$HOME/.local/bin:${PATH}"
-            export SHA="<< pipeline.git.revision >>"
-            export DATETIME="$(date -u +"%FT%H%MZ")"
-            export BRANCH="<<pipeline.git.branch>>"
-            if [ "<<pipeline.git.tag>>" != "" ]; then
-              export TAG="<<pipeline.git.tag>>"
-            else
-              export TAG="v0.0.0-xxxxxxx"
-            fi
-            sudo dpkg --configure -a
-            sudo apt install python3.10 python3-pip build-essential -y
-            pip3 install gsutil
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs  | sh -s -- -y
             source $HOME/.cargo/env
             cargo install hyperfine
-            echo "$GOOGLE_CLOUD_STORAGE_BACALHAU_CICD_RW" | base64 --decode > ~/.boto
             (
               cd benchmark
               bash start_and_run.sh
             )
-            gsutil -m cp benchmark/results/* "${GCS_PERF_RESULTS_BUCKET}/${DATETIME}-${BRANCH}-${TAG}-${SHA}"
+      - run:
+          name: Upload results
+          env:
+          command: |
+            export PATH="$HOME/.local/bin:${PATH}"
+            export DATETIME="$(date -u +"%FT%H%MZ")"
+            sudo apt install python3.10 python3-pip build-essential -y
+            pip3 install gsutil
+            if test -z "${CIRCLE_TAG}"; then
+              export CIRCLE_TAG="v0.0.0-xxxxxxx"
+            fi
+            echo "$GOOGLE_CLOUD_STORAGE_BACALHAU_CICD_RW" | base64 --decode > ~/.boto
+            gsutil -m cp benchmark/results/* "${GCS_PERF_RESULTS_BUCKET}/${DATETIME}-${CIRCLE_BRANCH}-${CIRCLE_TAG}-${CIRCLE_SHA1}"
       - heroku/install
       - run:
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -371,7 +371,7 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Run Perf and Upload Results
+          name: Run performance test
           command: |
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs  | sh -s -- -y
             source $HOME/.cargo/env
@@ -394,8 +394,8 @@ jobs:
             gsutil -m cp benchmark/results/* "${GCS_PERF_RESULTS_BUCKET}/${DATETIME}-${CIRCLE_BRANCH}-${CIRCLE_TAG}-${CIRCLE_SHA1}"
       - heroku/install
       - run:
+          name: Update dashboard
           command: |
-            # Updates dashboard data with latest from GCS
             heroku run build --app bacalhau-dashboards
 
   release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -386,11 +386,10 @@ jobs:
           command: |
             export PATH="$HOME/.local/bin:${PATH}"
             export DATETIME="$(date -u +"%FT%H%MZ")"
-            sudo apt install python3.10 python3-pip build-essential -y
-            pip3 install gsutil
             if test -z "${CIRCLE_TAG}"; then
               export CIRCLE_TAG="v0.0.0-xxxxxxx"
             fi
+            pip3 install gsutil
             echo "$GOOGLE_CLOUD_STORAGE_BACALHAU_CICD_RW" | base64 --decode > ~/.boto
             gsutil -m cp benchmark/results/* "${GCS_PERF_RESULTS_BUCKET}/${DATETIME}-${CIRCLE_BRANCH}-${CIRCLE_TAG}-${CIRCLE_SHA1}"
       - heroku/install


### PR DESCRIPTION
The performance job now seems to struggle to make package changes on Ubuntu, which I think it a CircleCI-specific problem. We can work around this by just not installing Python, which is already at the correct version on CircleCI.

Resolves #1447.