### PR TITLE
Ensure Docker networking handles a real-life Go build

### DIFF
--- a/pkg/executor/docker/executor.go
+++ b/pkg/executor/docker/executor.go
@@ -326,7 +326,7 @@ func (e *Executor) cleanupJob(ctx context.Context, shard model.JobShard) {
 		return
 	}
 
-	err := docker.RemoveObjectsWithLabel(ctx, e.Client, labelJobName, shard.ID())
+	err := docker.RemoveObjectsWithLabel(ctx, e.Client, labelJobName, e.ID+shard.ID())
 	logLevel := map[bool]zerolog.Level{true: zerolog.DebugLevel, false: zerolog.ErrorLevel}[err == nil]
 	log.Ctx(ctx).WithLevel(logLevel).Err(err).Msg("Cleaned up job Docker resources")
 }

--- a/pkg/executor/docker/executor_test.go
+++ b/pkg/executor/docker/executor_test.go
@@ -213,6 +213,23 @@ func (suite *ExecutorTestSuite) TestDockerNetworkingHTTP() {
 	require.Equal(suite.T(), "/hello.txt", result.STDOUT)
 }
 
+func (suite *ExecutorTestSuite) TestDockerNetworkingHTTPWithMultipleDomains() {
+	result, err := suite.runJob(model.Spec{
+		Engine: model.EngineDocker,
+		Network: model.NetworkConfig{
+			Type: model.NetworkHTTP,
+			Domains: []string{
+				suite.containerHttpURL().Hostname(),
+				"bacalhau.org",
+			},
+		},
+		Docker: suite.curlTask(),
+	})
+	require.NoError(suite.T(), err, result.STDERR)
+	require.Zero(suite.T(), result.ExitCode, result.STDERR)
+	require.Equal(suite.T(), "/hello.txt", result.STDOUT)
+}
+
 func (suite *ExecutorTestSuite) TestDockerNetworkingFiltersHTTP() {
 	result, err := suite.runJob(model.Spec{
 		Engine: model.EngineDocker,

--- a/pkg/executor/docker/gateway/Dockerfile
+++ b/pkg/executor/docker/gateway/Dockerfile
@@ -20,10 +20,10 @@
 #
 # In particular, the image expects some environment variables to be supplied:
 #
-# - BACALHAU_HTTP_CLIENTS which is a one-per-line list of subnets allowed to
+# - BACALHAU_HTTP_CLIENTS which is a JSON array of strings of subnets allowed to
 #   access the gateway
-# - BACALHAU_HTTP_DOMAINS which is a one-per-line list of domains that clients
-#   are allowed to access
+# - BACALHAU_HTTP_DOMAINS which is a JSON array of strings of domains that
+#   clients are allowed to access
 # - BACALHAU_JOB_ID which contains the ID of the Bacalhau job being run
 #
 # The container needs to be started with --cap-add=NET_ADMIN so that it can

--- a/pkg/executor/docker/gateway/gateway.sh
+++ b/pkg/executor/docker/gateway/gateway.sh
@@ -21,7 +21,7 @@ done
 # Apply rate limits to the outbound connections. We just do this for all
 # interfaces rather than working out which is our Internet connection.
 for IFACE in $(ip --json address show | jq -rc '.[] | .ifname'); do
-    tc qdisc add dev $IFACE root tbf rate 1mbit burst 32kbit latency 10sec
+    tc qdisc add dev $IFACE root tbf rate 10mbit burst 32kbit latency 10sec
 done
 
 # Add Bacalhau job ID to outgoing requests. We can use this to detect jobs

--- a/pkg/executor/docker/gateway/gateway.sh
+++ b/pkg/executor/docker/gateway/gateway.sh
@@ -3,8 +3,8 @@ set -eux
 
 # Write out our supplied config to disk.
 mkdir -p /etc/bacalhau
-echo $BACALHAU_HTTP_CLIENTS > /etc/bacalhau/allowed-clients.txt
-echo $BACALHAU_HTTP_DOMAINS > /etc/bacalhau/allowed-domains.txt
+echo $BACALHAU_HTTP_CLIENTS | jq -r '.[]' > /etc/bacalhau/allowed-clients.txt
+echo $BACALHAU_HTTP_DOMAINS | jq -r '.[]' > /etc/bacalhau/allowed-domains.txt
 
 # Don't forward any packets... otherwise our proxy can be bypassed.
 iptables -P FORWARD DROP

--- a/pkg/executor/docker/network.go
+++ b/pkg/executor/docker/network.go
@@ -2,9 +2,9 @@ package docker
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net"
-	"strings"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -13,6 +13,7 @@ import (
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
+	"go.uber.org/multierr"
 )
 
 const (
@@ -26,7 +27,7 @@ const (
 	// pkg/executor/docker/gateway/Dockerfile for design notes. We specify this
 	// using a fully-versioned tag so that the interface between code and image
 	// stay in sync.
-	httpGatewayImage = "ghcr.io/bacalhau-project/http-gateway:v0.3.16"
+	httpGatewayImage = "ghcr.io/bacalhau-project/http-gateway:v0.3.15-47-g70f95a3d"
 
 	// The hostname used by Mac OS X and Windows hosts to refer to the Docker
 	// host in a network context. Linux hosts can use this hostname if they
@@ -109,11 +110,16 @@ func (e *Executor) createHTTPGateway(
 	subnet := internalNetwork.IPAM.Config[0].Subnet
 
 	// Create the gateway container initially attached to the *host* network
-	domainList := strings.Join(shard.Job.Spec.Network.Domains, "\n")
+	domainList, derr := json.Marshal(shard.Job.Spec.Network.Domains)
+	clientList, cerr := json.Marshal([]string{subnet})
+	if derr != nil || cerr != nil {
+		return nil, nil, errors.Wrap(multierr.Combine(derr, cerr), "error preparing gateway config")
+	}
+
 	gatewayContainer, err := e.Client.ContainerCreate(ctx, &container.Config{
 		Image: httpGatewayImage,
 		Env: []string{
-			fmt.Sprintf("BACALHAU_HTTP_CLIENTS=%s", subnet),
+			fmt.Sprintf("BACALHAU_HTTP_CLIENTS=%s", clientList),
 			fmt.Sprintf("BACALHAU_HTTP_DOMAINS=%s", domainList),
 			fmt.Sprintf("BACALHAU_JOB_ID=%s", shard.Job.Metadata.ID),
 		},

--- a/pkg/executor/docker/network.go
+++ b/pkg/executor/docker/network.go
@@ -27,7 +27,7 @@ const (
 	// pkg/executor/docker/gateway/Dockerfile for design notes. We specify this
 	// using a fully-versioned tag so that the interface between code and image
 	// stay in sync.
-	httpGatewayImage = "ghcr.io/bacalhau-project/http-gateway:v0.3.15-47-g70f95a3d"
+	httpGatewayImage = "ghcr.io/bacalhau-project/http-gateway:v0.3.15-50-g9955b03d"
 
 	// The hostname used by Mac OS X and Windows hosts to refer to the Docker
 	// host in a network context. Linux hosts can use this hostname if they

--- a/pkg/model/network.go
+++ b/pkg/model/network.go
@@ -52,7 +52,7 @@ const (
 var domainRegex = regexp.MustCompile(`\b([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}\b`)
 
 func ParseNetwork(s string) (Network, error) {
-	for typ := NetworkNone; typ < NetworkFull; typ++ {
+	for typ := NetworkNone; typ <= NetworkHTTP; typ++ {
 		if equal(typ.String(), s) {
 			return typ, nil
 		}


### PR DESCRIPTION
This PR makes a number of small tweaks to the Docker networking stack to better handle real-world applications, namely ensuring multiple domains can be specified and that the rate limiting lets downloads happen in a realistic time frame.

The test case is a Go build using: 

```yaml
Spec:
  Docker:
    Entrypoint:
    - go
    - install
    - github.com/filecoin-project/bacalhau@v0.3.16
    Image: golang:1.19
    EnvironmentVariables:
    - GOBIN=/outputs
  Engine: Docker
  Network:
    Type: HTTP
    Domains:
      - proxy.golang.org
      - sum.golang.org
      - index.golang.org
      - storage.googleapis.com
  Publisher: Estuary
  Verifier: Noop
  Outputs:
    - Name: outputs
      path: /outputs
```
