### PR TITLE
feat(docker): add bacalhau Docker container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -413,7 +413,6 @@ jobs:
           name: Update dashboard
           command: |
             heroku run build --app bacalhau-dashboards
-
   release:
     executor: linux-amd64
     steps:
@@ -616,6 +615,20 @@ jobs:
                 -d '{"event_type":"build-schema-pages"}'
             fi
 
+  docker:
+    executor: linux-amd64
+    steps:
+      - checkout
+      - run:
+          name: Login to GHCR
+          command: |
+            echo $GHCR_PAT | docker login ghcr.io -u circleci --password-stdin
+      - run:
+          name: Push application Docker image
+          command: |
+            docker context create buildx-build
+            docker buildx create --use buildx-build
+            make push-bacalhau-image
 
 orbs:
   heroku: circleci/heroku@1.2.6
@@ -793,6 +806,9 @@ workflows:
           name: update-terraform-files
           requires:
             - release-all-binaries
+          filters:
+            <<: *filters_tags_only
+      - docker:
           filters:
             <<: *filters_tags_only
 

--- a/.dockerignore
+++ b/.dockerignore
@@ -17,7 +17,6 @@
 **/.vscode
 **/vendor/*
 **/bin/*
-**//bacalhau
 **/.venv
 **/temperature_sensor_data.csv
 **/temperature_sensor_data.csv.bz2
@@ -46,3 +45,4 @@
 **/job-*
 **/coverage/
 **/coverage.out
+**/Dockerfile

--- a/Makefile
+++ b/Makefile
@@ -164,8 +164,32 @@ build-http-gateway-image:
 		-t ${HTTP_GATEWAY_IMAGE}:${HTTP_GATEWAY_TAG} \
 		pkg/executor/docker/gateway
 
+BACALHAU_IMAGE ?= ghcr.io/bacalhau-project/bacalhau
+BACALHAU_TAG ?= ${TAG}
+.PHONY: build-bacalhau-image
+build-bacalhau-image:
+	docker build --progress=plain \
+		--tag ${BACALHAU_IMAGE}:latest \
+		--file docker/bacalhau-image/Dockerfile \
+		.
+
+.PHONY: push-bacalhau-image
+push-bacalhau-image:
+	docker buildx build --push --progress=plain \
+		--platform linux/amd64,linux/arm64 \
+		--tag ${BACALHAU_IMAGE}:${BACALHAU_TAG} \
+		--tag ${BACALHAU_IMAGE}:latest \
+		--label org.opencontainers.artifact.created=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ") \
+		--label org.opencontainers.image.version=${BACALHAU_TAG} \
+		--cache-from=type=registry,ref=${BACALHAU_IMAGE}:latest \
+		--file docker/bacalhau-image/Dockerfile \
+		.
+
 .PHONY: build-docker-images
 build-docker-images: build-http-gateway-image
+
+.PHONY: push-docker-images
+push-docker-images: build-http-gateway-image
 
 # Release tarballs suitable for upload to GitHub release pages
 ################################################################################

--- a/docker/bacalhau-image/Dockerfile
+++ b/docker/bacalhau-image/Dockerfile
@@ -1,0 +1,17 @@
+# syntax=docker/dockerfile:1.4
+FROM cgr.dev/chainguard/go:1.19 as build
+WORKDIR /work
+COPY Makefile .
+COPY go.mod .
+COPY . .
+RUN make build-bacalhau
+RUN find ./bin -name 'bacalhau' -exec mv -t ./bin {} +
+
+FROM cgr.dev/chainguard/static:latest
+COPY --from=build /work/bin/bacalhau /bacalhau
+ENTRYPOINT ["/bacalhau"]
+LABEL org.opencontainers.image.source https://github.com/filecoin-project/bacalhau
+LABEL org.opencontainers.image.title "Bacalhau"
+LABEL org.opencontainers.image.description "The Bacalhau network provices decentralised compute for compute over data. See https://bacalhau.org for more info."
+LABEL org.opencontainers.image.licenses Apache-2.0
+LABEL org.opencontainers.image.url https://bacalhau.org

--- a/docker/bacalhau-image/README.md
+++ b/docker/bacalhau-image/README.md
@@ -1,0 +1,19 @@
+# Bacalhau Docker Image
+
+This directory contains a Dockerfile script to build a Docker image containing the Bacalhau binary.
+
+## Usage
+
+You can find detailed information about the Bacalhau command on the [Bacalhau documentation website](https://docs.bacalhau.org/).
+
+### Development Node
+
+You can run a small Bacalhau cluster by running the `devstack` subcommand. This runs an in-memory IPFS node and several local Bacalhau nodes. This is useful for testing and development. See the [the `docs/running_locally.md` documentation](../../docs/running_locally.md) for more information.
+
+```
+docker run --env IGNORE_PID_AND_PORT_FILES=true --env PREDICTABLE_API_PORT=1 --publish 20000:20000 ghcr.io/bacalhau-project/bacalhau:latest devstack
+```
+
+### Production Node
+
+Follow the instructions on the [Bacalhau documentation website](https://docs.bacalhau.org/running-node/quick-start) to run a Bacalhau node in production.


### PR DESCRIPTION
This PR allows you to run Bacalhau from a Docker container. For example:

```
docker run -it ghcr.io/bacalhau-project/bacalhau:latest docker run --wait --input-urls=https://bacalhau.org/index.html ghcr.io/bacalhau-project/examples/upload:v1
```

* Images will be built and push upon any new tag.
* I back-ported the dockerfile and makefile to build a 3.16 image. 
* I'll update the docs once this has merged.