### PR TITLE
Update HTTP gateway image to the latest version

### DIFF
--- a/pkg/executor/docker/network.go
+++ b/pkg/executor/docker/network.go
@@ -28,7 +28,7 @@ const (
 	// pkg/executor/docker/gateway/Dockerfile for design notes. We specify this
 	// using a fully-versioned tag so that the interface between code and image
 	// stay in sync.
-	httpGatewayImage = "ghcr.io/bacalhau-project/http-gateway:v0.3.15-58-g438e22e3"
+	httpGatewayImage = "ghcr.io/bacalhau-project/http-gateway:v0.3.17"
 
 	// The hostname used by Mac OS X and Windows hosts to refer to the Docker
 	// host in a network context. Linux hosts can use this hostname if they


### PR DESCRIPTION
New image includes tweaks to remove DEBUG log spam