### PR TITLE
Jobs with a non-zero exit status should still complete

### DIFF
--- a/pkg/devstack/devstack.go
+++ b/pkg/devstack/devstack.go
@@ -160,13 +160,6 @@ func NewDevStack(
 			return nil, fmt.Errorf("failed to create ipfs client: %w", err)
 		}
 
-		// Assign all the ports up front, so that they can't collide
-		var ports []int
-		ports, err = freeport.GetFreePorts(3)
-		if err != nil {
-			return nil, err
-		}
-
 		var libp2pHost host.Host
 		var libp2pPort int
 		libp2pPeer := []multiaddr.Multiaddr{}
@@ -177,7 +170,10 @@ func NewDevStack(
 		//////////////////////////////////////
 		// libp2p
 		//////////////////////////////////////
-		libp2pPort, ports = ports[0], ports[1:]
+		libp2pPort, err := freeport.GetFreePort()
+		if err != nil {
+			return nil, err
+		}
 
 		if i == 0 {
 			if options.Peer != "" {
@@ -221,14 +217,13 @@ func NewDevStack(
 		if os.Getenv("PREDICTABLE_API_PORT") != "" {
 			apiPort = 20000 + i
 		} else {
-			apiPort, ports = ports[0], ports[1:]
+			apiPort = 0
 		}
 
 		//////////////////////////////////////
 		// metrics
 		//////////////////////////////////////
-		var metricsPort int
-		metricsPort, _ = ports[0], ports[1:]
+		metricsPort := 0
 
 		//////////////////////////////////////
 		// in-memory datastore

--- a/pkg/executor/docker/executor.go
+++ b/pkg/executor/docker/executor.go
@@ -305,17 +305,12 @@ func (e *Executor) RunShard(
 		}
 	}()
 
-	var exitCodeErr error
-	if containerExitStatusCode != 0 {
-		exitCodeErr = fmt.Errorf("exit code was not zero: %d", containerExitStatusCode)
-	}
-
 	return executor.WriteJobResults(
 		jobResultsDir,
 		stdoutPipe,
 		stderrPipe,
 		int(containerExitStatusCode),
-		multierr.Combine(containerError, startErr, stdoutErr, stderrErr, exitCodeErr),
+		multierr.Combine(containerError, startErr, stdoutErr, stderrErr),
 	)
 }
 

--- a/pkg/executor/docker/executor_test.go
+++ b/pkg/executor/docker/executor_test.go
@@ -174,7 +174,7 @@ func (suite *ExecutorTestSuite) TestDockerNetworkingNone() {
 		Network: model.NetworkConfig{Type: model.NetworkNone},
 		Docker:  suite.curlTask(),
 	})
-	require.Error(suite.T(), err)
+	require.NoError(suite.T(), err)
 	require.Empty(suite.T(), result.STDOUT)
 	require.NotEmpty(suite.T(), result.STDERR)
 	require.NotZero(suite.T(), result.ExitCode)

--- a/pkg/test/devstack/errorlogs_test.go
+++ b/pkg/test/devstack/errorlogs_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/filecoin-project/bacalhau/pkg/docker"
 	"github.com/filecoin-project/bacalhau/pkg/executor"
 	"github.com/filecoin-project/bacalhau/pkg/executor/noop"
 	"github.com/filecoin-project/bacalhau/pkg/ipfs"
@@ -21,10 +22,23 @@ type DevstackErrorLogsSuite struct {
 	scenario.ScenarioRunner
 }
 
-// In order for 'go test' to run this suite, we need to create
-// a normal test function and pass our suite to suite.Run
 func TestDevstackErrorLogsSuite(t *testing.T) {
 	suite.Run(t, new(DevstackErrorLogsSuite))
+}
+
+var executorTestCases = []model.Spec{
+	{
+		Engine:    model.EngineNoop,
+		Publisher: model.PublisherIpfs,
+	},
+	{
+		Engine:    model.EngineDocker,
+		Publisher: model.PublisherIpfs,
+		Docker: model.JobSpecDocker{
+			Image:      "ubuntu",
+			Entrypoint: []string{"bash", "-c", "echo -n 'apples' >&1; echo -n 'oranges' >&2; exit 19;"},
+		},
+	},
 }
 
 var errorLogsTestCase = scenario.Scenario{
@@ -49,13 +63,16 @@ var errorLogsTestCase = scenario.Scenario{
 			model.JobStateCompleted: 1,
 		}),
 	},
-	Spec: model.Spec{
-		Engine:    model.EngineNoop,
-		Verifier:  model.VerifierNoop,
-		Publisher: model.PublisherIpfs,
-	},
 }
 
-func (suite *DevstackErrorLogsSuite) TestErrorContainer() {
-	suite.RunScenario(errorLogsTestCase)
+func (suite *DevstackErrorLogsSuite) TestCanGetResultsFromErroredJob() {
+	for _, testCase := range executorTestCases {
+		suite.Run(testCase.Engine.String(), func() {
+			docker.MaybeNeedDocker(suite.T(), testCase.Engine == model.EngineDocker)
+
+			scenario := errorLogsTestCase
+			scenario.Spec = testCase
+			suite.RunScenario(scenario)
+		})
+	}
 }

--- a/pkg/test/scenario/results.go
+++ b/pkg/test/scenario/results.go
@@ -67,6 +67,7 @@ func ManyChecks(checks ...CheckResults) CheckResults {
 	return func(resultsDir string) error {
 		var wg multierrgroup.Group
 		for _, check := range checks {
+			check := check
 			wg.Go(func() error { return check(resultsDir) })
 		}
 		return wg.Wait()


### PR DESCRIPTION
Currently the Docker executor will treat any container that finishes with a non-zero exit status as an error. This unfortunately means that it does not process the results from the container.

This commit establishes the following principle:

> Jobs are only considered to be "errored" if there is a system error that prevented full execution of the job.

I.e, if the user submits code that errors when run, the system should not consider this to be an error.

In keeping with this, we have modified the Docker executor to no longer return errors when the exit code is not zero.

Resolves #1504.