### PR TITLE
Allow HTTP job networking using an allowlist

### DIFF
--- a/ops/terraform/main.tf
+++ b/ops/terraform/main.tf
@@ -91,6 +91,14 @@ sudo tee /terraform_node/start-bacalhau.sh > /dev/null <<'EOI'
 ${file("${path.module}/remote_files/scripts/start-bacalhau.sh")}
 EOI
 
+sudo tee /terraform_node/apply-http-allowlist.sh > /dev/null <<'EOI'
+${file("${path.module}/remote_files/scripts/apply-http-allowlist.sh")}
+EOI
+
+sudo tee /terraform_node/http-domain-allowlist.txt > /dev/null <<'EOI'
+${file("${path.module}/remote_files/scripts/http-domain-allowlist.txt")}
+EOI
+
 #########
 # health checker
 #########
@@ -292,7 +300,7 @@ resource "google_compute_firewall" "bacalhau_ssh_firewall" {
 
   allow {
     protocol = "tcp"
-    // Port 22   - Provides ssh access to the bacalhau server, for debugging 
+    // Port 22   - Provides ssh access to the bacalhau server, for debugging
     ports = ["22"]
   }
 

--- a/ops/terraform/remote_files/scripts/apply-http-allowlist.sh
+++ b/ops/terraform/remote_files/scripts/apply-http-allowlist.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# Script to be used with --job-selection-probe-exec that will:
+# - reject jobs with --network=Full
+# - reject jobs with --domain=... not in our allowlist
+# - accept all other jobs
+
+ALLOWLIST=./http-domain-allowlist.txt
+
+TYPE=$(echo "$BACALHAU_JOB_SELECTION_PROBE_DATA" | jq -r '.spec.Network.Type')
+test "$TYPE" = 'HTTP' || test "$TYPE" = 'None'
+
+cd "$(dirname $0)"
+MISSING=$(comm -13 \
+    <(cat "$ALLOWLIST" | grep -v '#' | sort) \
+    <(echo "$BACALHAU_JOB_SELECTION_PROBE_DATA" | jq -r '.spec.Network.Domains[]' | sort))
+
+test -z "$MISSING"

--- a/ops/terraform/remote_files/scripts/http-domain-allowlist.txt
+++ b/ops/terraform/remote_files/scripts/http-domain-allowlist.txt
@@ -1,0 +1,110 @@
+# This is the domain allowlist used for HTTP networking for "the Bacalhau team
+# provided compute nodes" (as opposed to "all compute nodes on the Bacalhau
+# network").
+#
+# This list is very much about *our* perception of risk, what things *we* are
+# comfortable with, and ensuring that *our* nodes are not performing
+# illegal/questionable behaviour (as opposed to trying to define an allowlist
+# for all compute providers to use, which would be much harder).
+#
+# Why do we have network restrictions?
+# ====================================
+# Broadly, to stop certain behaviours on our nodes that we don't want to
+# support.
+#
+# 1. Illegal behaviour on our nodes is our problem and we are liable for it (or
+#    will have to put in effort to contest we are liable). Example: using a job
+#    to download copyright files from one place and upload them to another.
+# 2. Behaviour that our hosting provider(s) deem against their ToS might result
+#    in the shut down of our compute nodes.
+# 3. Behaviour that circumvents the Bacalhau network operation (e.g. for paid
+#    jobs, using network connections to publish results before they've been paid
+#    for, and then denying payment)
+# 4. Behaviour that degrades the ability of our nodes to serve legitimate
+#    requests and/or encourages flood use of our nodes (e.g. for unpaid jobs,
+#    using our nodes as bitcoin miners, constantly, in a loop, meaning that our
+#    ability to serve legitimate volunteer/example requests is reduced)
+# 5. Behaviour that allows a job to be compromised by a malicious actor to
+#    achieve one of the above behaviours (e.g. for paid jobs, allowing a
+#    compromised package to download and run a bitcoin miner, sucking up all of
+#    the user's money).
+#
+# What use cases should we use networking to meet?
+# ================================================
+# Well we have a sensible idea of what not to use it for:
+#
+# * As a summary of above: nothing illegal, nothing against Google TOS, nothing
+#   to circumvent our network principles, nothing that allows repeated use of
+#   the network to the point of degradation for other users
+# * Bacalhau alerady has data input and output using storage and publishers, so
+#   we shouldn't use networking to meet any use cases where it is already
+#   possible using a suitably formatted job spec.
+#
+# And as a suggestion, we could start with the following list that we have
+# observed people asking for:
+#
+# * Jobs where a tool expects a certain HTTP API for proper operation (e.g.
+#   build tools, like go, cargo, gem, pip etc) and hence where bringing data in
+#   via IPFS/URL download is not feasible/practical
+# * Jobs whose sole role is to provide some [IPFS] consolidation of Internet
+#   endpoints (e.g. a job that downloads data/scrapes web pages from a set of
+#   domains, and archives the results on IPFS/Filecoin)
+# * Jobs that enable our own use cases or those of our partners whom we have a
+#   trusted relationship with (e.g. Project Frog, or people we give grants to)
+#   and hence have more trust that the privilege will not be abused
+#
+# We should also treat jobs that will only make safe HTTP requests more
+# leniently than those that do not (i.e. a job just downloading data is
+# generally safer to approve than one that is POSTing results to different
+# places). So domains that are predominantly read-only are normally fine,
+# whereas those with writeable APIs need more care.
+#
+# How do I know what domains to approve?
+# ======================================
+# You need to assure yourself that approving access to the domain meets ALL of
+# the requirements in the first list of the above section and ONE OF the
+# requirements in the second list of the above section.
+#
+# Start by checking out the domain on the web: what is it used for? Does it have
+# good documentation of what can be done on it? Is it mainly for read-only data
+# access or does it also include writable endpoints? Is the organisation
+# operating it easy to find?
+#
+# Are the operators of the domain likely to have a content policy and
+# moderation? So that it is not likely that the domain currently is being used
+# for nefarious purposes, and anything that our user does that tries to use it
+# for that will be shutdown/removed. Generally bigger players that display data
+# publicly (e.g. Github) will have this.
+#
+# Remember that we should operate a "default deny" policy – if we can't be
+# reasonably confident the domain access will be used appropriately, we just say
+# no.
+#
+# We also need to think about what a domain "could" be used for outside of what
+# the requestor is asking to use it for. E.g. if they are saying they only want
+# to use it download some static files, but access to the domain could also
+# enable some bitcoin-mining workflow, we should probably be saying no to that
+# request.
+#
+# (We may find that domain-based allow-listing is not enough, and we need to go
+# to the next level – job-based allow-listing, e.g. you can only access these
+# domains if you want to run certain jobs we have approved.)
+#
+# Who updates this file and how?
+# ==============================
+# Anyone who has access to update Bacalhau compute nodes in production also has
+# the ability to approve or deny allowlist changes. They should think through
+# the above rationale and come to a decision.
+#
+# Community members who want to use new domains can either make the request on
+# Slack or submit a Github PR against the allowlist that includes the domains
+# they want to use.
+
+# example domains
+example.com
+
+# golang dependencies
+proxy.golang.org
+sum.golang.org
+index.golang.org
+storage.googleapis.com

--- a/ops/terraform/remote_files/scripts/install-node.sh
+++ b/ops/terraform/remote_files/scripts/install-node.sh
@@ -69,6 +69,7 @@ function install-ipfs() {
 
 function install-bacalhau() {
   echo "Installing Bacalhau"
+  sudo apt-get -y install --no-install-recommends jq
   wget "https://github.com/filecoin-project/bacalhau/releases/download/${BACALHAU_VERSION}/bacalhau_${BACALHAU_VERSION}_linux_amd64.tar.gz"
   tar xfv "bacalhau_${BACALHAU_VERSION}_linux_amd64.tar.gz"
   sudo mv ./bacalhau /usr/local/bin/bacalhau
@@ -178,7 +179,7 @@ function mount-disk() {
   done
   # mount /dev/sdb at /data
   sudo mkdir -p /data
-  sudo mount /dev/sdb /data || (sudo mkfs -t ext4 /dev/sdb && sudo mount /dev/sdb /data) 
+  sudo mount /dev/sdb /data || (sudo mkfs -t ext4 /dev/sdb && sudo mount /dev/sdb /data)
 }
 
 # make sure that "ipfs init" has been run

--- a/ops/terraform/remote_files/scripts/start-bacalhau.sh
+++ b/ops/terraform/remote_files/scripts/start-bacalhau.sh
@@ -37,7 +37,7 @@ if [[ "${TERRAFORM_NODE_INDEX}" != "0" ]]; then
       export UNSAFE_NODE0_ID="$BACALHAU_NODE0_UNSAFE_ID"
     fi
     export CONNECT_PEER=$(getMultiaddress "$TERRAFORM_NODE0_IP" "$UNSAFE_NODE0_ID")
-  # otherwise we will construct our connect string based on 
+  # otherwise we will construct our connect string based on
   # what node index we are
   else
     # we are > node0 so we can connect to node0
@@ -53,9 +53,13 @@ if [[ "${TERRAFORM_NODE_INDEX}" != "0" ]]; then
   fi
 fi
 
+BACALHAU_PROBE_EXEC='/terraform_node/apply-http-allowlist.sh'
+
 bacalhau serve \
   --node-type requester,compute \
   --job-selection-data-locality anywhere \
+  --job-selection-accept-networked \
+  --job-selection-probe-exec "${BACALHAU_PROBE_EXEC}" \
   --ipfs-connect /ip4/127.0.0.1/tcp/5001 \
   --swarm-port "${BACALHAU_PORT}" \
   --api-port 1234 \

--- a/pkg/compute/bidstrategy/networking_allowlist_test.go
+++ b/pkg/compute/bidstrategy/networking_allowlist_test.go
@@ -1,0 +1,62 @@
+package bidstrategy
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/filecoin-project/bacalhau/pkg/model"
+	"github.com/stretchr/testify/require"
+)
+
+type networkAllowlistTestCase struct {
+	Type      model.Network
+	Domains   []string
+	ShouldBid bool
+}
+
+func (tc networkAllowlistTestCase) String() string {
+	return fmt.Sprintf(
+		"should bid %t with %s networking and domains %s",
+		tc.ShouldBid,
+		tc.Type,
+		strings.Join(tc.Domains, " "),
+	)
+}
+
+var networkAllowlistTestCases []networkAllowlistTestCase = []networkAllowlistTestCase{
+	{model.NetworkNone, []string{}, true},
+	{model.NetworkFull, []string{}, false},
+	{model.NetworkHTTP, []string{}, true},
+	{model.NetworkHTTP, []string{"example.com"}, true},
+	{model.NetworkFull, []string{"example.com"}, false},
+	{model.NetworkHTTP, []string{"malware.com"}, false},
+	{model.NetworkFull, []string{"malware.com"}, false},
+	{model.NetworkHTTP, []string{"example.com", "proxy.golang.org"}, true},
+	{model.NetworkHTTP, []string{"malware.com", "proxy.golang.org"}, false},
+}
+
+func TestNetworkAllowlistStrategyFiltersDomains(t *testing.T) {
+	strategy := NewExternalCommandStrategy(ExternalCommandStrategyParams{
+		Command: "../../../ops/terraform/remote_files/scripts/apply-http-allowlist.sh",
+	})
+
+	for _, testCase := range networkAllowlistTestCases {
+		t.Run(testCase.String(), func(t *testing.T) {
+			resp, err := strategy.ShouldBid(context.Background(), BidStrategyRequest{
+				Job: model.Job{
+					Spec: model.Spec{
+						Network: model.NetworkConfig{
+							Type:    testCase.Type,
+							Domains: testCase.Domains,
+						},
+					},
+				},
+			})
+
+			require.NoError(t, err)
+			require.Equal(t, testCase.ShouldBid, resp.ShouldBid, resp.Reason)
+		})
+	}
+}


### PR DESCRIPTION
We have previously added support for HTTP networking that enforces domains are restricted to a certain allowlist. The idea is for compute providers to somehow decide what jobs they are willing to run using the domain list in the job spec and bid appropriately.

This commit adds the simplest possible decision-making: an allowlist. There is now a probe to be used with the "job selection exec probe" that will compare what is on the allowlist to what is provided in the spec. If there is anything in the spec not on the allowlist, the job is rejected (or if the job is asking for full networking).

This is intended as configuration for the "Bacalhau compute provider" rather than a new core feature for all compute providers. We are still learning about what compute providers will do with networking features and expect them to want more sophisticated strategies in the future.