### PR TITLE
Add tag inclusion and exclusion list filters

### DIFF
--- a/cmd/bacalhau/flags.go
+++ b/cmd/bacalhau/flags.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/filecoin-project/bacalhau/pkg/job"
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/filecoin-project/bacalhau/pkg/storage/url/urldownload"
 	"github.com/spf13/pflag"
@@ -223,5 +224,37 @@ func EnvVarMapFlag(value *map[string]string) *MapValueFlag[string, string] {
 		parser:   separatorParser("="),
 		stringer: func(k *string, v *string) string { return fmt.Sprintf("%s=%s", *k, *v) },
 		typeStr:  "key=value",
+	}
+}
+
+func parseTag(s string) (string, error) {
+	var err error
+	if !job.IsSafeAnnotation(s) {
+		err = fmt.Errorf("%q is not a valid tag", s)
+	}
+	return s, err
+}
+
+func IncludedTagFlag(value *[]model.IncludedTag) *ArrayValueFlag[model.IncludedTag] {
+	return &ArrayValueFlag[model.IncludedTag]{
+		value: value,
+		parser: func(s string) (model.IncludedTag, error) {
+			s, err := parseTag(s)
+			return model.IncludedTag(s), err
+		},
+		stringer: func(t *model.IncludedTag) string { return string(*t) },
+		typeStr:  "tag",
+	}
+}
+
+func ExcludedTagFlag(value *[]model.ExcludedTag) *ArrayValueFlag[model.ExcludedTag] {
+	return &ArrayValueFlag[model.ExcludedTag]{
+		value: value,
+		parser: func(s string) (model.ExcludedTag, error) {
+			s, err := parseTag(s)
+			return model.ExcludedTag(s), err
+		},
+		stringer: func(t *model.ExcludedTag) string { return string(*t) },
+		typeStr:  "tag",
 	}
 }

--- a/cmd/bacalhau/list.go
+++ b/cmd/bacalhau/list.go
@@ -31,21 +31,25 @@ var (
 )
 
 type ListOptions struct {
-	HideHeader   bool       // Hide the column headers
-	IDFilter     string     // Filter by Job List to IDs matching substring.
-	NoStyle      bool       // Remove all styling from table output.
-	MaxJobs      int        // Print the first NUM jobs instead of the first 10.
-	OutputFormat string     // The output format for the list of jobs (json or text)
-	SortReverse  bool       // Reverse order of table - for time sorting, this will be newest first.
-	SortBy       ColumnEnum // Sort by field, defaults to creation time, with newest first [Allowed "id", "created_at"].
-	OutputWide   bool       // Print full values in the table results
-	ReturnAll    bool       // Return all jobs, not just those that belong to the user
+	HideHeader   bool                // Hide the column headers
+	IDFilter     string              // Filter by Job List to IDs matching substring.
+	IncludeTags  []model.IncludedTag // Only return jobs with these annotations
+	ExcludeTags  []model.ExcludedTag // Only return jobs without these annotations
+	NoStyle      bool                // Remove all styling from table output.
+	MaxJobs      int                 // Print the first NUM jobs instead of the first 10.
+	OutputFormat string              // The output format for the list of jobs (json or text)
+	SortReverse  bool                // Reverse order of table - for time sorting, this will be newest first.
+	SortBy       ColumnEnum          // Sort by field, defaults to creation time, with newest first [Allowed "id", "created_at"].
+	OutputWide   bool                // Print full values in the table results
+	ReturnAll    bool                // Return all jobs, not just those that belong to the user
 }
 
 func NewListOptions() *ListOptions {
 	return &ListOptions{
 		HideHeader:   false,
 		IDFilter:     "",
+		IncludeTags:  model.IncludeAny,
+		ExcludeTags:  model.ExcludeNone,
 		NoStyle:      false,
 		MaxJobs:      10,
 		OutputFormat: "text",
@@ -73,6 +77,10 @@ func newListCmd() *cobra.Command {
 	listCmd.PersistentFlags().BoolVar(&OL.HideHeader, "hide-header", OL.HideHeader,
 		`do not print the column headers.`)
 	listCmd.PersistentFlags().StringVar(&OL.IDFilter, "id-filter", OL.IDFilter, `filter by Job List to IDs matching substring.`)
+	listCmd.PersistentFlags().Var(IncludedTagFlag(&OL.IncludeTags), "include-tag",
+		`Only return jobs that have the passed tag in their annotations`)
+	listCmd.PersistentFlags().Var(ExcludedTagFlag(&OL.ExcludeTags), "exclude-tag",
+		`Only return jobs that do not have the passed tag in their annotations`)
 	listCmd.PersistentFlags().BoolVar(&OL.NoStyle, "no-style", OL.NoStyle, `remove all styling from table output.`)
 	listCmd.PersistentFlags().IntVarP(
 		&OL.MaxJobs, "number", "n", OL.MaxJobs,
@@ -153,7 +161,16 @@ func list(cmd *cobra.Command, OL *ListOptions) error {
 	log.Debug().Msgf("Found no-style header flag set to: %t", OL.NoStyle)
 	log.Debug().Msgf("Found output wide flag set to: %t", OL.OutputWide)
 
-	jobs, err := GetAPIClient().List(ctx, OL.IDFilter, OL.MaxJobs, OL.ReturnAll, OL.SortBy.String(), OL.SortReverse)
+	jobs, err := GetAPIClient().List(
+		ctx,
+		OL.IDFilter,
+		OL.IncludeTags,
+		OL.ExcludeTags,
+		OL.MaxJobs,
+		OL.ReturnAll,
+		OL.SortBy.String(),
+		OL.SortReverse,
+	)
 	if err != nil {
 		Fatal(cmd, fmt.Sprintf("Error listing jobs: %s", err), 1)
 	}

--- a/cmd/bacalhau/list_test.go
+++ b/cmd/bacalhau/list_test.go
@@ -56,7 +56,7 @@ func (suite *ListSuite) TestList_NumberOfJobs() {
 	}
 
 	for _, tc := range tests {
-		func() {
+		suite.Run(fmt.Sprintf("%d jobs %d output", tc.numberOfJobs, tc.numberOfJobsOutput), func() {
 			ctx := context.Background()
 			c, cm := publicapi.SetupRequesterNodeForTests(suite.T(), false)
 			defer cm.Cleanup()
@@ -79,7 +79,7 @@ func (suite *ListSuite) TestList_NumberOfJobs() {
 			require.NoError(suite.T(), err)
 
 			require.Equal(suite.T(), tc.numberOfJobsOutput, strings.Count(out, "\n"))
-		}()
+		})
 	}
 }
 
@@ -148,6 +148,81 @@ func (suite *ListSuite) TestList_IdFilter() {
 
 	require.Contains(suite.T(), firstItem.Metadata.ID, jobLongIds[0], "The filtered job id was not found in the response")
 	require.Equal(suite.T(), 1, len(response.Jobs), "The list of jobs is not strictly filtered to the requested job id")
+}
+
+func (suite *ListSuite) TestList_AnnotationFilter() {
+	testCases := []struct {
+		Name                                              string
+		JobLabels, ListLabels                             []string
+		AppearByDefault, AppearOnInclude, AppearOnExclude bool
+	}{
+		{"empty filters have no effect", []string{}, []string{}, true, true, true},
+		{"include filters unlabelled jobs", []string{}, []string{"test"}, true, false, true},
+		{"exclude filters labelled jobs", []string{"test"}, []string{"test"}, true, true, false},
+		{"filters match job labels", []string{"jobb"}, []string{"test"}, true, false, true},
+		{"multiple annotations match any", []string{"test", "jobb"}, []string{"test"}, true, true, false},
+		{"multiple filters match any", []string{"t1"}, []string{"t1", "t2"}, true, true, false},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(tc.Name, func() {
+			ctx := context.Background()
+			c, cm := publicapi.SetupRequesterNodeForTests(suite.T(), false)
+			defer cm.Cleanup()
+
+			// create job with label
+			j := publicapi.MakeNoopJob()
+			j.Spec.Annotations = tc.JobLabels
+			j, err := c.Submit(ctx, j, nil)
+			require.NoError(suite.T(), err)
+
+			parsedBasedURI, _ := url.Parse(c.BaseURI)
+			host, port, _ := net.SplitHostPort(parsedBasedURI.Host)
+			checkList := func(shouldAppear bool, flags ...string) {
+				args := []string{"list",
+					"--hide-header",
+					"--api-host", host,
+					"--api-port", port,
+					"--output", "json",
+				}
+				args = append(args, flags...)
+				_, out, err := ExecuteTestCobraCommand(suite.T(), args...)
+				require.NoError(suite.T(), err)
+
+				response := listResponse{}
+				err = model.JSONUnmarshalWithMax([]byte(out), &response.Jobs)
+				if shouldAppear {
+					require.NotEmpty(suite.T(), response.Jobs)
+					require.Equal(suite.T(), j.Metadata.ID, response.Jobs[0].Metadata.ID)
+				} else {
+					require.Empty(suite.T(), response.Jobs)
+				}
+			}
+
+			// default list
+			suite.Run("default", func() {
+				checkList(tc.AppearByDefault)
+			})
+
+			// list with label included
+			suite.Run("label_included", func() {
+				flags := []string{}
+				for _, label := range tc.ListLabels {
+					flags = append(flags, "--include-tag", label)
+				}
+				checkList(tc.AppearOnInclude, flags...)
+			})
+
+			// list with label excluded
+			suite.Run("label_excluded", func() {
+				flags := []string{}
+				for _, label := range tc.ListLabels {
+					flags = append(flags, "--exclude-tag", label)
+				}
+				checkList(tc.AppearOnExclude, flags...)
+			})
+		})
+	}
 }
 
 func (suite *ListSuite) TestList_SortFlags() {

--- a/ops/aws/canary/lambda/go.mod
+++ b/ops/aws/canary/lambda/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/aws/aws-lambda-go v1.34.1
 	github.com/aws/aws-sdk-go v1.44.96
-	github.com/filecoin-project/bacalhau v0.3.14
+	github.com/filecoin-project/bacalhau v0.3.15-0.20221212143514-de90de104457
 	github.com/rs/zerolog v1.28.0
 	github.com/slack-go/slack v0.11.3
 	github.com/spf13/pflag v1.0.5

--- a/ops/aws/canary/lambda/go.sum
+++ b/ops/aws/canary/lambda/go.sum
@@ -265,8 +265,8 @@ github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/filecoin-project/bacalhau v0.3.14 h1:QcrKQ7pe2fWywJb7+agH/XNfrmnnr41TVgVBYoRoKxs=
-github.com/filecoin-project/bacalhau v0.3.14/go.mod h1:qHfQ0wZsKaqohkFtQXXT2k9NE+WgA8SSH10FSg3i4BY=
+github.com/filecoin-project/bacalhau v0.3.15-0.20221212143514-de90de104457 h1:fCoR1jCpRy8WN2ti8CoKR01SAc/DcQ8BB1ovqtfLC8U=
+github.com/filecoin-project/bacalhau v0.3.15-0.20221212143514-de90de104457/go.mod h1:qHfQ0wZsKaqohkFtQXXT2k9NE+WgA8SSH10FSg3i4BY=
 github.com/filecoin-project/filecoin-ffi v0.30.4-0.20200910194244-f640612a1a1f/go.mod h1:+If3s2VxyjZn+KGGZIoRXBDSFQ9xL404JBJGf4WhEj0=
 github.com/filecoin-project/go-address v0.0.3/go.mod h1:jr8JxKsYx+lQlQZmF5i2U0Z+cGQ59wMIps/8YW/lDj8=
 github.com/filecoin-project/go-address v0.0.5/go.mod h1:jr8JxKsYx+lQlQZmF5i2U0Z+cGQ59wMIps/8YW/lDj8=

--- a/ops/aws/canary/lambda/pkg/scenarios/list.go
+++ b/ops/aws/canary/lambda/pkg/scenarios/list.go
@@ -3,6 +3,7 @@ package scenarios
 import (
 	"context"
 
+	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/rs/zerolog/log"
 )
 
@@ -11,7 +12,7 @@ func List(ctx context.Context) error {
 	// scenario to mimic the behavior of bacalhau cli.
 	client := getClient()
 
-	jobs, err := client.List(ctx, "", 10, false, "created_at", true)
+	jobs, err := client.List(ctx, "", model.IncludeAny, model.ExcludeNone, 10, false, "created_at", true)
 	if err != nil {
 		return err
 	}

--- a/ops/aws/canary/lambda/pkg/scenarios/utils.go
+++ b/ops/aws/canary/lambda/pkg/scenarios/utils.go
@@ -17,6 +17,7 @@ import (
 )
 
 const defaultEchoMessage = "hello λ!"
+const canaryAnnotation = "canary"
 
 func getSampleDockerJob() *model.Job {
 	var j = &model.Job{
@@ -33,6 +34,7 @@ func getSampleDockerJob() *model.Job {
 				defaultEchoMessage,
 			},
 		},
+		Annotations: []string{canaryAnnotation},
 	}
 
 	j.Spec.Deal = model.Deal{
@@ -74,6 +76,7 @@ func getSampleDockerIPFSJob() *model.Job {
 				Path:          "/outputs",
 			},
 		},
+		Annotations: []string{canaryAnnotation},
 	}
 
 	j.Spec.Deal = model.Deal{

--- a/pkg/localdb/inmemory/inmemory.go
+++ b/pkg/localdb/inmemory/inmemory.go
@@ -8,6 +8,8 @@ import (
 
 	sync "github.com/lukemarsden/golang-mutex-tracer"
 	"github.com/rs/zerolog/log"
+	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
 
 	"github.com/filecoin-project/bacalhau/pkg/bacerrors"
 	jobutils "github.com/filecoin-project/bacalhau/pkg/job"
@@ -109,48 +111,66 @@ func (d *InMemoryDatastore) GetJobs(ctx context.Context, query localdb.JobQuery)
 		if err != nil {
 			return nil, err
 		}
+		return []*model.Job{j}, nil
+	}
+
+	for _, j := range maps.Values(d.jobs) {
+		if len(result) == query.Limit {
+			break
+		}
+
+		if !query.ReturnAll && query.ClientID != "" && query.ClientID != j.Metadata.ClientID {
+			// Job is not for the requesting client, so ignore it.
+			continue
+		}
+
+		included := len(query.IncludeTags) == 0
+		for _, tag := range query.IncludeTags {
+			if slices.Contains(j.Spec.Annotations, string(tag)) {
+				included = true
+				break
+			}
+		}
+
+		if !included {
+			continue
+		}
+
+		included = true
+		for _, tag := range query.ExcludeTags {
+			if slices.Contains(j.Spec.Annotations, string(tag)) {
+				included = false
+				break
+			}
+		}
+
+		if !included {
+			continue
+		}
+
 		result = append(result, j)
-	} else {
-		if query.ReturnAll {
-			log.Ctx(ctx).Debug().Msgf("querying for all jobs, limit %d", query.Limit)
-			for _, j := range d.jobs {
-				result = append(result, j)
-			}
-		} else if query.ClientID != "" {
-			log.Ctx(ctx).Debug().Msgf("querying for jobs with filter ClientID %s", query.ClientID)
-			for _, j := range d.jobs {
-				if j.Metadata.ClientID == query.ClientID {
-					result = append(result, j)
-				}
-			}
-		}
-
-		listSorter := func(i, j int) bool {
-			switch query.SortBy {
-			case "id":
-				if query.SortReverse {
-					// what does it mean to sort by ID?
-					return result[i].Metadata.ID > result[j].Metadata.ID
-				} else {
-					return result[i].Metadata.ID < result[j].Metadata.ID
-				}
-			case "created_at":
-				if query.SortReverse {
-					return result[i].Metadata.CreatedAt.UTC().Unix() > result[j].Metadata.CreatedAt.UTC().Unix()
-				} else {
-					return result[i].Metadata.CreatedAt.UTC().Unix() < result[j].Metadata.CreatedAt.UTC().Unix()
-				}
-			default:
-				return false
-			}
-		}
-		sort.Slice(result, listSorter)
-	}
-	// apply limit
-	if len(result) >= query.Limit {
-		result = result[:query.Limit]
 	}
 
+	listSorter := func(i, j int) bool {
+		switch query.SortBy {
+		case "id":
+			if query.SortReverse {
+				// what does it mean to sort by ID?
+				return result[i].Metadata.ID > result[j].Metadata.ID
+			} else {
+				return result[i].Metadata.ID < result[j].Metadata.ID
+			}
+		case "created_at":
+			if query.SortReverse {
+				return result[i].Metadata.CreatedAt.UTC().Unix() > result[j].Metadata.CreatedAt.UTC().Unix()
+			} else {
+				return result[i].Metadata.CreatedAt.UTC().Unix() < result[j].Metadata.CreatedAt.UTC().Unix()
+			}
+		default:
+			return false
+		}
+	}
+	sort.Slice(result, listSorter)
 	return result, nil
 }
 

--- a/pkg/localdb/types.go
+++ b/pkg/localdb/types.go
@@ -7,12 +7,14 @@ import (
 )
 
 type JobQuery struct {
-	ID          string `json:"id"`
-	ClientID    string `json:"clientID"`
-	Limit       int    `json:"limit"`
-	ReturnAll   bool   `json:"return_all"`
-	SortBy      string `json:"sort_by"`
-	SortReverse bool   `json:"sort_reverse"`
+	ID          string              `json:"id"`
+	ClientID    string              `json:"clientID"`
+	IncludeTags []model.IncludedTag `json:"include_tags"`
+	ExcludeTags []model.ExcludedTag `json:"exclude_tags"`
+	Limit       int                 `json:"limit"`
+	ReturnAll   bool                `json:"return_all"`
+	SortBy      string              `json:"sort_by"`
+	SortReverse bool                `json:"sort_reverse"`
 }
 
 type LocalEventFilter func(ev model.JobLocalEvent) bool

--- a/pkg/model/tag.go
+++ b/pkg/model/tag.go
@@ -1,0 +1,14 @@
+package model
+
+// We use these types to make it harder to accidentally mix up passing the wrong
+// annotations to the wrong argument, e.g. avoid Excluded = []string{"included"}
+type (
+	IncludedTag string
+	ExcludedTag string
+)
+
+// Set of annotations that will not do any filtering of jobs.
+var (
+	IncludeAny  []IncludedTag = []IncludedTag{}
+	ExcludeNone []ExcludedTag = []ExcludedTag{}
+)

--- a/pkg/publicapi/client.go
+++ b/pkg/publicapi/client.go
@@ -68,7 +68,16 @@ func (apiClient *APIClient) Alive(ctx context.Context) (bool, error) {
 }
 
 // List returns the list of jobs in the node's transport.
-func (apiClient *APIClient) List(ctx context.Context, idFilter string, maxJobs int, returnAll bool, sortBy string, sortReverse bool) (
+func (apiClient *APIClient) List(
+	ctx context.Context,
+	idFilter string,
+	includeTags []model.IncludedTag,
+	excludeTags []model.ExcludedTag,
+	maxJobs int,
+	returnAll bool,
+	sortBy string,
+	sortReverse bool,
+) (
 	[]*model.Job, error) {
 	ctx, span := system.GetTracer().Start(ctx, "pkg/publicapi.List")
 	defer span.End()
@@ -77,6 +86,8 @@ func (apiClient *APIClient) List(ctx context.Context, idFilter string, maxJobs i
 		ClientID:    system.GetClientID(),
 		MaxJobs:     maxJobs,
 		JobID:       idFilter,
+		IncludeTags: includeTags,
+		ExcludeTags: excludeTags,
 		ReturnAll:   returnAll,
 		SortBy:      sortBy,
 		SortReverse: sortReverse,
@@ -100,7 +111,7 @@ func (apiClient *APIClient) Get(ctx context.Context, jobID string) (*model.Job, 
 		return &model.Job{}, false, fmt.Errorf("jobID must be non-empty in a Get call")
 	}
 
-	jobsList, err := apiClient.List(ctx, jobID, 1, false, "created_at", true)
+	jobsList, err := apiClient.List(ctx, jobID, model.IncludeAny, model.ExcludeNone, 1, false, "created_at", true)
 	if err != nil {
 		return &model.Job{}, false, err
 	}

--- a/pkg/publicapi/endpoints_list.go
+++ b/pkg/publicapi/endpoints_list.go
@@ -14,12 +14,14 @@ import (
 )
 
 type listRequest struct {
-	JobID       string `json:"id" example:"9304c616-291f-41ad-b862-54e133c0149e"`
-	ClientID    string `json:"client_id" example:"ac13188e93c97a9c2e7cf8e86c7313156a73436036f30da1ececc2ce79f9ea51"`
-	MaxJobs     int    `json:"max_jobs" example:"10"`
-	ReturnAll   bool   `json:"return_all" `
-	SortBy      string `json:"sort_by" example:"created_at"`
-	SortReverse bool   `json:"sort_reverse"`
+	JobID       string              `json:"id" example:"9304c616-291f-41ad-b862-54e133c0149e"`
+	ClientID    string              `json:"client_id" example:"ac13188e93c97a9c2e7cf8e86c7313156a73436036f30da1ececc2ce79f9ea51"`
+	IncludeTags []model.IncludedTag `json:"include_tags" example:"['any-tag']"`
+	ExcludeTags []model.ExcludedTag `json:"exclude_tags" example:"['any-tag']"`
+	MaxJobs     int                 `json:"max_jobs" example:"10"`
+	ReturnAll   bool                `json:"return_all" `
+	SortBy      string              `json:"sort_by" example:"created_at"`
+	SortReverse bool                `json:"sort_reverse"`
 }
 
 type listResponse struct {
@@ -87,6 +89,8 @@ func (apiServer *APIServer) getJobsList(ctx context.Context, listReq listRequest
 		ClientID:    listReq.ClientID,
 		ID:          listReq.JobID,
 		Limit:       listReq.MaxJobs,
+		IncludeTags: listReq.IncludeTags,
+		ExcludeTags: listReq.ExcludeTags,
 		ReturnAll:   listReq.ReturnAll,
 		SortBy:      listReq.SortBy,
 		SortReverse: listReq.SortReverse,


### PR DESCRIPTION
Users can label their jobs with arbitrary tags using the `Annotations` field of the job spec or by passing appropriate flags to the run commands.

This commit allows the `bacalhau list` command to accept flags that use job tags to filter the list of jobs returned. Two flags are available: one that filters jobs that include passed tags, and another that filters jobs to only those excluding passed tags. The flags can be used multiple times, and perform OR matching (so passing X and Y will include/exclude jobs with X or Y).

We also tag the canary jobs with labels to improve our metrics resolution. Now that canary jobs are labelled, we can easily exclude them from job lists using:

    bacalhau list --exclude-tag canary

Resolves #1475.