### PR TITLE
Check storage and publishers before bidding on job

### DIFF
--- a/pkg/compute/bidstrategy/engines_installed_strategy.go
+++ b/pkg/compute/bidstrategy/engines_installed_strategy.go
@@ -6,28 +6,45 @@ import (
 
 	"github.com/filecoin-project/bacalhau/pkg/executor"
 	"github.com/filecoin-project/bacalhau/pkg/model"
+	"github.com/filecoin-project/bacalhau/pkg/publisher"
+	"github.com/filecoin-project/bacalhau/pkg/storage"
 	"github.com/filecoin-project/bacalhau/pkg/verifier"
 )
 
 type EnginesInstalledStrategyParams struct {
-	Executors executor.ExecutorProvider
-	Verifiers verifier.VerifierProvider
+	Storages   storage.StorageProvider
+	Executors  executor.ExecutorProvider
+	Verifiers  verifier.VerifierProvider
+	Publishers publisher.PublisherProvider
 }
 
 type EnginesInstalledStrategy struct {
-	executors executor.ExecutorProvider
-	verifiers verifier.VerifierProvider
+	storages   storage.StorageProvider
+	executors  executor.ExecutorProvider
+	verifiers  verifier.VerifierProvider
+	publishers publisher.PublisherProvider
 }
 
 func NewEnginesInstalledStrategy(params EnginesInstalledStrategyParams) *EnginesInstalledStrategy {
 	return &EnginesInstalledStrategy{
-		executors: params.Executors,
-		verifiers: params.Verifiers,
+		storages:   params.Storages,
+		executors:  params.Executors,
+		verifiers:  params.Verifiers,
+		publishers: params.Publishers,
 	}
 }
 
 func (s *EnginesInstalledStrategy) ShouldBid(ctx context.Context, request BidStrategyRequest) (BidStrategyResponse, error) {
 	// skip bidding if we don't have the executor and verifier for the job spec
+	for _, input := range request.Job.Spec.Inputs {
+		if !s.storages.HasStorage(ctx, input.StorageSource) {
+			return BidStrategyResponse{
+				ShouldBid: false,
+				Reason:    fmt.Sprintf("storage %s not installed", input.StorageSource),
+			}, nil
+		}
+	}
+
 	if !s.executors.HasExecutor(ctx, request.Job.Spec.Engine) {
 		return BidStrategyResponse{
 			ShouldBid: false,
@@ -39,6 +56,13 @@ func (s *EnginesInstalledStrategy) ShouldBid(ctx context.Context, request BidStr
 		return BidStrategyResponse{
 			ShouldBid: false,
 			Reason:    fmt.Sprintf("verifier %s not installed", request.Job.Spec.Verifier),
+		}, nil
+	}
+
+	if !s.publishers.HasPublisher(ctx, request.Job.Spec.Publisher) {
+		return BidStrategyResponse{
+			ShouldBid: false,
+			Reason:    fmt.Sprintf("publisher %s not installed", request.Job.Spec.Publisher),
 		}, nil
 	}
 

--- a/pkg/compute/bidstrategy/engines_installed_strategy_test.go
+++ b/pkg/compute/bidstrategy/engines_installed_strategy_test.go
@@ -1,0 +1,241 @@
+//go:build unit || !integration
+
+package bidstrategy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/filecoin-project/bacalhau/pkg/executor"
+	"github.com/filecoin-project/bacalhau/pkg/model"
+	"github.com/filecoin-project/bacalhau/pkg/publisher"
+	"github.com/filecoin-project/bacalhau/pkg/storage"
+	"github.com/filecoin-project/bacalhau/pkg/verifier"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnginesInstalledStrategy(t *testing.T) {
+	tests := []struct {
+		name       string
+		storages   dummyStorageProvider
+		executors  dummyExecutorProvider
+		verifiers  dummyVerifierProvider
+		publishers dummyPublisherProvider
+		bid        BidStrategyRequest
+		shouldBid  bool
+	}{
+		{
+			name:       "no-storage",
+			storages:   map[model.StorageSourceType]struct{}{model.StorageSourceURLDownload: {}},
+			executors:  map[model.Engine]struct{}{model.EngineDocker: {}},
+			verifiers:  map[model.Verifier]struct{}{model.VerifierNoop: {}},
+			publishers: map[model.Publisher]struct{}{model.PublisherEstuary: {}},
+			bid: BidStrategyRequest{
+				Job: model.Job{
+					Spec: model.Spec{
+						Inputs:    []model.StorageSpec{},
+						Engine:    model.EngineDocker,
+						Verifier:  model.VerifierNoop,
+						Publisher: model.PublisherEstuary,
+					},
+				},
+			},
+			shouldBid: true,
+		},
+		{
+			name:       "invalid-storage",
+			storages:   map[model.StorageSourceType]struct{}{model.StorageSourceURLDownload: {}},
+			executors:  map[model.Engine]struct{}{model.EngineDocker: {}},
+			verifiers:  map[model.Verifier]struct{}{model.VerifierNoop: {}},
+			publishers: map[model.Publisher]struct{}{model.PublisherEstuary: {}},
+			bid: BidStrategyRequest{
+				Job: model.Job{
+					Spec: model.Spec{
+						Inputs: []model.StorageSpec{
+							{
+								StorageSource: model.StorageSourceIPFS,
+							},
+						},
+						Engine:    model.EngineDocker,
+						Verifier:  model.VerifierNoop,
+						Publisher: model.PublisherEstuary,
+					},
+				},
+			},
+			shouldBid: false,
+		},
+		{
+			name:       "invalid-executor",
+			storages:   map[model.StorageSourceType]struct{}{model.StorageSourceInline: {}},
+			executors:  map[model.Engine]struct{}{model.EngineWasm: {}},
+			verifiers:  map[model.Verifier]struct{}{model.VerifierDeterministic: {}},
+			publishers: map[model.Publisher]struct{}{model.PublisherEstuary: {}},
+			bid: BidStrategyRequest{
+				Job: model.Job{
+					Spec: model.Spec{
+						Inputs: []model.StorageSpec{
+							{
+								StorageSource: model.StorageSourceInline,
+							},
+						},
+						Engine:    model.EngineDocker,
+						Verifier:  model.VerifierDeterministic,
+						Publisher: model.PublisherEstuary,
+					},
+				},
+			},
+			shouldBid: false,
+		},
+		{
+			name:       "invalid-verifier",
+			storages:   map[model.StorageSourceType]struct{}{model.StorageSourceURLDownload: {}},
+			executors:  map[model.Engine]struct{}{model.EngineDocker: {}},
+			verifiers:  map[model.Verifier]struct{}{model.VerifierNoop: {}},
+			publishers: map[model.Publisher]struct{}{model.PublisherEstuary: {}},
+			bid: BidStrategyRequest{
+				Job: model.Job{
+					Spec: model.Spec{
+						Inputs: []model.StorageSpec{
+							{
+								StorageSource: model.StorageSourceURLDownload,
+							},
+						},
+						Engine:    model.EngineDocker,
+						Verifier:  model.VerifierDeterministic,
+						Publisher: model.PublisherEstuary,
+					},
+				},
+			},
+			shouldBid: false,
+		},
+		{
+			name:       "invalid-publisher",
+			storages:   map[model.StorageSourceType]struct{}{model.StorageSourceFilecoin: {}},
+			executors:  map[model.Engine]struct{}{model.EngineDocker: {}},
+			verifiers:  map[model.Verifier]struct{}{model.VerifierNoop: {}},
+			publishers: map[model.Publisher]struct{}{model.PublisherFilecoin: {}},
+			bid: BidStrategyRequest{
+				Job: model.Job{
+					Spec: model.Spec{
+						Inputs: []model.StorageSpec{
+							{
+								StorageSource: model.StorageSourceFilecoin,
+							},
+						},
+						Engine:    model.EngineDocker,
+						Verifier:  model.VerifierNoop,
+						Publisher: model.PublisherEstuary,
+					},
+				},
+			},
+			shouldBid: false,
+		},
+		{
+			name:       "valid-request",
+			storages:   map[model.StorageSourceType]struct{}{model.StorageSourceInline: {}},
+			executors:  map[model.Engine]struct{}{model.EngineWasm: {}},
+			verifiers:  map[model.Verifier]struct{}{model.VerifierDeterministic: {}},
+			publishers: map[model.Publisher]struct{}{model.PublisherIpfs: {}},
+			bid: BidStrategyRequest{
+				Job: model.Job{
+					Spec: model.Spec{
+						Inputs: []model.StorageSpec{
+							{
+								StorageSource: model.StorageSourceInline,
+							},
+						},
+						Engine:    model.EngineWasm,
+						Verifier:  model.VerifierDeterministic,
+						Publisher: model.PublisherIpfs,
+					},
+				},
+			},
+			shouldBid: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			subject := NewEnginesInstalledStrategy(EnginesInstalledStrategyParams{
+				Storages:   test.storages,
+				Executors:  test.executors,
+				Verifiers:  test.verifiers,
+				Publishers: test.publishers,
+			})
+
+			actual, err := subject.ShouldBid(context.Background(), test.bid)
+			require.NoError(t, err)
+
+			assert.Equal(t, test.shouldBid, actual.ShouldBid, actual.Reason)
+		})
+	}
+}
+
+var _ storage.StorageProvider = dummyStorageProvider{}
+
+type dummyStorageProvider map[model.StorageSourceType]struct{}
+
+func (d dummyStorageProvider) GetStorage(context.Context, model.StorageSourceType) (storage.Storage, error) {
+	panic("not implemented")
+}
+
+func (d dummyStorageProvider) HasStorage(_ context.Context, sourceType model.StorageSourceType) bool {
+	if _, ok := d[sourceType]; ok {
+		return true
+	}
+	return false
+}
+
+var _ executor.ExecutorProvider = dummyExecutorProvider{}
+
+type dummyExecutorProvider map[model.Engine]struct{}
+
+func (d dummyExecutorProvider) AddExecutor(context.Context, model.Engine, executor.Executor) error {
+	panic("not implemented")
+
+}
+
+func (d dummyExecutorProvider) GetExecutor(context.Context, model.Engine) (executor.Executor, error) {
+	panic("not implemented")
+
+}
+
+func (d dummyExecutorProvider) HasExecutor(_ context.Context, engineType model.Engine) bool {
+	if _, ok := d[engineType]; ok {
+		return true
+	}
+	return false
+}
+
+var _ verifier.VerifierProvider = dummyVerifierProvider{}
+
+type dummyVerifierProvider map[model.Verifier]struct{}
+
+func (d dummyVerifierProvider) GetVerifier(context.Context, model.Verifier) (verifier.Verifier, error) {
+	panic("not implemented")
+
+}
+
+func (d dummyVerifierProvider) HasVerifier(_ context.Context, job model.Verifier) bool {
+	if _, ok := d[job]; ok {
+		return true
+	}
+	return false
+}
+
+var _ publisher.PublisherProvider = dummyPublisherProvider{}
+
+type dummyPublisherProvider map[model.Publisher]struct{}
+
+func (d dummyPublisherProvider) GetPublisher(context.Context, model.Publisher) (publisher.Publisher, error) {
+	panic("not implemented")
+
+}
+
+func (d dummyPublisherProvider) HasPublisher(_ context.Context, publisher model.Publisher) bool {
+	if _, ok := d[publisher]; ok {
+		return true
+	}
+	return false
+}

--- a/pkg/compute/bidstrategy/export_test.go
+++ b/pkg/compute/bidstrategy/export_test.go
@@ -1,3 +1,5 @@
+//go:build unit || !integration
+
 package bidstrategy
 
 import "github.com/filecoin-project/bacalhau/pkg/model"

--- a/pkg/compute/bidstrategy/networking_allowlist_test.go
+++ b/pkg/compute/bidstrategy/networking_allowlist_test.go
@@ -1,3 +1,5 @@
+//go:build unit || !integration
+
 package bidstrategy
 
 import (

--- a/pkg/compute/bidstrategy/networking_strategy_test.go
+++ b/pkg/compute/bidstrategy/networking_strategy_test.go
@@ -1,3 +1,5 @@
+//go:build unit || !integration
+
 package bidstrategy
 
 import (

--- a/pkg/compute/bidstrategy/timeout_strategy_test.go
+++ b/pkg/compute/bidstrategy/timeout_strategy_test.go
@@ -1,3 +1,5 @@
+//go:build unit || !integration
+
 package bidstrategy
 
 import (

--- a/pkg/node/compute.go
+++ b/pkg/node/compute.go
@@ -17,6 +17,7 @@ import (
 	"github.com/filecoin-project/bacalhau/pkg/publisher"
 	"github.com/filecoin-project/bacalhau/pkg/pubsub"
 	"github.com/filecoin-project/bacalhau/pkg/simulator"
+	"github.com/filecoin-project/bacalhau/pkg/storage"
 	"github.com/filecoin-project/bacalhau/pkg/system"
 	"github.com/filecoin-project/bacalhau/pkg/transport/bprotocol"
 	simulator_protocol "github.com/filecoin-project/bacalhau/pkg/transport/simulator"
@@ -44,6 +45,7 @@ func NewComputeNode(
 	config ComputeConfig,
 	simulatorNodeID string,
 	simulatorRequestHandler *simulator.RequestHandler,
+	storages storage.StorageProvider,
 	executors executor.ExecutorProvider,
 	verifiers verifier.VerifierProvider,
 	publishers publisher.PublisherProvider,
@@ -143,8 +145,10 @@ func NewComputeNode(
 			NetworkSize: 1,
 		}),
 		bidstrategy.NewEnginesInstalledStrategy(bidstrategy.EnginesInstalledStrategyParams{
-			Executors: executors,
-			Verifiers: verifiers,
+			Storages:   storages,
+			Executors:  executors,
+			Verifiers:  verifiers,
+			Publishers: publishers,
 		}),
 		bidstrategy.NewExternalCommandStrategy(bidstrategy.ExternalCommandStrategyParams{
 			Command: config.JobSelectionPolicy.ProbeExec,

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -196,6 +196,7 @@ func NewNode(
 			config.ComputeConfig,
 			config.SimulatorNodeID,
 			simulatorRequestHandler,
+			storageProviders,
 			executors,
 			verifiers,
 			publishers,

--- a/pkg/publisher/noop/publisher.go
+++ b/pkg/publisher/noop/publisher.go
@@ -8,7 +8,7 @@ import (
 	"github.com/filecoin-project/bacalhau/pkg/system"
 )
 
-// Publisher provider that always return NoopPublisher regardless of requested publisher type
+// NoopPublisherProvider is a publisher provider that always return NoopPublisher regardless of requested publisher type
 type NoopPublisherProvider struct {
 	noopPublisher *NoopPublisher
 }
@@ -19,8 +19,13 @@ func NewNoopPublisherProvider(noopPublisher *NoopPublisher) *NoopPublisherProvid
 	}
 }
 
-func (s *NoopPublisherProvider) GetPublisher(ctx context.Context, publisherType model.Publisher) (publisher.Publisher, error) {
+func (s *NoopPublisherProvider) GetPublisher(context.Context, model.Publisher) (publisher.Publisher, error) {
 	return s.noopPublisher, nil
+}
+
+func (s *NoopPublisherProvider) HasPublisher(ctx context.Context, publisher model.Publisher) bool {
+	_, err := s.GetPublisher(ctx, publisher)
+	return err == nil
 }
 
 type NoopPublisher struct{}
@@ -29,15 +34,15 @@ func NewNoopPublisher() *NoopPublisher {
 	return &NoopPublisher{}
 }
 
-func (publisher *NoopPublisher) IsInstalled(ctx context.Context) (bool, error) {
+func (publisher *NoopPublisher) IsInstalled(context.Context) (bool, error) {
 	return true, nil
 }
 
 func (publisher *NoopPublisher) PublishShardResult(
 	ctx context.Context,
-	shard model.JobShard,
-	hostID string,
-	shardResultPath string,
+	_ model.JobShard,
+	_ string,
+	_ string,
 ) (model.StorageSpec, error) {
 	//nolint:staticcheck,ineffassign
 	ctx, span := system.GetTracer().Start(ctx, "pkg/publisher/noop.PublishShardResult")

--- a/pkg/publisher/publisher_provider.go
+++ b/pkg/publisher/publisher_provider.go
@@ -8,7 +8,7 @@ import (
 	"github.com/filecoin-project/bacalhau/pkg/model"
 )
 
-// A simple publisher repo that selects a publisher based on the job's publisher type.
+// MappedPublisherProvider is a simple publisher repo that selects a publisher based on the job's publisher type.
 type MappedPublisherProvider struct {
 	publishers                    map[model.Publisher]Publisher
 	publishersInstalledCache      map[model.Publisher]bool
@@ -49,4 +49,9 @@ func (p *MappedPublisherProvider) GetPublisher(ctx context.Context, publisherTyp
 	}
 
 	return publisher, nil
+}
+
+func (p *MappedPublisherProvider) HasPublisher(ctx context.Context, publisher model.Publisher) bool {
+	_, err := p.GetPublisher(ctx, publisher)
+	return err == nil
 }

--- a/pkg/publisher/types.go
+++ b/pkg/publisher/types.go
@@ -6,16 +6,17 @@ import (
 	"github.com/filecoin-project/bacalhau/pkg/model"
 )
 
-// Returns a publisher for the given publisher type
+// PublisherProvider returns a publisher for the given publisher type
 type PublisherProvider interface {
 	GetPublisher(ctx context.Context, job model.Publisher) (Publisher, error)
+	HasPublisher(ctx context.Context, publisher model.Publisher) bool
 }
 
 // Publisher is the interface for publishing results of a job
 // The job spec will choose which publisher(s) it wants to use
 // (there can be multiple publishers configured)
 type Publisher interface {
-	// tells you if the required software is installed on this machine
+	// IsInstalled tells you if the required software is installed on this machine
 	IsInstalled(context.Context) (bool, error)
 
 	// compute node

--- a/pkg/storage/noop/noop.go
+++ b/pkg/storage/noop/noop.go
@@ -30,7 +30,7 @@ type StorageConfig struct {
 	ExternalHooks StorageConfigExternalHooks
 }
 
-// Storage provider that always return NoopStorage regardless of requested source type
+// NoopStorageProvider is a storage provider that always return NoopStorage regardless of requested source type
 type NoopStorageProvider struct {
 	noopStorage *NoopStorage
 }
@@ -41,8 +41,13 @@ func NewNoopStorageProvider(noopStorage *NoopStorage) *NoopStorageProvider {
 	}
 }
 
-func (s *NoopStorageProvider) GetStorage(ctx context.Context, storageType model.StorageSourceType) (storage.Storage, error) {
+func (s *NoopStorageProvider) GetStorage(context.Context, model.StorageSourceType) (storage.Storage, error) {
 	return s.noopStorage, nil
+}
+
+func (s *NoopStorageProvider) HasStorage(ctx context.Context, sourceType model.StorageSourceType) bool {
+	_, err := s.GetStorage(ctx, sourceType)
+	return err == nil
 }
 
 // a storage driver runs the downloads content
@@ -54,14 +59,14 @@ type NoopStorage struct {
 	Config StorageConfig
 }
 
-func NewNoopStorage(ctx context.Context, cm *system.CleanupManager, config StorageConfig) (*NoopStorage, error) {
+func NewNoopStorage(_ context.Context, _ *system.CleanupManager, config StorageConfig) (*NoopStorage, error) {
 	storageHandler := &NoopStorage{
 		Config: config,
 	}
 	return storageHandler, nil
 }
 
-func NewNoopStorageWithConfig(ctx context.Context, cm *system.CleanupManager, config StorageConfig) (*NoopStorage, error) {
+func NewNoopStorageWithConfig(_ context.Context, _ *system.CleanupManager, config StorageConfig) (*NoopStorage, error) {
 	storageHandler := &NoopStorage{
 		Config: config,
 	}

--- a/pkg/storage/storage_provider.go
+++ b/pkg/storage/storage_provider.go
@@ -45,3 +45,8 @@ func (p *MappedStorageProvider) GetStorage(ctx context.Context, storageType mode
 
 	return storage, nil
 }
+
+func (p *MappedStorageProvider) HasStorage(ctx context.Context, sourceType model.StorageSourceType) bool {
+	_, err := p.GetStorage(ctx, sourceType)
+	return err == nil
+}

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -6,9 +6,10 @@ import (
 	"github.com/filecoin-project/bacalhau/pkg/model"
 )
 
-// Returns a storage that can be used by the job to store data.
+// StorageProvider returns a storage that can be used by the job to store data.
 type StorageProvider interface {
 	GetStorage(ctx context.Context, storageSourceType model.StorageSourceType) (Storage, error)
+	HasStorage(ctx context.Context, sourceType model.StorageSourceType) bool
 }
 
 type Storage interface {

--- a/pkg/test/compute/setup_test.go
+++ b/pkg/test/compute/setup_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/filecoin-project/bacalhau/pkg/publicapi"
 	noop_publisher "github.com/filecoin-project/bacalhau/pkg/publisher/noop"
 	"github.com/filecoin-project/bacalhau/pkg/pubsub"
+	noop_storage "github.com/filecoin-project/bacalhau/pkg/storage/noop"
 	"github.com/filecoin-project/bacalhau/pkg/system"
 	noop_verifier "github.com/filecoin-project/bacalhau/pkg/verifier/noop"
 	"github.com/phayes/freeport"
@@ -70,6 +71,9 @@ func (s *ComputeSuite) setupNode() {
 	})
 	s.NoError(err)
 
+	storage, err := noop_storage.NewNoopStorage(nil, nil, noop_storage.StorageConfig{})
+	s.Require().NoError(err)
+
 	s.node, err = node.NewComputeNode(
 		context.Background(),
 		s.cm,
@@ -79,6 +83,7 @@ func (s *ComputeSuite) setupNode() {
 		s.config,
 		"",
 		nil,
+		noop_storage.NewNoopStorageProvider(storage),
 		noop_executor.NewNoopExecutorProvider(s.executor),
 		noop_verifier.NewNoopVerifierProvider(s.verifier),
 		noop_publisher.NewNoopPublisherProvider(s.publisher),


### PR DESCRIPTION
Verify that the compute node supports the storage driver and publisher before bidding on a job, like is already done for the compute engine and verifier.

Fixes #570