### PR TITLE
Fix issue workflow

### DIFF
--- a/.github/workflows/project_triage_assign.yml
+++ b/.github/workflows/project_triage_assign.yml
@@ -1,0 +1,15 @@
+name: Move new issues into Triage
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  automate-project-columns:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: alex-page/github-project-automation-plus@v0.8.1
+        with:
+          project: Bacalhau Main
+          column: Triage
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/project_triage_assign.yml
+++ b/.github/workflows/project_triage_assign.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   automate-project-columns:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - uses: alex-page/github-project-automation-plus@v0.8.1
         with:


### PR DESCRIPTION
Reinstate issue workflow, as that was actually moving the issues even though the action is failing, and increase permissions to hopefully fix error. 