### PR TITLE
Allow certain users to bypass timeout check

### DIFF
--- a/pkg/model/ipld.go
+++ b/pkg/model/ipld.go
@@ -77,7 +77,7 @@ func Reinterpret[T any](node datamodel.Node, schema *Schema) (*T, error) {
 	schemaType := schema.GetSchemaType((*T)(nil))
 
 	var buf bytes.Buffer
-	var val *T = new(T)
+	var val = new(T)
 	err := json.Encode(node, &buf)
 	if err != nil {
 		return val, err

--- a/pkg/model/utils.go
+++ b/pkg/model/utils.go
@@ -5,10 +5,8 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
-	"unsafe"
 
 	"github.com/c2h5oh/datasize"
-	"github.com/rs/zerolog/log"
 	"sigs.k8s.io/yaml"
 )
 
@@ -16,12 +14,9 @@ type KeyString string
 type KeyInt int
 
 const MaxSerializedStringInput = int(10 * datasize.MB)
-const MaxSerializedStringOutput = int(10 * datasize.MB)
 
 // Arbitrarily choosing 1000 jobs to serialize - this is a pretty high
 const MaxNumberOfObjectsToSerialize = 1000
-
-const JSONIndentSpaceNumber = 4
 
 const ShortIDLength = 8
 
@@ -29,33 +24,6 @@ func equal(a, b string) bool {
 	a = strings.TrimSpace(a)
 	b = strings.TrimSpace(b)
 	return strings.EqualFold(a, b)
-}
-
-func PrintContextInternals(ctx interface{}, inner bool) {
-	contextValues := reflect.ValueOf(ctx).Elem()
-	contextKeys := reflect.TypeOf(ctx).Elem()
-
-	if !inner {
-		log.Debug().Msgf("\nFields for %s.%s\n", contextKeys.PkgPath(), contextKeys.Name())
-	}
-
-	if contextKeys.Kind() == reflect.Struct {
-		for i := 0; i < contextValues.NumField(); i++ {
-			reflectValue := contextValues.Field(i)
-			reflectValue = reflect.NewAt(reflectValue.Type(), unsafe.Pointer(reflectValue.UnsafeAddr())).Elem()
-
-			reflectField := contextKeys.Field(i)
-
-			if reflectField.Name == "Context" {
-				PrintContextInternals(reflectValue.Interface(), true)
-			} else {
-				log.Debug().Msgf("field name: %+v\n", reflectField.Name)
-				log.Debug().Msgf("value: %+v\n", reflectValue.Interface())
-			}
-		}
-	} else {
-		log.Debug().Msgf("context is empty (int)\n")
-	}
 }
 
 const (

--- a/pkg/node/compute.go
+++ b/pkg/node/compute.go
@@ -156,8 +156,9 @@ func NewComputeNode(
 			RejectStatelessJobs: config.JobSelectionPolicy.RejectStatelessJobs,
 		}),
 		bidstrategy.NewTimeoutStrategy(bidstrategy.TimeoutStrategyParams{
-			MaxJobExecutionTimeout: config.MaxJobExecutionTimeout,
-			MinJobExecutionTimeout: config.MinJobExecutionTimeout,
+			MaxJobExecutionTimeout:                config.MaxJobExecutionTimeout,
+			MinJobExecutionTimeout:                config.MinJobExecutionTimeout,
+			JobExecutionTimeoutClientIDBypassList: config.JobExecutionTimeoutClientIDBypassList,
 		}),
 	)
 

--- a/pkg/node/config_compute.go
+++ b/pkg/node/config_compute.go
@@ -24,6 +24,8 @@ type ComputeConfigParams struct {
 	MaxJobExecutionTimeout     time.Duration
 	DefaultJobExecutionTimeout time.Duration
 
+	JobExecutionTimeoutClientIDBypassList []string
+
 	// Bid strategies config
 	JobSelectionPolicy model.JobSelectionPolicy
 
@@ -55,6 +57,10 @@ type ComputeConfig struct {
 	// DefaultJobExecutionTimeout default value for the execution timeout this compute node will assign to jobs with
 	// no timeout requirement defined.
 	DefaultJobExecutionTimeout time.Duration
+
+	// JobExecutionTimeoutClientIDBypassList is the list of clients that are allowed to bypass the job execution timeout
+	// check.
+	JobExecutionTimeoutClientIDBypassList []string
 
 	// Bid strategies config
 	JobSelectionPolicy model.JobSelectionPolicy
@@ -137,6 +143,8 @@ func NewComputeConfigWith(params ComputeConfigParams) (config ComputeConfig) {
 		MinJobExecutionTimeout:     params.MinJobExecutionTimeout,
 		MaxJobExecutionTimeout:     params.MaxJobExecutionTimeout,
 		DefaultJobExecutionTimeout: params.DefaultJobExecutionTimeout,
+
+		JobExecutionTimeoutClientIDBypassList: params.JobExecutionTimeoutClientIDBypassList,
 
 		JobSelectionPolicy: params.JobSelectionPolicy,
 

--- a/pkg/system/config_test.go
+++ b/pkg/system/config_test.go
@@ -20,65 +20,63 @@ func TestSystemConfigSuite(t *testing.T) {
 	suite.Run(t, new(SystemConfigSuite))
 }
 
-// Before each test
-func (suite *SystemConfigSuite) SetupTest() {
-	logger.ConfigureTestLogging(suite.T())
-	require.NoError(suite.T(), InitConfigForTesting(suite.T()))
+func (s *SystemConfigSuite) SetupTest() {
+	logger.ConfigureTestLogging(s.T())
 }
 
-func (suite *SystemConfigSuite) TestMessageSigning() {
+func (s *SystemConfigSuite) TestMessageSigning() {
 	defer func() {
 		if r := recover(); r != nil {
-			suite.T().Errorf("unexpected panic: %v", r)
+			s.T().Errorf("unexpected panic: %v", r)
 		}
 	}()
 
-	require.NoError(suite.T(), InitConfigForTesting(suite.T()))
+	require.NoError(s.T(), InitConfigForTesting(s.T()))
 
 	msg := []byte("Hello, world!")
 	sig, err := SignForClient(msg)
-	require.NoError(suite.T(), err)
+	require.NoError(s.T(), err)
 
 	ok, err := VerifyForClient(msg, sig)
-	require.NoError(suite.T(), err)
-	require.True(suite.T(), ok)
+	require.NoError(s.T(), err)
+	require.True(s.T(), ok)
 
 	publicKey := GetClientPublicKey()
 	err = Verify(msg, sig, publicKey)
-	require.NoError(suite.T(), err)
+	require.NoError(s.T(), err)
 }
 
-func (suite *SystemConfigSuite) TestGetClientID() {
+func (s *SystemConfigSuite) TestGetClientID() {
 	defer func() {
 		if r := recover(); r != nil {
-			suite.T().Errorf("unexpected panic: %v", r)
+			s.T().Errorf("unexpected panic: %v", r)
 		}
 	}()
 
-	require.NoError(suite.T(), InitConfigForTesting(suite.T()))
-	id := GetClientID()
-	require.NotEmpty(suite.T(), id)
+	var firstId string
+	s.Run("first", func() {
+		s.Require().NoError(InitConfigForTesting(s.T()))
+		firstId = GetClientID()
+		s.Require().NotEmpty(firstId)
+	})
 
-	require.NoError(suite.T(), InitConfigForTesting(suite.T()))
-	id2 := GetClientID()
-	require.NotEmpty(suite.T(), id2)
+	var secondId string
+	s.Run("second", func() {
+		s.Require().NoError(InitConfigForTesting(s.T()))
+		secondId = GetClientID()
+		s.Require().NotEmpty(secondId)
 
-	// Two different clients should have different IDs.
-	require.NotEqual(suite.T(), id, id2)
+		// Two different clients should have different IDs.
+		s.Assert().NotEqual(firstId, secondId)
+	})
 }
 
-func (suite *SystemConfigSuite) TestPublicKeyMatchesID() {
-	defer func() {
-		if r := recover(); r != nil {
-			suite.T().Errorf("unexpected panic: %v", r)
-		}
-	}()
-
-	require.NoError(suite.T(), InitConfigForTesting(suite.T()))
+func (s *SystemConfigSuite) TestPublicKeyMatchesID() {
+	require.NoError(s.T(), InitConfigForTesting(s.T()))
 
 	id := GetClientID()
 	publicKey := GetClientPublicKey()
 	ok, err := PublicKeyMatchesID(publicKey, id)
-	require.NoError(suite.T(), err)
-	require.True(suite.T(), ok)
+	require.NoError(s.T(), err)
+	require.True(s.T(), ok)
 }

--- a/pkg/test/devstack/timeout_test.go
+++ b/pkg/test/devstack/timeout_test.go
@@ -15,6 +15,7 @@ import (
 	_ "github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/filecoin-project/bacalhau/pkg/node"
+	"github.com/filecoin-project/bacalhau/pkg/system"
 	"github.com/filecoin-project/bacalhau/pkg/test/scenario"
 	"github.com/stretchr/testify/suite"
 )
@@ -34,6 +35,7 @@ func (suite *DevstackTimeoutSuite) TestRunningTimeout() {
 		minBids                             int
 		concurrency                         int
 		computeJobNegotiationTimeout        time.Duration
+		computeJobExecutionBypassList       []string
 		computeMinJobExecutionTimeout       time.Duration
 		computeMaxJobExecutionTimeout       time.Duration
 		requesterJobNegotiationTimeout      time.Duration
@@ -50,9 +52,10 @@ func (suite *DevstackTimeoutSuite) TestRunningTimeout() {
 			Stack: &scenario.StackConfig{
 				DevStackOptions: &devstack.DevStackOptions{NumberOfHybridNodes: testCase.nodeCount},
 				ComputeConfig: node.NewComputeConfigWith(node.ComputeConfigParams{
-					JobNegotiationTimeout:  testCase.computeJobNegotiationTimeout,
-					MinJobExecutionTimeout: testCase.computeMinJobExecutionTimeout,
-					MaxJobExecutionTimeout: testCase.computeMaxJobExecutionTimeout,
+					JobNegotiationTimeout:                 testCase.computeJobNegotiationTimeout,
+					MinJobExecutionTimeout:                testCase.computeMinJobExecutionTimeout,
+					MaxJobExecutionTimeout:                testCase.computeMaxJobExecutionTimeout,
+					JobExecutionTimeoutClientIDBypassList: testCase.computeJobExecutionBypassList,
 				}),
 				RequesterConfig: node.NewRequesterConfigWith(node.RequesterConfigParams{
 					JobNegotiationTimeout:              testCase.requesterJobNegotiationTimeout,
@@ -150,7 +153,7 @@ func (suite *DevstackTimeoutSuite) TestRunningTimeout() {
 			errorCount:                          1,
 		},
 		{
-			// no bid will be submitted, so the requester node should timeout
+			// no bid will be submitted, so the requester node should time out
 			name:                                "job_timeout_longer_than_max_running_timeout",
 			computeJobNegotiationTimeout:        10 * time.Second,
 			computeMinJobExecutionTimeout:       1 * time.Nanosecond,
@@ -166,7 +169,7 @@ func (suite *DevstackTimeoutSuite) TestRunningTimeout() {
 			errorCount:                          1,
 		},
 		{
-			// no bid will be submitted, so the requester node should timeout
+			// no bid will be submitted, so the requester node should time out
 			name:                                "job_timeout_less_than_min_running_timeout",
 			computeJobNegotiationTimeout:        10 * time.Second,
 			computeMinJobExecutionTimeout:       5 * time.Minute,
@@ -180,6 +183,37 @@ func (suite *DevstackTimeoutSuite) TestRunningTimeout() {
 			sleepTime:                           20 * time.Second,
 			jobTimeout:                          2 * time.Minute,
 			errorCount:                          1,
+		},
+		{
+			name:                                "job_timeout_greater_than_max",
+			computeJobNegotiationTimeout:        10 * time.Second,
+			computeMinJobExecutionTimeout:       1 * time.Nanosecond,
+			computeMaxJobExecutionTimeout:       1 * time.Minute,
+			requesterJobNegotiationTimeout:      10 * time.Second,
+			requesterDefaultJobExecutionTimeout: 40 * time.Second,
+			requesterMinJobExecutionTimeout:     1 * time.Nanosecond,
+			nodeCount:                           1,
+			minBids:                             1,
+			concurrency:                         1,
+			sleepTime:                           1 * time.Second,
+			jobTimeout:                          2 * time.Minute,
+			errorCount:                          1,
+		},
+		{
+			name:                                "job_timeout_greater_than_max_but_on_allowed_list",
+			computeJobExecutionBypassList:       []string{system.GetClientID()},
+			computeJobNegotiationTimeout:        10 * time.Second,
+			computeMinJobExecutionTimeout:       1 * time.Nanosecond,
+			computeMaxJobExecutionTimeout:       1 * time.Minute,
+			requesterJobNegotiationTimeout:      10 * time.Second,
+			requesterDefaultJobExecutionTimeout: 40 * time.Second,
+			requesterMinJobExecutionTimeout:     1 * time.Nanosecond,
+			nodeCount:                           1,
+			minBids:                             1,
+			concurrency:                         1,
+			sleepTime:                           1 * time.Second,
+			jobTimeout:                          2 * time.Minute,
+			completedCount:                      1,
 		},
 	} {
 		suite.Run(testCase.name, func() {


### PR DESCRIPTION
Certain workloads may not fit within the one-hour time limit currently imposed on all jobs, but someone running a Bacalhau node may wish to trust certain users with running longer jobs - such as processing BOINC tasks. This change allows a node to be configured so certain client IDs bypass the timeout check, allowing them to be whatever length they need to be.

Fixes #1659