### PR TITLE
Stop Bacalhau from crashing when Docker times out

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -276,7 +276,7 @@ devstack:
 
 .PHONY: devstack-one
 devstack-one:
-	IGNORE_PORT_FILES=true PREDICTABLE_API_PORT=1 go run . devstack --requester-nodes 0 --compute-nodes 0 --hybrid-nodes 1
+	IGNORE_PID_AND_PORT_FILES=true PREDICTABLE_API_PORT=1 go run . devstack --requester-nodes 0 --compute-nodes 0 --hybrid-nodes 1
 
 .PHONY: devstack-100
 devstack-100:

--- a/pkg/executor/docker/network.go
+++ b/pkg/executor/docker/network.go
@@ -106,7 +106,7 @@ func (e *Executor) createHTTPGateway(
 		Scope:      "local",
 		Internal:   true,
 		Attachable: true,
-		Labels:     e.jobContainerLabels(&shard),
+		Labels:     e.jobContainerLabels(shard),
 	})
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "error creating network")
@@ -135,7 +135,7 @@ func (e *Executor) createHTTPGateway(
 		},
 		Healthcheck:     &container.HealthConfig{}, //TODO
 		NetworkDisabled: false,
-		Labels:          e.jobContainerLabels(&shard),
+		Labels:          e.jobContainerLabels(shard),
 	}, &container.HostConfig{
 		NetworkMode: dockerNetworkBridge,
 		CapAdd:      gatewayCapabilities,

--- a/pkg/executor/results.go
+++ b/pkg/executor/results.go
@@ -11,6 +11,7 @@ import (
 	"github.com/filecoin-project/bacalhau/pkg/ipfs"
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/filecoin-project/bacalhau/pkg/system"
+	"github.com/filecoin-project/bacalhau/pkg/util/closer"
 	"go.ptx.dk/multierrgroup"
 	"go.uber.org/multierr"
 )
@@ -49,7 +50,7 @@ func writeOutputResult(resultsDir string, output outputResult) error {
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	defer closer.CloseWithLogOnError("file", file)
 
 	// First write the bytes we have already read, and then write whatever
 	// is left in the buffer, but only up to the maximum file limit.
@@ -67,7 +68,7 @@ func writeOutputResult(resultsDir string, output outputResult) error {
 	return nil
 }
 
-// WriteJobResult produces files and a model.RunCommandResult in the standard
+// WriteJobResults produces files and a model.RunCommandResult in the standard
 // format, including truncating the contents of both where necessary to fit
 // within system-defined limits.
 //


### PR DESCRIPTION
Bacalhau was panicking when a Docker job reached the `timeout` value, as the container's logs couldn't be fetched with a cancelled context.

Fixes #1694