### PR TITLE
+x apply-http-allowlist.sh

### DIFF
--- a/ops/terraform/main.tf
+++ b/ops/terraform/main.tf
@@ -94,6 +94,7 @@ EOI
 sudo tee /terraform_node/apply-http-allowlist.sh > /dev/null <<'EOI'
 ${file("${path.module}/remote_files/scripts/apply-http-allowlist.sh")}
 EOI
+chmod +x /terraform_node/apply-http-allowlist.sh
 
 sudo tee /terraform_node/http-domain-allowlist.txt > /dev/null <<'EOI'
 ${file("${path.module}/remote_files/scripts/http-domain-allowlist.txt")}

--- a/ops/terraform/remote_files/scripts/start-bacalhau.sh
+++ b/ops/terraform/remote_files/scripts/start-bacalhau.sh
@@ -54,7 +54,6 @@ if [[ "${TERRAFORM_NODE_INDEX}" != "0" ]]; then
 fi
 
 BACALHAU_PROBE_EXEC='/terraform_node/apply-http-allowlist.sh'
-chmod +x "$BACALHAU_PROBE_EXEC"
 
 bacalhau serve \
   --node-type requester,compute \

--- a/ops/terraform/remote_files/scripts/start-bacalhau.sh
+++ b/ops/terraform/remote_files/scripts/start-bacalhau.sh
@@ -54,6 +54,7 @@ if [[ "${TERRAFORM_NODE_INDEX}" != "0" ]]; then
 fi
 
 BACALHAU_PROBE_EXEC='/terraform_node/apply-http-allowlist.sh'
+chmod +x "$BACALHAU_PROBE_EXEC"
 
 bacalhau serve \
   --node-type requester,compute \


### PR DESCRIPTION
`apply-http-allowlist.sh` was deployed without execute permission, which resulted in compute nodes rejecting all bids. Updating install script to explicitly grant execute permission 