### PR TITLE
Filtered, throttled HTTP(S)-only networking for Docker jobs

### DIFF
--- a/cmd/bacalhau/docker_run.go
+++ b/cmd/bacalhau/docker_run.go
@@ -31,7 +31,7 @@ var (
 			-v QmeZRGhe4PmjctYVSVHuEiA9oSXnqmYa4kQubSHgWbjv72:/input_images \
 			dpokidov/imagemagick:7.1.0-47-ubuntu \
 			-- magick mogrify -resize 100x100 -quality 100 -path /outputs '/input_images/*.jpg'
-			
+
 		# Dry Run: Check the job specification before submitting it to the bacalhau network
 		bacalhau docker run --dry-run ubuntu echo hello
 
@@ -59,6 +59,7 @@ type DockerRunOptions struct {
 	Memory           string
 	GPU              string
 	Networking       model.Network
+	NetworkDomains   []string
 	WorkingDirectory string   // Working directory for docker
 	Labels           []string // Labels for the job on the Bacalhau network (for searching)
 
@@ -96,6 +97,7 @@ func NewDockerRunOptions() *DockerRunOptions {
 		Memory:             "",
 		GPU:                "",
 		Networking:         model.NetworkNone,
+		NetworkDomains:     []string{},
 		SkipSyntaxChecking: false,
 		WorkingDirectory:   "",
 		Labels:             []string{},
@@ -211,6 +213,10 @@ func newDockerRunCmd() *cobra.Command { //nolint:funlen
 	dockerRunCmd.PersistentFlags().Var(
 		NetworkFlag(&ODR.Networking), "network",
 		`Networking capability required by the job`,
+	)
+	dockerRunCmd.PersistentFlags().StringArrayVar(
+		&ODR.NetworkDomains, "domain", ODR.NetworkDomains,
+		`Domain(s) that the job needs to access (for HTTP networking)`,
 	)
 	dockerRunCmd.PersistentFlags().BoolVar(
 		&ODR.SkipSyntaxChecking, "skip-syntax-checking", ODR.SkipSyntaxChecking,
@@ -357,6 +363,7 @@ func CreateJob(ctx context.Context,
 		odr.Memory,
 		odr.GPU,
 		odr.Networking,
+		odr.NetworkDomains,
 		odr.InputUrls,
 		odr.InputVolumes,
 		odr.OutputVolumes,

--- a/pkg/compute/executor.go
+++ b/pkg/compute/executor.go
@@ -49,13 +49,18 @@ func NewBaseExecutor(params BaseExecutorParams) *BaseExecutor {
 
 // Run the execution of a shard after it has been accepted, and propose a result to the requester to be verified.
 func (e BaseExecutor) Run(ctx context.Context, execution store.Execution) (err error) {
+	ctx = log.Ctx(ctx).With().
+		Str("Shard", execution.Shard.ID()).
+		Str("ExecutionID", execution.ID).
+		Logger().WithContext(ctx)
+
 	defer func() {
 		if err != nil {
 			e.handleFailure(ctx, execution, err, "Running")
 		}
 	}()
 
-	log.Ctx(ctx).Debug().Msgf("Running execution %s", execution.ID)
+	log.Ctx(ctx).Debug().Msg("Running execution")
 	err = e.store.UpdateExecutionState(ctx, store.UpdateExecutionStateRequest{
 		ExecutionID:   execution.ID,
 		ExpectedState: store.ExecutionStateBidAccepted,
@@ -99,6 +104,7 @@ func (e BaseExecutor) Run(ctx context.Context, execution store.Execution) (err e
 		}
 
 		if err != nil {
+			log.Ctx(ctx).Error().Err(err).Msg("failed to run shard")
 			return
 		}
 	}

--- a/pkg/executor/docker/executor_test.go
+++ b/pkg/executor/docker/executor_test.go
@@ -5,10 +5,9 @@ package docker
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
-	"net/http/httptest"
 	"net/url"
-	"path"
 	"runtime"
 	"strconv"
 	"strings"
@@ -26,7 +25,7 @@ import (
 type ExecutorTestSuite struct {
 	suite.Suite
 	executor *Executor
-	server   *httptest.Server
+	server   *http.Server
 	cm       *system.CleanupManager
 }
 
@@ -53,28 +52,47 @@ func (suite *ExecutorTestSuite) SetupTest() {
 		w.Write([]byte(r.URL.Path))
 	}
 
-	suite.server = httptest.NewServer(http.HandlerFunc(handler))
-	suite.T().Cleanup(suite.server.Close)
+	// We have to manually discover the correct IP address for the server to
+	// listen on because on Linux hosts simply using 127.0.0.1 will get caught
+	// in the loopback interface of the gateway container. We have to listen on
+	// whatever "host.docker.internal" resolves to, which is the IP address of
+	// the "docker0" interface.
+	var gateway net.IP
+	if runtime.GOOS == "linux" {
+		gateway, err = docker.HostGatewayIP(context.Background(), suite.executor.Client)
+		require.NoError(suite.T(), err)
+	} else {
+		gateway = net.ParseIP("127.0.0.1")
+	}
+
+	serverAddr := net.TCPAddr{IP: gateway, Port: 0}
+	listener, err := net.Listen("tcp", serverAddr.String())
+	require.NoError(suite.T(), err)
+	// Don't need to close the listener as it'll be closed by the server.
+
+	suite.server = &http.Server{
+		Addr:    listener.Addr().String(),
+		Handler: http.HandlerFunc(handler),
+	}
+	suite.cm.RegisterCallback(suite.server.Close)
+	go suite.server.Serve(listener)
 }
 
-func (suite *ExecutorTestSuite) containerHttpURL() string {
-	url, err := url.Parse(suite.server.URL)
+func (suite *ExecutorTestSuite) containerHttpURL() *url.URL {
+	url, err := url.Parse("http://" + suite.server.Addr)
 	require.NoError(suite.T(), err)
 
 	// On Mac/Windows, we are within a VM and hence we need to route to the
 	// host. On Linux we are not, so localhost should work.
 	// See e.g. https://stackoverflow.com/a/24326540
-	host := "host.docker.internal"
-	if runtime.GOOS == "linux" {
-		host = "localhost"
-	}
-	return fmt.Sprintf("http://%s:%s", host, url.Port())
+	url.Host = fmt.Sprintf("%s:%s", dockerHostHostname, url.Port())
+	return url
 }
 
 func (suite *ExecutorTestSuite) curlTask() model.JobSpecDocker {
 	return model.JobSpecDocker{
 		Image:      "curlimages/curl",
-		Entrypoint: []string{"curl", path.Join(suite.containerHttpURL(), "hello.txt")},
+		Entrypoint: []string{"curl", "--fail-with-body", suite.containerHttpURL().JoinPath("hello.txt").String()},
 	}
 }
 
@@ -165,6 +183,7 @@ func (suite *ExecutorTestSuite) TestDockerNetworkingFull() {
 		Docker:  suite.curlTask(),
 	})
 	require.NoError(suite.T(), err, result.STDERR)
+	require.Zero(suite.T(), result.ExitCode, result.STDERR)
 	require.Equal(suite.T(), "/hello.txt", result.STDOUT)
 }
 
@@ -178,4 +197,67 @@ func (suite *ExecutorTestSuite) TestDockerNetworkingNone() {
 	require.Empty(suite.T(), result.STDOUT)
 	require.NotEmpty(suite.T(), result.STDERR)
 	require.NotZero(suite.T(), result.ExitCode)
+}
+
+func (suite *ExecutorTestSuite) TestDockerNetworkingHTTP() {
+	result, err := suite.runJob(model.Spec{
+		Engine: model.EngineDocker,
+		Network: model.NetworkConfig{
+			Type:    model.NetworkHTTP,
+			Domains: []string{suite.containerHttpURL().Hostname()},
+		},
+		Docker: suite.curlTask(),
+	})
+	require.NoError(suite.T(), err, result.STDERR)
+	require.Zero(suite.T(), result.ExitCode, result.STDERR)
+	require.Equal(suite.T(), "/hello.txt", result.STDOUT)
+}
+
+func (suite *ExecutorTestSuite) TestDockerNetworkingFiltersHTTP() {
+	result, err := suite.runJob(model.Spec{
+		Engine: model.EngineDocker,
+		Network: model.NetworkConfig{
+			Type:    model.NetworkHTTP,
+			Domains: []string{"bacalhau.org"},
+		},
+		Docker: suite.curlTask(),
+	})
+	// The curl will succeed but should return a non-zero exit code and error page.
+	require.NoError(suite.T(), err)
+	require.NotZero(suite.T(), result.ExitCode)
+	require.Contains(suite.T(), result.STDOUT, "ERROR: The requested URL could not be retrieved")
+}
+
+func (suite *ExecutorTestSuite) TestDockerNetworkingFiltersHTTPS() {
+	result, err := suite.runJob(model.Spec{
+		Engine: model.EngineDocker,
+		Network: model.NetworkConfig{
+			Type:    model.NetworkHTTP,
+			Domains: []string{suite.containerHttpURL().Hostname()},
+		},
+		Docker: model.JobSpecDocker{
+			Image:      "curlimages/curl",
+			Entrypoint: []string{"curl", "--fail-with-body", "https://www.bacalhau.org"},
+		},
+	})
+	// The curl will succeed but should return a non-zero exit code and error page.
+	require.NoError(suite.T(), err)
+	require.NotZero(suite.T(), result.ExitCode)
+	require.Empty(suite.T(), result.STDOUT)
+}
+
+func (suite *ExecutorTestSuite) TestDockerNetworkingAppendsHTTPHeader() {
+	suite.server.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(r.Header.Get("X-Bacalhau-Job-ID")))
+	})
+	result, err := suite.runJob(model.Spec{
+		Engine: model.EngineDocker,
+		Network: model.NetworkConfig{
+			Type:    model.NetworkHTTP,
+			Domains: []string{suite.containerHttpURL().Hostname()},
+		},
+		Docker: suite.curlTask(),
+	})
+	require.NoError(suite.T(), err)
+	require.Equal(suite.T(), "test", result.STDOUT, result.STDOUT)
 }

--- a/pkg/executor/docker/gateway/Dockerfile
+++ b/pkg/executor/docker/gateway/Dockerfile
@@ -1,0 +1,38 @@
+# Dockerfile for Bacalhau HTTP gateway
+#
+# This Dockerfile sets up a container image containing an HTTP(S) proxy with a
+# specific allow-list of Internet domains that should be accessible. The proxy
+# allows access to these domains only and blocks all other traffic. The
+# container also enforces rate limits on the traffic.
+#
+# The container is designed to be attached to two networks:
+#
+# 1. A bridge connecting it to all containers taking part in the job, which is
+#    internal only and not connected to the Internet
+# 2. A host network that is Internet connected, which only the proxy can access
+#
+# This enforces that the containers in the bridge network can only access the
+# external network via the proxy.
+#
+# The image uses Squid as an HTTP(S) proxy, iptables to filter packet flows and
+# iproute2 to do traffic shaping. See the squid.conf for how the allow-lists are
+# managed and gateway.sh for how the traffic control is configured.
+#
+# In particular, the image expects some environment variables to be supplied:
+#
+# - BACALHAU_HTTP_CLIENTS which is a one-per-line list of subnets allowed to
+#   access the gateway
+# - BACALHAU_HTTP_DOMAINS which is a one-per-line list of domains that clients
+#   are allowed to access
+# - BACALHAU_JOB_ID which contains the ID of the Bacalhau job being run
+#
+# The container needs to be started with --cap-add=NET_ADMIN so that it can
+# configure iptables and traffic control.
+
+FROM ubuntu:22.04
+RUN apt update && apt install -y squid iptables iproute2 jq
+
+ADD squid.conf /etc/squid/conf.d/
+ADD gateway.sh /bin
+
+CMD ["sh", "/bin/gateway.sh"]

--- a/pkg/executor/docker/gateway/gateway.sh
+++ b/pkg/executor/docker/gateway/gateway.sh
@@ -24,6 +24,11 @@ for IFACE in $(ip --json address show | jq -rc '.[] | .ifname'); do
     tc qdisc add dev $IFACE root tbf rate 1mbit burst 32kbit latency 10sec
 done
 
+# Add Bacalhau job ID to outgoing requests. We can use this to detect jobs
+# trying to spawn other jobs.
+echo request_header_access X-Bacalhau-Job-ID deny all > /etc/squid/conf.d/bac-job.conf
+echo request_header_add X-Bacalhau-Job-ID "$BACALHAU_JOB_ID" all >> /etc/squid/conf.d/bac-job.conf
+
 # Now that everything is configured, run Squid.
 squid -d2
 sleep 1

--- a/pkg/executor/docker/gateway/gateway.sh
+++ b/pkg/executor/docker/gateway/gateway.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+set -eux
+
+# Write out our supplied config to disk.
+mkdir -p /etc/bacalhau
+echo $BACALHAU_HTTP_CLIENTS > /etc/bacalhau/allowed-clients.txt
+echo $BACALHAU_HTTP_DOMAINS > /etc/bacalhau/allowed-domains.txt
+
+# Don't forward any packets... otherwise our proxy can be bypassed.
+iptables -P FORWARD DROP
+
+# Only accept packets for our HTTP proxy from our internal subnet,
+# or for connections we initiated, or internal packets.
+iptables -P INPUT DROP
+iptables -A INPUT -i lo -j ACCEPT
+iptables -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+for BRIDGE_SUBNET in $(cat /etc/bacalhau/allowed-clients.txt); do
+    iptables -A INPUT -p tcp --src $BRIDGE_SUBNET --dport 8080 -j ACCEPT
+done
+
+# Apply rate limits to the outbound connections. We just do this for all
+# interfaces rather than working out which is our Internet connection.
+for IFACE in $(ip --json address show | jq -rc '.[] | .ifname'); do
+    tc qdisc add dev $IFACE root tbf rate 1mbit burst 32kbit latency 10sec
+done
+
+# Now that everything is configured, run Squid.
+squid -d2
+sleep 1
+tail -f /var/log/squid/access.log

--- a/pkg/executor/docker/gateway/squid.conf
+++ b/pkg/executor/docker/gateway/squid.conf
@@ -1,0 +1,30 @@
+# Bacalhau config file for Squid
+#
+# This config file sets up a list of allowed domains that the client is allowed
+# to access. The list of clients is restricted to just executors running the job
+# (so even if there is some misconfiguration of the Docker networking, this acts
+# as another line of defence). 
+#
+# Both of these access lists are expected to be in /etc/bacalhau somehow.
+
+# The syntax for the allowed-domains list is one qualified domain per line e.g.:
+#
+#     .domain1.com
+#     .domain2.com
+acl allowed-domains dstdomain "/etc/bacalhau/allowed-domains.txt"
+
+# The syntax for the allowed-clients list is one IP addr/subnet per line e.g.:
+#
+#     172.1.2.0/16
+#     172.2.3.4
+acl allowed-clients src "/etc/bacalhau/allowed-clients.txt"
+
+# A valid request has to be for an allowed domain and from an allowed client:
+acl valid_reqs_from_executor all-of allowed-domains allowed-clients
+
+# Allow valid requests to happen and deny all others:
+http_access allow valid_reqs_from_executor
+http_access deny all
+
+# Run the HTTP proxy on port:
+http_port 8080

--- a/pkg/executor/docker/network.go
+++ b/pkg/executor/docker/network.go
@@ -1,0 +1,163 @@
+package docker
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/filecoin-project/bacalhau/pkg/docker"
+	"github.com/filecoin-project/bacalhau/pkg/logger"
+	"github.com/filecoin-project/bacalhau/pkg/model"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	dockerNetworkNone   = container.NetworkMode("none")
+	dockerNetworkHost   = container.NetworkMode("host")
+	dockerNetworkBridge = container.NetworkMode("bridge")
+)
+
+const (
+	// The Docker image used to provide HTTP filtering and throttling. See
+	// pkg/executor/docker/gateway/Dockerfile for design notes. We specify this
+	// using a fully-versioned tag so that the interface between code and image
+	// stay in sync.
+	httpGatewayImage = "ghcr.io/bacalhau-project/http-gateway:v0.3.16"
+
+	// The hostname used by Mac OS X and Windows hosts to refer to the Docker
+	// host in a network context. Linux hosts can use this hostname if they
+	// are set up using the `dockerHostAddCommand` as an extra host.
+	dockerHostHostname = "host.docker.internal"
+
+	// The magic word recognized by the Docker engine in place of an IP address
+	// that always maps to the IP address of the Docker host.
+	dockerHostIPAddressMagicWord = "host-gateway"
+
+	// A string that can be passed as an ExtraHost to a Docker run or create
+	// command that will ensure the host is visible on the network from within
+	// the container, even on a Linux host where localhost is sufficient.
+	dockerHostAddCommand = dockerHostHostname + ":" + dockerHostIPAddressMagicWord
+)
+
+const (
+	// The port used by the proxy server within the HTTP gateway container. This
+	// is also specified in squid.conf and gateway.sh.
+	httpProxyPort = 8080
+)
+
+var (
+	// The capabilities that the gateway container needs. See the Dockerfile.
+	gatewayCapabilities = []string{"NET_ADMIN"}
+)
+
+func (e *Executor) setupNetworkForJob(
+	ctx context.Context,
+	shard model.JobShard,
+	containerConfig *container.Config,
+	hostConfig *container.HostConfig,
+) (err error) {
+	containerConfig.NetworkDisabled = shard.Job.Spec.Network.Disabled()
+	switch shard.Job.Spec.Network.Type {
+	case model.NetworkNone:
+		hostConfig.NetworkMode = dockerNetworkNone
+	case model.NetworkFull:
+		hostConfig.NetworkMode = dockerNetworkHost
+		hostConfig.ExtraHosts = append(hostConfig.ExtraHosts, dockerHostAddCommand)
+	case model.NetworkHTTP:
+		var internalNetwork *types.NetworkResource
+		var proxyAddr *net.TCPAddr
+		internalNetwork, proxyAddr, err = e.createHTTPGateway(ctx, shard)
+		if err != nil {
+			return
+		}
+		hostConfig.NetworkMode = container.NetworkMode(internalNetwork.Name)
+		containerConfig.Env = append(containerConfig.Env,
+			fmt.Sprintf("http_proxy=%s", proxyAddr.String()),
+			fmt.Sprintf("https_proxy=%s", proxyAddr.String()),
+		)
+	default:
+		err = fmt.Errorf("unsupported network type %q", shard.Job.Spec.Network.Type.String())
+	}
+	return
+}
+
+func (e *Executor) createHTTPGateway(
+	ctx context.Context,
+	shard model.JobShard,
+) (*types.NetworkResource, *net.TCPAddr, error) {
+	// Create an internal only bridge network to join our gateway and job container
+	networkResp, err := e.Client.NetworkCreate(ctx, e.dockerObjectName(shard, "network"), types.NetworkCreate{
+		Driver:     "bridge",
+		Scope:      "local",
+		Internal:   true,
+		Attachable: true,
+		Labels:     e.jobContainerLabels(&shard),
+	})
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "error creating network")
+	}
+
+	// Get the subnet that Docker has picked for the newly created network
+	internalNetwork, err := e.Client.NetworkInspect(ctx, networkResp.ID, types.NetworkInspectOptions{})
+	if err != nil || len(internalNetwork.IPAM.Config) < 1 {
+		return nil, nil, errors.Wrap(err, "error getting network subnet")
+	}
+	subnet := internalNetwork.IPAM.Config[0].Subnet
+
+	// Create the gateway container initially attached to the *host* network
+	domainList := strings.Join(shard.Job.Spec.Network.Domains, "\n")
+	gatewayContainer, err := e.Client.ContainerCreate(ctx, &container.Config{
+		Image: httpGatewayImage,
+		Env: []string{
+			fmt.Sprintf("BACALHAU_HTTP_CLIENTS=%s", subnet),
+			fmt.Sprintf("BACALHAU_HTTP_DOMAINS=%s", domainList),
+			fmt.Sprintf("BACALHAU_JOB_ID=%s", shard.Job.Metadata.ID),
+		},
+		Healthcheck:     &container.HealthConfig{}, //TODO
+		NetworkDisabled: false,
+		Labels:          e.jobContainerLabels(&shard),
+	}, &container.HostConfig{
+		NetworkMode: dockerNetworkBridge,
+		CapAdd:      gatewayCapabilities,
+		ExtraHosts:  []string{dockerHostAddCommand},
+	}, nil, nil, e.dockerObjectName(shard, "gateway"))
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "error creating gateway container")
+	}
+
+	// Attach the bridge network to the container
+	err = e.Client.NetworkConnect(ctx, internalNetwork.ID, gatewayContainer.ID, nil)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "error attaching network to gateway")
+	}
+
+	// Start the container and wait for it to come up
+	err = e.Client.ContainerStart(ctx, gatewayContainer.ID, types.ContainerStartOptions{})
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to start network gateway container")
+	}
+
+	stdout, stderr, err := docker.FollowLogs(ctx, e.Client, gatewayContainer.ID)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to get gateway container logs")
+	}
+	go logger.LogStream(log.Ctx(ctx).With().Str("Source", "stdout").Logger().WithContext(ctx), stdout)
+	go logger.LogStream(log.Ctx(ctx).With().Str("Source", "stderr").Logger().WithContext(ctx), stderr)
+
+	// Look up the IP address of the gateway container and attach it to the spec
+	containerDetails, err := e.Client.ContainerInspect(ctx, gatewayContainer.ID)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "error getting gateway container details")
+	}
+	networkAttachment, ok := containerDetails.NetworkSettings.Networks[internalNetwork.Name]
+	if !ok || networkAttachment.IPAddress == "" {
+		return nil, nil, fmt.Errorf("gateway does not appear to be attached to internal network")
+	}
+	proxyIP := net.ParseIP(networkAttachment.IPAddress)
+	proxyAddr := net.TCPAddr{IP: proxyIP, Port: httpProxyPort}
+	return &internalNetwork, &proxyAddr, err
+}

--- a/pkg/executor/results.go
+++ b/pkg/executor/results.go
@@ -122,3 +122,7 @@ func WriteJobResults(resultsDir string, stdout, stderr io.Reader, exitcode int, 
 	result.ExitCode = exitcode
 	return result, err
 }
+
+func FailResult(err error) (*model.RunCommandResult, error) {
+	return &model.RunCommandResult{ErrorMsg: err.Error()}, err
+}

--- a/pkg/job/factory.go
+++ b/pkg/job/factory.go
@@ -46,6 +46,7 @@ func ConstructDockerJob( //nolint:funlen
 	p model.Publisher,
 	cpu, memory, gpu string,
 	network model.Network,
+	domains []string,
 	inputUrls []string,
 	inputVolumes []string,
 	outputVolumes []string,
@@ -126,6 +127,10 @@ func ConstructDockerJob( //nolint:funlen
 			Image:                image,
 			Entrypoint:           entrypoint,
 			EnvironmentVariables: env,
+		},
+		Network: model.NetworkConfig{
+			Type:    network,
+			Domains: domains,
 		},
 		Timeout:     timeout,
 		Resources:   jobResources,

--- a/pkg/job/factory_test.go
+++ b/pkg/job/factory_test.go
@@ -77,6 +77,7 @@ func (suite *JobFactorySuite) TestRun_DockerJobOutputs() {
 					"1",               // memory
 					"0",               // gpu
 					model.NetworkNone, // networking
+					[]string{},        // domains
 					[]string{},        // input urls
 					[]string{},        // input volumes
 					outputVolumes,

--- a/pkg/job/validate.go
+++ b/pkg/job/validate.go
@@ -52,6 +52,10 @@ func VerifyJob(ctx context.Context, j *model.Job) error {
 		return fmt.Errorf("invalid publisher type: %s", j.Spec.Publisher.String())
 	}
 
+	if err := j.Spec.Network.IsValid(); err != nil {
+		return err
+	}
+
 	if j.Spec.Deal.Confidence > j.Spec.Deal.Concurrency {
 		return fmt.Errorf("the deal confidence cannot be higher than the concurrency")
 	}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,6 +1,7 @@
 package logger
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"io"
@@ -176,6 +177,16 @@ func configureIpfsLogging(l zerolog.Logger) {
 	core := zapcore.NewCore(encoder, &zerologWriteSyncer{l: l}, zap.NewAtomicLevelAt(zapcore.DebugLevel))
 
 	ipfslog2.SetPrimaryCore(core)
+}
+
+func LogStream(ctx context.Context, r io.Reader) {
+	s := bufio.NewScanner(r)
+	for s.Scan() {
+		log.Ctx(ctx).Debug().Msg(s.Text())
+	}
+	if s.Err() != nil {
+		log.Ctx(ctx).Error().Err(s.Err()).Msg("error consuming log")
+	}
 }
 
 func findRepositoryRoot() string {

--- a/pkg/model/network.go
+++ b/pkg/model/network.go
@@ -1,14 +1,55 @@
 package model
 
-import "fmt"
+import (
+	"fmt"
+	"regexp"
+
+	"go.uber.org/multierr"
+)
 
 //go:generate stringer -type=Network --trimprefix=Network
 type Network int
 
 const (
+	// Specifies that the job does not require networking.
 	NetworkNone Network = iota
+
+	// Specifies that the job requires unfiltered raw IP networking.
 	NetworkFull
+
+	// Specifies that the job requires HTTP networking to certain domains.
+	//
+	// The model is: the job specifier submits a job with the domain(s) it will
+	// need to communicate with, the compute provider uses this to make some
+	// decision about the risk of the job and bids accordingly, and then at run
+	// time the traffic is limited to only the domain(s) specified.
+	//
+	// As a command, something like:
+	//
+	//  bacalhau docker run —network=http —domain=crates.io —domain=github.com -v Qmy1234myd4t4:/code rust/compile
+	//
+	// The “risk” for the compute provider is that the job does something that
+	// violates its terms, the terms of its hosting provider or ISP, or even the
+	// law in it’s jurisdiction (e.g. accessing and spreading illegal content,
+	// performing cyber attacks). So the same sort of risk as operating a Tor
+	// exit node.
+	//
+	// The risk for the job specifier is that we are operating in an environment
+	// they are paying for, so there is an incentive to hijack that environment
+	// (e.g. via a compromised package download that runs a crypto miner on
+	// install, and uses up all of the paid-for job time). Having the traffic
+	// enforced to only domains specified makes those sorts of attacks much
+	// trickier and less valuable.
+	//
+	// The compute provider might well enforce its limits by other means, but
+	// having the domains specified up front allows it to skip bidding on jobs
+	// it knows will fail in its executor. So this is hopefully a better UX for
+	// job specifiers who can have their job picked up only by someone who will
+	// run it successfully.
+	NetworkHTTP
 )
+
+var domainRegex = regexp.MustCompile(`\b([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}\b`)
 
 func ParseNetwork(s string) (Network, error) {
 	for typ := NetworkNone; typ < NetworkFull; typ++ {
@@ -31,11 +72,28 @@ func (n *Network) UnmarshalText(text []byte) (err error) {
 }
 
 type NetworkConfig struct {
-	Type Network `json:"Type"`
+	Type    Network  `json:"Type"`
+	Domains []string `json:"Domains,omitempty"`
 }
 
 // Returns whether network connections should be completely disabled according
 // to this config.
 func (n NetworkConfig) Disabled() bool {
 	return n.Type == NetworkNone
+}
+
+// IsValid returns an error if any of the fields do not pass validation, or nil
+// otherwise.
+func (n NetworkConfig) IsValid() (err error) {
+	if n.Type < NetworkNone || n.Type > NetworkHTTP {
+		err = multierr.Append(err, fmt.Errorf("invalid networking type %q", n.Type))
+	}
+
+	for _, domain := range n.Domains {
+		if !domainRegex.MatchString(domain) {
+			err = multierr.Append(err, fmt.Errorf("invalid domain %q", domain))
+		}
+	}
+
+	return
 }

--- a/pkg/model/network_string.go
+++ b/pkg/model/network_string.go
@@ -10,11 +10,12 @@ func _() {
 	var x [1]struct{}
 	_ = x[NetworkNone-0]
 	_ = x[NetworkFull-1]
+	_ = x[NetworkHTTP-2]
 }
 
-const _Network_name = "NoneFull"
+const _Network_name = "NoneFullHTTP"
 
-var _Network_index = [...]uint8{0, 4, 8}
+var _Network_index = [...]uint8{0, 4, 8, 12}
 
 func (i Network) String() string {
 	if i < 0 || i >= Network(len(_Network_index)-1) {

--- a/pkg/publicapi/client.go
+++ b/pkg/publicapi/client.go
@@ -32,7 +32,8 @@ const APIShortTimeoutSeconds = 10
 
 // APIClient is a utility for interacting with a node's API server.
 type APIClient struct {
-	BaseURI string
+	BaseURI        string
+	DefaultHeaders map[string]string
 
 	client *http.Client
 }
@@ -40,7 +41,8 @@ type APIClient struct {
 // NewAPIClient returns a new client for a node's API server.
 func NewAPIClient(baseURI string) *APIClient {
 	return &APIClient{
-		BaseURI: baseURI,
+		BaseURI:        baseURI,
+		DefaultHeaders: map[string]string{},
 
 		client: &http.Client{
 			Timeout: 300 * time.Second,
@@ -327,6 +329,9 @@ func (apiClient *APIClient) post(ctx context.Context, api string, reqData, resDa
 		return bacerrors.NewResponseUnknownError(fmt.Errorf("publicapi: error creating post request: %v", err))
 	}
 	req.Header.Set("Content-type", "application/json")
+	for header, value := range apiClient.DefaultHeaders {
+		req.Header.Set(header, value)
+	}
 	req.Close = true // don't keep connections lying around
 
 	var res *http.Response

--- a/pkg/test/publicapi/server_test.go
+++ b/pkg/test/publicapi/server_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/filecoin-project/bacalhau/pkg/publicapi"
 	testutils "github.com/filecoin-project/bacalhau/pkg/test/utils"
 	"github.com/filecoin-project/bacalhau/pkg/types"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -66,6 +67,16 @@ func (s *ServerSuite) TestList() {
 	jobs, err = s.client.List(ctx, "", model.IncludeAny, model.ExcludeNone, 10, true, "created_at", true)
 	require.NoError(s.T(), err)
 	require.Len(s.T(), jobs, 1)
+}
+
+func (s *ServerSuite) TestSubmitRejectsJobWithSigilHeader() {
+	j := testutils.MakeNoopJob()
+	jobID, err := uuid.NewRandom()
+	require.NoError(s.T(), err)
+
+	s.client.DefaultHeaders["X-Bacalhau-Job-ID"] = jobID.String()
+	_, err = s.client.Submit(context.Background(), j, nil)
+	require.Error(s.T(), err)
 }
 
 func (s *ServerSuite) TestHealthz() {


### PR DESCRIPTION
This PR adds a new “HTTP” network type that jobs can now use to specify they need HTTP networking (as opposed to fully general networking) and the domain names they require access to.

The Docker executor supports this new networking type. It enforces the HTTP-only nature of the connection by separately running an HTTP proxy (one per job shard). All traffic can only leave the executor container via the proxy, and hence only HTTP(S) between declared domains are
accessible.

The HTTP connection is also throttled to ~1 Mbit. This is so that if multiple compute nodes run a job concurrently, there is not an accidental DDoS of remote endpoints.

Now that we have networking, it is possible for networked jobs to run `bacalhau` themselves and trigger new jobs. Whilst this is a powerful feature, it can also lead to a “fork bomb”-style exhaustion attack as jobs could clone themselves with ever increasing concurrency. This is
particularly dangerous as it would require taking down a majority of the nodes on the network to prevent the jobs from respawning.

So we also now append a header to all outbound HTTP requests made by a job using HTTP networking that signals that the HTTP request is coming from a running job. We configure the submission endpoint to reject any job creation request that contains this header. In this way, we now prevent jobs from creating other jobs.

When we have paid jobs, this is less of an issue as the payment channel will eventually exhaust. We can later selectively add the header only for unpaid jobs, but for now it covers all jobs.

Note that the current default behaviour of compute nodes rejecting all networked jobs by default remains in place. Compute providers still need to opt-in to networking for this feature to be accessible.