### PR TITLE
local directory storage driver

### DIFF
--- a/pkg/model/storage_source.go
+++ b/pkg/model/storage_source.go
@@ -20,6 +20,7 @@ const (
 	StorageSourceFilecoin
 	StorageSourceEstuary
 	StorageSourceInline
+	StorageSourceLocalDirectory
 	storageSourceDone // must be last
 )
 

--- a/pkg/model/storage_spec.go
+++ b/pkg/model/storage_spec.go
@@ -20,6 +20,9 @@ type StorageSpec struct {
 	// Source URL of the data
 	URL string `json:"URL,omitempty"`
 
+	// The path of the host data if we are using local directory paths
+	SourcePath string `json:"SourcePath,omitempty"`
+
 	// The path that the spec's data should be mounted on, where it makes
 	// sense (for example, in a Docker storage spec this will be a filesystem
 	// path).

--- a/pkg/model/storagesourcetype_string.go
+++ b/pkg/model/storagesourcetype_string.go
@@ -15,12 +15,13 @@ func _() {
 	_ = x[StorageSourceFilecoin-4]
 	_ = x[StorageSourceEstuary-5]
 	_ = x[StorageSourceInline-6]
-	_ = x[storageSourceDone-7]
+	_ = x[StorageSourceLocalDirectory-7]
+	_ = x[storageSourceDone-8]
 }
 
-const _StorageSourceType_name = "storageSourceUnknownIPFSURLDownloadFilecoinUnsealedFilecoinEstuaryInlinestorageSourceDone"
+const _StorageSourceType_name = "storageSourceUnknownIPFSURLDownloadFilecoinUnsealedFilecoinEstuaryInlineLocalDirectorystorageSourceDone"
 
-var _StorageSourceType_index = [...]uint8{0, 20, 24, 35, 51, 59, 66, 72, 89}
+var _StorageSourceType_index = [...]uint8{0, 20, 24, 35, 51, 59, 66, 72, 86, 103}
 
 func (i StorageSourceType) String() string {
 	if i < 0 || i >= StorageSourceType(len(_StorageSourceType_index)-1) {

--- a/pkg/storage/local_directory/storage_test.go
+++ b/pkg/storage/local_directory/storage_test.go
@@ -1,0 +1,103 @@
+//go:build unit || !integration
+
+package localdirectory
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/filecoin-project/bacalhau/pkg/logger"
+	_ "github.com/filecoin-project/bacalhau/pkg/logger"
+	"github.com/filecoin-project/bacalhau/pkg/model"
+	"github.com/filecoin-project/bacalhau/pkg/system"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+var ctx context.Context
+var tempDir string
+var driver *StorageProvider
+var cm *system.CleanupManager
+
+type LocalDirectorySuite struct {
+	suite.Suite
+}
+
+func (suite *LocalDirectorySuite) prepareStorageSpec(sourcePath string) model.StorageSpec {
+	folderPath := filepath.Join(tempDir, sourcePath)
+	err := os.MkdirAll(folderPath, os.ModePerm)
+	require.NoError(suite.T(), err)
+	return model.StorageSpec{
+		// source path is some kind of sub-path
+		// inside our local folder
+		SourcePath: sourcePath,
+		Path:       "/path/inside/the/container",
+	}
+}
+
+// In order for 'go test' to run this suite, we need to create
+// a normal test function and pass our suite to suite.Run
+func TestLocalDirectorySuite(t *testing.T) {
+	suite.Run(t, new(LocalDirectorySuite))
+}
+
+// Before each test
+func (suite *LocalDirectorySuite) SetupTest() {
+	var setupErr error
+	logger.ConfigureTestLogging(suite.T())
+	cm = system.NewCleanupManager()
+	ctx = context.Background()
+	tempDir = suite.T().TempDir()
+	driver, setupErr = NewStorage(cm, tempDir)
+	require.NoError(suite.T(), setupErr)
+}
+
+func (suite *LocalDirectorySuite) TestIsInstalled() {
+	installed, err := driver.IsInstalled(ctx)
+	require.NoError(suite.T(), err)
+	require.True(suite.T(), installed)
+}
+
+func (suite *LocalDirectorySuite) TestHasStorageLocally() {
+	subpath := "apples/oranges"
+	spec := suite.prepareStorageSpec(subpath)
+	hasStorageTrue, err := driver.HasStorageLocally(ctx, spec)
+	require.NoError(suite.T(), err)
+	require.True(suite.T(), hasStorageTrue, "file that exists should return true for HasStorageLocally")
+	spec.SourcePath = "apples/pears"
+	hasStorageFalse, err := driver.HasStorageLocally(ctx, spec)
+	require.NoError(suite.T(), err)
+	require.False(suite.T(), hasStorageFalse, "file that does not exist should return false for HasStorageLocally")
+}
+
+func (suite *LocalDirectorySuite) TestGetVolumeSize() {
+	subpath := "apples/oranges"
+	folderPath := filepath.Join(tempDir, subpath)
+	fileContents := "hello world"
+	spec := suite.prepareStorageSpec(subpath)
+	filePath := filepath.Join(folderPath, "file")
+	err := os.WriteFile(filePath, []byte(fileContents), 0644)
+	require.NoError(suite.T(), err)
+	volumeSize, err := driver.GetVolumeSize(ctx, spec)
+	require.NoError(suite.T(), err)
+	require.Equal(suite.T(), uint64(len(fileContents)), volumeSize, "the volume size should be the size of the file")
+}
+
+func (suite *LocalDirectorySuite) TestPrepareStorage() {
+	subpath := "apples/oranges"
+	spec := suite.prepareStorageSpec(subpath)
+	volume, err := driver.PrepareStorage(ctx, spec)
+	require.NoError(suite.T(), err)
+	require.Equal(suite.T(), volume.Source, filepath.Join(tempDir, subpath), "the volume source is correct")
+}
+
+func (suite *LocalDirectorySuite) TestExplode() {
+	subpath := "apples/oranges"
+	spec := suite.prepareStorageSpec(subpath)
+	exploded, err := driver.Explode(ctx, spec)
+	require.NoError(suite.T(), err)
+	require.Equal(suite.T(), len(exploded), 1, "the exploded list should be 1 item long")
+	require.Equal(suite.T(), exploded[0].SourcePath, subpath, "the subpath is correct")
+}

--- a/pkg/storage/util/dirsize.go
+++ b/pkg/storage/util/dirsize.go
@@ -1,0 +1,21 @@
+//nolint:stylecheck // prefer caps for these
+package util
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func DirSize(path string) (uint64, error) {
+	var size uint64
+	err := filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			size += uint64(info.Size())
+		}
+		return err
+	})
+	return size, err
+}


### PR DESCRIPTION
This PR adds a local directory storage driver which means that you can configure local directories as storage sources for jobs which is useful for on-prem scenarios where you want to use node selectors to target specific nodes who have data locally in known folders.

