### PR TITLE
Avoid timeouts so large they become negative

### DIFF
--- a/pkg/compute/bidstrategy/timeout_strategy.go
+++ b/pkg/compute/bidstrategy/timeout_strategy.go
@@ -3,6 +3,8 @@ package bidstrategy
 import (
 	"context"
 	"fmt"
+	"math"
+	"strconv"
 	"time"
 
 	"github.com/filecoin-project/bacalhau/pkg/model"
@@ -30,15 +32,26 @@ func NewTimeoutStrategy(params TimeoutStrategyParams) *TimeoutStrategy {
 }
 
 func (s *TimeoutStrategy) ShouldBid(_ context.Context, request BidStrategyRequest) (BidStrategyResponse, error) {
+	if request.Job.Spec.Timeout <= 0 {
+		return newShouldBidResponse(), nil
+	}
+
+	// Timeout will be multiplied by 1000000000 (time.Second) when it gets converted to a time.Duration (which is an int64 underneath),
+	// so make sure that iit can fit into it.
+	if request.Job.Spec.Timeout > float64(math.MaxInt64/int64(time.Second)) {
+		timeout := strconv.FormatFloat(request.Job.Spec.Timeout, 'f', -1, sixtyFourBitFloat)
+		return BidStrategyResponse{
+			ShouldBid: false,
+			Reason:    fmt.Sprintf("job timeout %s exceeds maximum possible value", timeout),
+		}, nil
+	}
+
 	for _, clientID := range s.jobExecutionTimeoutClientIDBypassList {
 		if request.Job.Metadata.ClientID == clientID {
 			return newShouldBidResponse(), nil
 		}
 	}
 
-	if request.Job.Spec.Timeout <= 0 {
-		return newShouldBidResponse(), nil
-	}
 	// skip bidding if the job spec defined a timeout value higher or lower than what we are willing to accept
 	if s.maxJobExecutionTimeout > 0 && request.Job.Spec.GetTimeout() > s.maxJobExecutionTimeout {
 		return BidStrategyResponse{
@@ -55,7 +68,8 @@ func (s *TimeoutStrategy) ShouldBid(_ context.Context, request BidStrategyReques
 	return newShouldBidResponse(), nil
 }
 
-func (s *TimeoutStrategy) ShouldBidBasedOnUsage(
-	_ context.Context, _ BidStrategyRequest, _ model.ResourceUsageData) (BidStrategyResponse, error) {
+func (s *TimeoutStrategy) ShouldBidBasedOnUsage(context.Context, BidStrategyRequest, model.ResourceUsageData) (BidStrategyResponse, error) {
 	return newShouldBidResponse(), nil
 }
+
+const sixtyFourBitFloat = 64

--- a/pkg/compute/bidstrategy/timeout_strategy_test.go
+++ b/pkg/compute/bidstrategy/timeout_strategy_test.go
@@ -1,0 +1,61 @@
+package bidstrategy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/filecoin-project/bacalhau/pkg/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTimeoutStrategy(t *testing.T) {
+	tests := []struct {
+		name      string
+		params    TimeoutStrategyParams
+		request   BidStrategyRequest
+		shouldBid bool
+		reason    string
+	}{
+		{
+			name: "timeout-too-large",
+			params: TimeoutStrategyParams{
+				JobExecutionTimeoutClientIDBypassList: []string{"client"},
+			},
+			request: BidStrategyRequest{
+				Job: model.Job{
+					Metadata: model.Metadata{ClientID: "client"},
+					Spec:     model.Spec{Timeout: 9223372036.1},
+				},
+			},
+			shouldBid: false,
+			reason:    "job timeout 9223372036.1 exceeds maximum possible value",
+		},
+		{
+			name: "client-skip-list",
+			params: TimeoutStrategyParams{
+				JobExecutionTimeoutClientIDBypassList: []string{"client"},
+			},
+			request: BidStrategyRequest{
+				Job: model.Job{
+					Metadata: model.Metadata{ClientID: "client"},
+					Spec:     model.Spec{Timeout: 9223372036},
+				},
+			},
+			shouldBid: true,
+			reason:    "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			subject := NewTimeoutStrategy(test.params)
+
+			response, err := subject.ShouldBid(context.Background(), test.request)
+			require.NoError(t, err)
+
+			assert.Equal(t, test.shouldBid, response.ShouldBid)
+			assert.Equal(t, test.reason, response.Reason)
+		})
+	}
+}


### PR DESCRIPTION
Ensure that timeouts are small enough to fit into a `time.Duration`