### PR TITLE
Remove calls to `debug.PrintStack`

### DIFF
--- a/pkg/docker/utils.go
+++ b/pkg/docker/utils.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/docker/docker/api/types"
 	dockerclient "github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/jsonmessage"
@@ -141,7 +143,7 @@ func StopContainer(ctx context.Context, dockerClient *dockerclient.Client, nameO
 func RemoveContainer(ctx context.Context, dockerClient *dockerclient.Client, nameOrID string) error {
 	container, err := GetContainer(ctx, dockerClient, nameOrID)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	if container == nil {
 		return nil
@@ -150,14 +152,14 @@ func RemoveContainer(ctx context.Context, dockerClient *dockerclient.Client, nam
 	timeout := time.Millisecond * 100
 	err = dockerClient.ContainerStop(ctx, container.ID, &timeout)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	err = dockerClient.ContainerRemove(ctx, container.ID, types.ContainerRemoveOptions{
 		RemoveVolumes: true,
 		Force:         true,
 	})
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	return nil
 }

--- a/pkg/executor/docker/executor.go
+++ b/pkg/executor/docker/executor.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime/debug"
 	"strings"
 
 	"github.com/filecoin-project/bacalhau/pkg/compute/capacity"
@@ -332,8 +331,7 @@ func (e *Executor) cleanupJob(ctx context.Context, shard model.JobShard) {
 
 	err := docker.RemoveContainer(ctx, e.Client, e.jobContainerName(shard))
 	if err != nil {
-		log.Ctx(ctx).Error().Msgf("Docker remove container error: %s", err.Error())
-		debug.PrintStack()
+		log.Ctx(ctx).Err(err).Msg("Docker remove container error")
 	}
 }
 

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -1,0 +1,37 @@
+package logger
+
+import (
+	"github.com/filecoin-project/bacalhau/pkg/logger/testpackage/subpackage/subsubpackage"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+	"strings"
+	"testing"
+)
+
+func TestConfigureLogging(t *testing.T) {
+	oldLogger := log.Logger
+	oldContextLogger := zerolog.DefaultContextLogger
+
+	t.Cleanup(func() {
+		log.Logger = oldLogger
+		zerolog.DefaultContextLogger = oldContextLogger
+	})
+
+	var logging strings.Builder
+	configureLogging(func(w *zerolog.ConsoleWriter) {
+		w.Out = &logging
+		w.NoColor = true
+	})
+
+	subsubpackage.TestLog("testing error logging", "testing message")
+
+	actual := logging.String()
+	// Like 12:47:40.875 | ERR testpackage/subpackage/subsubpackage/testutil.go:10 > testing message error="testing error logging" [stack:[{"func":"TestLog","line":"10","source":"testutil.go"},{"func":"TestConfigureLogging","line":"27","source":"logger_test.go"},...]]
+	t.Log(actual)
+
+	assert.Contains(t, actual, "testing message", "Log statement doesn't contain the log message")
+	assert.Contains(t, actual, `error="testing error logging"`, "Log statement doesn't contain the logged error")
+	assert.Contains(t, actual, subpackageName, "Log statement doesn't contain the full package path")
+	assert.Contains(t, actual, `stack:[{"func":"TestLog","line":`, "Log statement didn't automatically include the error's stacktrace")
+}

--- a/pkg/logger/logger_unix_test.go
+++ b/pkg/logger/logger_unix_test.go
@@ -1,0 +1,5 @@
+//go:build unix
+
+package logger
+
+const subpackageName = "testpackage/subpackage/subsubpackage/testutil.go"

--- a/pkg/logger/logger_windows_test.go
+++ b/pkg/logger/logger_windows_test.go
@@ -1,0 +1,5 @@
+//go:build windows
+
+package logger
+
+const subpackageName = "testpackage\\subpackage\\subsubpackage\\testutil.go"

--- a/pkg/logger/testpackage/subpackage/subsubpackage/testutil.go
+++ b/pkg/logger/testpackage/subpackage/subsubpackage/testutil.go
@@ -1,0 +1,13 @@
+package subsubpackage
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+)
+
+// TestLog exists to allow a test to make sure that we don't strip off package names.
+func TestLog(errorMessage string, message string) {
+	log.Ctx(context.Background()).Err(errors.WithStack(errors.New(errorMessage))).Msg(message)
+}

--- a/pkg/system/tracer.go
+++ b/pkg/system/tracer.go
@@ -7,12 +7,12 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"runtime/debug"
 
 	_ "github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/filecoin-project/bacalhau/pkg/version"
 	"github.com/joho/godotenv"
+	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 
 	"github.com/rs/zerolog/log"
@@ -280,9 +280,7 @@ func AddAttributeToSpanFromBaggage(ctx context.Context, span oteltrace.Span, nam
 	if m.Value() != "" {
 		span.SetAttributes(attribute.String(name, m.Value()))
 	} else {
-		log.Trace().Msgf("no value found for baggage key %s", name)
-		if log.Trace().Enabled() {
-			debug.PrintStack()
-		}
+		log.Trace().Err(errors.WithStack(errors.New("missing value"))).
+			Str("baggage_key", name).Msg("No value found for baggage key")
 	}
 }


### PR DESCRIPTION
Replace calls to `debug.PrintStack` with adding support logging stack traces on when logging errors by using the `github.com/pkg/errors` `WithStack` function.

Also stop reducing the logged package path down to only two levels as some `package/filename.go` combinations have duplicates scattered around the codebase. Having the full package path also allows IDEs, such as Goland, to be able to jump to the log location.

Fixes #1528