### PR TITLE
 Add text feedback when user doesnt specify an IMAGE tag/digest [new]

### DIFF
--- a/cmd/bacalhau/docker_run.go
+++ b/cmd/bacalhau/docker_run.go
@@ -25,18 +25,23 @@ var (
 
 	//nolint:lll // Documentation
 	dockerRunExample = templates.Examples(i18n.T(`
-		# Run a Docker job, using the image 'dpokidov/imagemagick', with a CID mounted at /input_images and an output volume mounted at /outputs in the container.
-		# All flags after the '--' are passed directly into the container for execution.
+		# Run a Docker job, using the image 'dpokidov/imagemagick', with a CID mounted at /input_images and an output volume mounted at /outputs in the container. All flags after the '--' are passed directly into the container for execution.
 		bacalhau docker run \
 			-v QmeZRGhe4PmjctYVSVHuEiA9oSXnqmYa4kQubSHgWbjv72:/input_images \
 			dpokidov/imagemagick:7.1.0-47-ubuntu \
 			-- magick mogrify -resize 100x100 -quality 100 -path /outputs '/input_images/*.jpg'
 
-		# Dry Run: Check the job specification before submitting it to the bacalhau network
+		# Dry Run: check the job specification before submitting it to the bacalhau network
 		bacalhau docker run --dry-run ubuntu echo hello
 
-		saving the job specification to a yaml file
+		# Save the job specification to a YAML file
 		bacalhau docker run --dry-run ubuntu echo hello > job.yaml
+
+		# Specify an image tag (default is 'latest' - using a specific tag other than 'latest' is recommended for reproducibility)
+		bacalhau docker run ubuntu:bionic echo hello
+
+		# Specify an image digest
+		bacalhau docker run ubuntu@sha256:35b4f89ec2ee42e7e12db3d107fe6a487137650a2af379bbd49165a1494246ea echo hello
 		`))
 )
 
@@ -132,7 +137,6 @@ func newDockerCmd() *cobra.Command {
 	}
 
 	dockerCmd.AddCommand(newDockerRunCmd())
-
 	return dockerCmd
 }
 
@@ -140,7 +144,7 @@ func newDockerRunCmd() *cobra.Command { //nolint:funlen
 	ODR := NewDockerRunOptions()
 
 	dockerRunCmd := &cobra.Command{
-		Use:     "run",
+		Use:     "run [flags] IMAGE[:TAG|@DIGEST] [COMMAND] [ARG...]",
 		Short:   "Run a docker job on the network",
 		Long:    dockerRunLong,
 		Example: dockerRunExample,
@@ -299,6 +303,15 @@ func dockerRun(cmd *cobra.Command, cmdArgs []string, ODR *DockerRunOptions) erro
 			return nil
 		}
 	}
+
+	quiet := ODR.RunTimeSettings.PrintJobIDOnly
+	if !quiet {
+		containsTag := DockerImageContainsTag(j.Spec.Docker.Image)
+		if !containsTag {
+			cmd.Printf("Using default tag: latest. Please specify a tag/digest for better reproducibility.\n")
+		}
+	}
+
 	if ODR.DryRun {
 		// Converting job to yaml
 		var yamlBytes []byte
@@ -320,6 +333,7 @@ func dockerRun(cmd *cobra.Command, cmdArgs []string, ODR *DockerRunOptions) erro
 	)
 }
 
+// CreateJob creates a job object from the given command line arguments and options.
 func CreateJob(ctx context.Context,
 	cmdArgs []string,
 	odr *DockerRunOptions) (*model.Job, error) {

--- a/cmd/bacalhau/utils.go
+++ b/cmd/bacalhau/utils.go
@@ -932,3 +932,14 @@ func formatMessage(msg string) string {
 	return fmt.Sprintf("\t%s%s",
 		strings.Repeat(" ", maxLength-len(msg)+2), msg)
 }
+
+// Check if the image contains a tag or a digest
+func DockerImageContainsTag(image string) bool {
+	if strings.Contains(image, ":") {
+		return true
+	}
+	if strings.Contains(image, "@") {
+		return true
+	}
+	return false
+}

--- a/pkg/job/validate.go
+++ b/pkg/job/validate.go
@@ -23,6 +23,7 @@ func VerifyJobCreatePayload(ctx context.Context, jc *model.JobCreatePayload) err
 	})
 }
 
+// VerifyJob verifies that job object passed is valid.
 func VerifyJob(ctx context.Context, j *model.Job) error {
 	if reflect.DeepEqual(model.Spec{}, j.Spec) {
 		return fmt.Errorf("job spec is empty")


### PR DESCRIPTION
### Better CLI inline docs regarding IMAGE tag/digest:

```
❯ go run . docker run --help
Runs a job using the Docker executor on the node.

Usage:
  bacalhau docker run [flags] IMAGE[:TAG|@DIGEST] [COMMAND] [ARG...]

Examples:
...
  
  # Specify an image tag (default is 'latest' - using a specific tag other than 'latest' is recommended for reproducibility)
  bacalhau docker run ubuntu:bionic echo hello
  
  # Specify an image digest
  bacalhau docker run ubuntu@sha256:35b4f89ec2ee42e7e12db3d107fe6a487137650a2af379bbd49165a1494246ea echo hello
```

### Better CLI prints when omitting TAG/DIGEST
```
❯ go run . docker run ubuntu date
Using default tag: latest. Please specify a tag/digest for better reproducibility.
Job successfully submitted.....
...

❯ go run . docker run ubuntu:lunar date
Job successfully submitted.....
```

### Details

Cherry picked 54c088c61403f0bf975d1bc0e67c49cd8eb86388 from https://github.com/filecoin-project/bacalhau/pull/1604