### PR TITLE
More reliable HTTP gateway

### DIFF
--- a/pkg/executor/docker/gateway/Dockerfile
+++ b/pkg/executor/docker/gateway/Dockerfile
@@ -36,3 +36,4 @@ ADD squid.conf /etc/squid/conf.d/
 ADD gateway.sh /bin
 
 CMD ["sh", "/bin/gateway.sh"]
+HEALTHCHECK --interval=1s --start-period=5s CMD ["bash", "-c", ": &>/dev/null </dev/tcp/127.0.0.1/8080"]

--- a/pkg/executor/docker/gateway/gateway.sh
+++ b/pkg/executor/docker/gateway/gateway.sh
@@ -31,5 +31,4 @@ echo request_header_add X-Bacalhau-Job-ID "$BACALHAU_JOB_ID" all >> /etc/squid/c
 
 # Now that everything is configured, run Squid.
 squid -d2
-sleep 1
-tail -f /var/log/squid/access.log
+tail -F /var/log/squid/access.log

--- a/pkg/executor/docker/network.go
+++ b/pkg/executor/docker/network.go
@@ -94,6 +94,12 @@ func (e *Executor) createHTTPGateway(
 	ctx context.Context,
 	shard model.JobShard,
 ) (*types.NetworkResource, *net.TCPAddr, error) {
+	// Get the gateway image if we don't have it already
+	err := docker.PullImage(ctx, e.Client, httpGatewayImage)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "error pulling gateway image")
+	}
+
 	// Create an internal only bridge network to join our gateway and job container
 	networkResp, err := e.Client.NetworkCreate(ctx, e.dockerObjectName(shard, "network"), types.NetworkCreate{
 		Driver:     "bridge",


### PR DESCRIPTION
- [Wait for HTTP gateway to be ready before starting jobs](https://github.com/filecoin-project/bacalhau/commit/c7dc759aae197a73c404bc24fbf70e66d1f42afd)
- [Automatically pull the HTTP gateway container image](https://github.com/filecoin-project/bacalhau/commit/2f64747d8975ea974a340a6da9b1c23ac6d07056) (Resolves #1655).
- [Ensure Docker logs reader captures all logs.](https://github.com/filecoin-project/bacalhau/commit/76e8b8a6e779511af227335f15544d5a1c4bf4e8) (Resolves #1657).