### PR TITLE
Stop TestDockerNetworkingAppendsHTTPHeader flaking

### DIFF
--- a/pkg/executor/results.go
+++ b/pkg/executor/results.go
@@ -32,6 +32,9 @@ func writeOutputResult(resultsDir string, output outputResult) error {
 	// write that directly to disk rather than needing to hold it all in memory.
 	summary := make([]byte, output.summaryLimit+1)
 	summaryRead, err := output.contents.Read(summary)
+	if err != nil && err != io.EOF {
+		return err
+	}
 
 	available := system.Min(summaryRead, int(output.summaryLimit))
 


### PR DESCRIPTION
Attempting to stream the logs while the container is running has a habit of missing the end of the logs, so we have to fetch the logs _after_ the container has possibly finished. As the existing context may have already timed out, we have to use a detached context that ignores the existing context's errors to fetch the logs.

Fixes #1729
Fixes #1730