### PR TITLE
Allow network traffic to two BOINC projects

### DIFF
--- a/ops/terraform/remote_files/scripts/http-domain-allowlist.txt
+++ b/ops/terraform/remote_files/scripts/http-domain-allowlist.txt
@@ -108,3 +108,15 @@ proxy.golang.org
 sum.golang.org
 index.golang.org
 storage.googleapis.com
+
+# boinc.multi-pool.info/latinsquares BOINC project
+78.26.93.125
+boinc.berkeley.edu
+boinc.multi-pool.info
+
+# einsteinathome.org BOINC project
+einsteinathome.org
+scheduler.einsteinathome.org
+einstein.phys.uwm.edu
+einstein-dl.syr.edu
+.aei.uni-hannover.de


### PR DESCRIPTION
Add relevant network destinations for the latinsquares and einsteinathome BOINC projects

Part of #699