### PR TITLE
Hide canaries by default from list command

### DIFF
--- a/cmd/bacalhau/flags.go
+++ b/cmd/bacalhau/flags.go
@@ -89,7 +89,7 @@ func (s *ArrayValueFlag[T]) Set(input string) error {
 
 // String implements pflag.Value
 func (s *ArrayValueFlag[T]) String() string {
-	strs := make([]string, len(*s.value))
+	strs := make([]string, 0, len(*s.value))
 	for _, spec := range *s.value {
 		spec := spec
 		strs = append(strs, s.stringer(&spec))

--- a/cmd/bacalhau/list.go
+++ b/cmd/bacalhau/list.go
@@ -21,13 +21,18 @@ var (
 		List jobs on the network.
 `))
 
-	//nolint:lll // Documentation
 	listExample = templates.Examples(i18n.T(`
 		# List jobs on the network
 		bacalhau list
 
 		# List jobs and output as json
 		bacalhau list --output json`))
+
+	// The tags that will be excluded by default, if the user does not pass any
+	// others to the list command.
+	defaultExcludedTags = []model.ExcludedTag{
+		"canary",
+	}
 )
 
 type ListOptions struct {
@@ -49,7 +54,7 @@ func NewListOptions() *ListOptions {
 		HideHeader:   false,
 		IDFilter:     "",
 		IncludeTags:  model.IncludeAny,
-		ExcludeTags:  model.ExcludeNone,
+		ExcludeTags:  defaultExcludedTags,
 		NoStyle:      false,
 		MaxJobs:      10,
 		OutputFormat: "text",

--- a/cmd/bacalhau/list_test.go
+++ b/cmd/bacalhau/list_test.go
@@ -151,17 +151,38 @@ func (suite *ListSuite) TestList_IdFilter() {
 }
 
 func (suite *ListSuite) TestList_AnnotationFilter() {
-	testCases := []struct {
+	type testCase struct {
 		Name                                              string
 		JobLabels, ListLabels                             []string
 		AppearByDefault, AppearOnInclude, AppearOnExclude bool
-	}{
+	}
+
+	testCases := []testCase{
 		{"empty filters have no effect", []string{}, []string{}, true, true, true},
 		{"include filters unlabelled jobs", []string{}, []string{"test"}, true, false, true},
 		{"exclude filters labelled jobs", []string{"test"}, []string{"test"}, true, true, false},
 		{"filters match job labels", []string{"jobb"}, []string{"test"}, true, false, true},
 		{"multiple annotations match any", []string{"test", "jobb"}, []string{"test"}, true, true, false},
 		{"multiple filters match any", []string{"t1"}, []string{"t1", "t2"}, true, true, false},
+	}
+
+	for _, tag := range defaultExcludedTags {
+		testCases = append(testCases, testCase{
+			fmt.Sprintf("%s filtered by default", string(tag)),
+			[]string{string(tag)},
+			[]string{string(tag)},
+			false,
+			true,
+			false,
+		})
+		testCases = append(testCases, testCase{
+			fmt.Sprintf("%s excluded with other tags", string(tag)),
+			[]string{string(tag)},
+			[]string{string("test")},
+			false,
+			false,
+			false,
+		})
 	}
 
 	for _, tc := range testCases {

--- a/pkg/localdb/inmemory/inmemory.go
+++ b/pkg/localdb/inmemory/inmemory.go
@@ -124,21 +124,15 @@ func (d *InMemoryDatastore) GetJobs(ctx context.Context, query localdb.JobQuery)
 			continue
 		}
 
+		// If we are not using include tags, by default every job is included.
+		// If a job is specifically included, that overrides it being excluded.
 		included := len(query.IncludeTags) == 0
-		for _, tag := range query.IncludeTags {
-			if slices.Contains(j.Spec.Annotations, string(tag)) {
+		for _, tag := range j.Spec.Annotations {
+			if slices.Contains(query.IncludeTags, model.IncludedTag(tag)) {
 				included = true
 				break
 			}
-		}
-
-		if !included {
-			continue
-		}
-
-		included = true
-		for _, tag := range query.ExcludeTags {
-			if slices.Contains(j.Spec.Annotations, string(tag)) {
+			if slices.Contains(query.ExcludeTags, model.ExcludedTag(tag)) {
 				included = false
 				break
 			}


### PR DESCRIPTION
The previous commit added support for including and excluding tags from the list command. We are so thrilled with this that we want to hide canaries by default.

This commit makes the `canary` tag hidden by default. Users can still see jobs with the tag by explicitly using `--include-tag canary` (as including a tag is now given preference over excluding it).

Resolves #1499.