### PR TITLE
canary pipeline integration test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,6 +237,11 @@ jobs:
       - checkout
 
       - run:
+          name: Set canary dependency
+          working_directory: ops/aws/canary/lambda
+          command: make update
+
+      - run:
           name: Build
           working_directory: ops/aws/canary/lambda
           command: make build -j
@@ -248,7 +253,7 @@ jobs:
             export GOBIN=${HOME}/bin
             export PATH=$GOBIN:$PATH
             go install gotest.tools/gotestsum@v1.8.2
-            make integration-test
+            make test
 
       - store_test_results:
           path: ops/aws/canary/lambda/tests.xml


### PR DESCRIPTION
A new integration test stage has been added to canary pipeline that verifies that latest commit is compatible with production endpoint before deploying a new version of the canary. This change also enables `check-canary` cricle-ci workflow to test locally against the latest commit instead of against production endpoint.