### PR TITLE
Ensure simulator avoids concurrent map writes

### DIFF
--- a/pkg/devstack/devstack.go
+++ b/pkg/devstack/devstack.go
@@ -224,24 +224,15 @@ func NewDevStack(
 		//////////////////////////////////////
 		// port for API
 		//////////////////////////////////////
-		var apiPort int
+		apiPort := 0
 		if os.Getenv("PREDICTABLE_API_PORT") != "" {
 			apiPort = 20000 + i
-		} else {
-			apiPort, err = freeport.GetFreePort()
-			if err != nil {
-				return nil, err
-			}
 		}
 
 		//////////////////////////////////////
 		// metrics
 		//////////////////////////////////////
-		var metricsPort int
-		metricsPort, err = freeport.GetFreePort()
-		if err != nil {
-			return nil, err
-		}
+		metricsPort := 0
 
 		//////////////////////////////////////
 		// in-memory datastore
@@ -326,11 +317,6 @@ func NewDevStack(
 		}
 
 		nodes = append(nodes, n)
-
-		// let's wait a small period to give the api server a chance to spin up
-		// meaning it's port will be in use the next time we spin around this loop
-		// and so hopefully avoid "listen tcp 0.0.0.0:43081: bind: address already in use" errors
-		time.Sleep(time.Millisecond * 100) //nolint:gomnd
 	}
 
 	// only start profiling after we've set everything up!

--- a/pkg/storage/parallel.go
+++ b/pkg/storage/parallel.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/filecoin-project/bacalhau/pkg/model"
+	"github.com/filecoin-project/bacalhau/pkg/util/generic"
 	"go.ptx.dk/multierrgroup"
 )
 
@@ -15,7 +16,7 @@ func ParallelPrepareStorage(
 	provider StorageProvider,
 	specs []model.StorageSpec,
 ) (map[*model.StorageSpec]StorageVolume, error) {
-	volumes := genericSyncMap[*model.StorageSpec, StorageVolume]{}
+	volumes := generic.SyncMap[*model.StorageSpec, StorageVolume]{}
 	waitgroup := multierrgroup.Group{}
 
 	for _, inputStorageSpec := range specs {

--- a/pkg/util/generic/syncmap.go
+++ b/pkg/util/generic/syncmap.go
@@ -1,0 +1,39 @@
+package generic
+
+import "sync"
+
+// A generic.SyncMap is a concurrency-safe sync.Map that uses strongly-typed
+// method signatures to ensure the types of its stored data are known.
+type SyncMap[K comparable, V any] struct {
+	sync.Map
+}
+
+func SyncMapFromMap[K comparable, V any](m map[K]V) *SyncMap[K, V] {
+	ret := &SyncMap[K, V]{}
+	for k, v := range m {
+		ret.Put(k, v)
+	}
+
+	return ret
+}
+
+func (m *SyncMap[K, V]) Get(key K) (V, bool) {
+	value, ok := m.Load(key)
+	if !ok {
+		var empty V
+		return empty, false
+	}
+	return value.(V), true
+}
+
+func (m *SyncMap[K, V]) Put(key K, value V) {
+	m.Store(key, value)
+}
+
+func (m *SyncMap[K, V]) Iter(ranger func(key K, value V) bool) {
+	m.Range(func(key, value any) bool {
+		k := key.(K)
+		v := value.(V)
+		return ranger(k, v)
+	})
+}


### PR DESCRIPTION
Previously the multi-node nature of the simulator would mean it sometimes is writing to its shared maps simultaneously. These have been changed to use a sync.Map that will ensure only one thread is simultaneously writing.

We also now allow the kernel to decide on the API server and metrics ports by default, to prevent port races in multi-node setups. (This was done elsewhere but apparently not in the devstack.)

Resolves #1650.