### PR TITLE
Stop Gateway container from spamming the logs

### DIFF
--- a/pkg/executor/docker/gateway/Dockerfile
+++ b/pkg/executor/docker/gateway/Dockerfile
@@ -30,10 +30,12 @@
 # configure iptables and traffic control.
 
 FROM ubuntu:22.04
-RUN apt update && apt install -y squid iptables iproute2 jq
+RUN apt update && apt install -y squid iptables iproute2 jq curl \
+    && rm -rf /var/lib/apt/lists/*
 
 ADD squid.conf /etc/squid/conf.d/
-ADD gateway.sh /bin
+ADD gateway.sh /usr/local/bin
+ADD health_check.sh /usr/local/bin
 
-CMD ["sh", "/bin/gateway.sh"]
-HEALTHCHECK --interval=1s --start-period=5s CMD ["bash", "-c", ": &>/dev/null </dev/tcp/127.0.0.1/8080"]
+CMD ["bash", "/usr/local/bin/gateway.sh"]
+HEALTHCHECK --interval=1s --start-period=5s CMD ["bash", "/usr/local/bin/health_check.sh" ]

--- a/pkg/executor/docker/gateway/gateway.sh
+++ b/pkg/executor/docker/gateway/gateway.sh
@@ -1,10 +1,20 @@
-#!/bin/sh
-set -eux
+#!/usr/bin/env bash
+
+# Exit on error. Append || true if you expect an error.
+set -o errexit
+# Exit on error inside any functions or subshells.
+set -o errtrace
+# Do not allow use of undefined vars. Use ${VAR:-} to use an undefined VAR
+set -o nounset
+# Catch the error in case mysqldump fails (but gzip succeeds) in `mysqldump |gzip`
+set -o pipefail
+# Turn on traces, useful while debugging but commented out by default
+#set -o xtrace
 
 # Write out our supplied config to disk.
 mkdir -p /etc/bacalhau
-echo $BACALHAU_HTTP_CLIENTS | jq -r '.[]' > /etc/bacalhau/allowed-clients.txt
-echo $BACALHAU_HTTP_DOMAINS | jq -r '.[]' > /etc/bacalhau/allowed-domains.txt
+echo "${BACALHAU_HTTP_CLIENTS}" | jq -r '.[]' > /etc/bacalhau/allowed-clients.txt
+echo "${BACALHAU_HTTP_DOMAINS}" | jq -r '.[]' > /etc/bacalhau/allowed-domains.txt
 
 # Don't forward any packets... otherwise our proxy can be bypassed.
 iptables -P FORWARD DROP
@@ -14,20 +24,24 @@ iptables -P FORWARD DROP
 iptables -P INPUT DROP
 iptables -A INPUT -i lo -j ACCEPT
 iptables -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
-for BRIDGE_SUBNET in $(cat /etc/bacalhau/allowed-clients.txt); do
-    iptables -A INPUT -p tcp --src $BRIDGE_SUBNET --dport 8080 -j ACCEPT
-done
+
+while IFS= read -r BRIDGE_SUBNET; do
+    iptables -A INPUT -p tcp --src "${BRIDGE_SUBNET}" --dport 8080 -j ACCEPT
+done < <(cat /etc/bacalhau/allowed-clients.txt)
 
 # Apply rate limits to the outbound connections. We just do this for all
 # interfaces rather than working out which is our Internet connection.
-for IFACE in $(ip --json address show | jq -rc '.[] | .ifname'); do
-    tc qdisc add dev $IFACE root tbf rate 10mbit burst 32kbit latency 10sec
-done
+while IFS= read -r IFACE; do
+    tc qdisc add dev "${IFACE}" root tbf rate 10mbit burst 32kbit latency 10sec
+done < <(ip --json address show | jq -rc '.[] | .ifname')
 
 # Add Bacalhau job ID to outgoing requests. We can use this to detect jobs
 # trying to spawn other jobs.
 echo request_header_access X-Bacalhau-Job-ID deny all > /etc/squid/conf.d/bac-job.conf
-echo request_header_add X-Bacalhau-Job-ID "$BACALHAU_JOB_ID" all >> /etc/squid/conf.d/bac-job.conf
+echo request_header_add X-Bacalhau-Job-ID "${BACALHAU_JOB_ID}" all >> /etc/squid/conf.d/bac-job.conf
+
+# Make sure the access log is present for us to tail at the end, even if squid hasn't logged anything yet
+touch /var/log/squid/access.log
 
 # Now that everything is configured, run Squid.
 squid -d2

--- a/pkg/executor/docker/gateway/health_check.sh
+++ b/pkg/executor/docker/gateway/health_check.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Exit on error. Append || true if you expect an error.
+set -o errexit
+# Exit on error inside any functions or subshells.
+set -o errtrace
+# Do not allow use of undefined vars. Use ${VAR:-} to use an undefined VAR
+set -o nounset
+# Catch the error in case mysqldump fails (but gzip succeeds) in `mysqldump |gzip`
+set -o pipefail
+# Turn on traces, useful while debugging but commented out by default
+#set -o xtrace
+
+[ "$(curl --max-time 1 --output /dev/null --silent --header 'Docker-Health-Check: true' localhost:8080 --write-out '%{http_code}')" == "400" ]

--- a/pkg/executor/docker/gateway/squid.conf
+++ b/pkg/executor/docker/gateway/squid.conf
@@ -28,3 +28,7 @@ http_access deny all
 
 # Run the HTTP proxy on port:
 http_port 8080
+
+# Don't log Docker health checks
+acl exclude req_header Docker-Health-Check .*
+access_log none exclude


### PR DESCRIPTION
Change the health check on the network gateway container so that Squid doesn't spam the logs with `DEBUG` statements like `0 127.0.0.1 NONE_NONE/000 0 - error:transaction-end-before-headers`.

Also remove the APT lists to reduce image size, fix things that shellcheck spotted, and turn off debug logging in the script.

Fixes #1691