### PR TITLE
publish job events async

### DIFF
--- a/pkg/node/requester.go
+++ b/pkg/node/requester.go
@@ -189,8 +189,8 @@ func NewRequesterNode(
 
 	bufferedJobEventPubSub := pubsub.NewBufferingPubSub[model.JobEvent](pubsub.BufferingPubSubParams{
 		DelegatePubSub: libp2p2JobEventPubSub,
-		MaxBufferSize:  32 * 1024,           //nolint:gomnd
-		MaxBufferAge:   1 * time.Nanosecond, // increase this once we move to an external job storage
+		MaxBufferSize:  1, //nolint:gomnd // increase this once we move to an external job storage
+		MaxBufferAge:   1 * time.Minute,
 	})
 
 	// Register event handlers


### PR DESCRIPTION
Publishing of job events were happing synchronously as I was seeing an increase in events arriving out of order as the network size increases. However, I was seeing that the lock to publish events sometimes was held for hundreds of milliseconds (100-300ms), and that was happening in the go routine that is orchestrating the job. 

For now, I've made publishing to be async as it should be acceptable in the network size we currently have, and opened an issue for a better future fix #1740 