### PR TITLE
close bprotocol sessions when done

### DIFF
--- a/pkg/transport/bprotocol/callback_proxy.go
+++ b/pkg/transport/bprotocol/callback_proxy.go
@@ -97,15 +97,15 @@ func proxyCallbackRequest(
 		// opening a stream to the destination peer
 		stream, err := p.host.NewStream(ctx, peerID, protocolID)
 		if err != nil {
-			if err != nil {
-				log.Ctx(ctx).Error().Err(err).Msgf("%s: failed to open stream to peer %s", reflect.TypeOf(request), targetPeerID)
-				return
-			}
+			log.Ctx(ctx).Error().Err(err).Msgf("%s: failed to open stream to peer %s", reflect.TypeOf(request), targetPeerID)
+			return
 		}
+		defer stream.Close() //nolint:errcheck
 
 		// write the request to the stream
 		_, err = stream.Write(data)
 		if err != nil {
+			stream.Reset() //nolint:errcheck
 			log.Ctx(ctx).Error().Err(err).Msgf("%s: failed to write request to peer %s", reflect.TypeOf(request), targetPeerID)
 			return
 		}

--- a/pkg/transport/bprotocol/compute_proxy.go
+++ b/pkg/transport/bprotocol/compute_proxy.go
@@ -131,16 +131,19 @@ func proxyRequest[Request any, Response any](
 	if err != nil {
 		return *response, fmt.Errorf("%s: failed to open stream to peer %s: %w", reflect.TypeOf(request), destPeerID, err)
 	}
+	defer stream.Close() //nolint:errcheck
 
 	// write the request to the stream
 	_, err = stream.Write(data)
 	if err != nil {
+		stream.Reset() //nolint:errcheck
 		return *response, fmt.Errorf("%s: failed to write request to peer %s: %w", reflect.TypeOf(request), destPeerID, err)
 	}
 
 	// Now we read the response that was sent from the dest peer
 	err = json.NewDecoder(stream).Decode(response)
 	if err != nil {
+		stream.Reset() //nolint:errcheck
 		return *response, fmt.Errorf("%s: failed to decode response from peer %s: %w", reflect.TypeOf(request), destPeerID, err)
 	}
 

--- a/pkg/transport/simulator/callback_proxy.go
+++ b/pkg/transport/simulator/callback_proxy.go
@@ -103,15 +103,15 @@ func proxyCallbackRequest(
 		// opening a stream to the destination peer
 		stream, err := p.host.NewStream(ctx, peerID, protocolID)
 		if err != nil {
-			if err != nil {
-				log.Ctx(ctx).Error().Err(err).Msgf("%s: failed to open stream to peer %s", reflect.TypeOf(request), targetPeerID)
-				return
-			}
+			log.Ctx(ctx).Error().Err(err).Msgf("%s: failed to open stream to peer %s", reflect.TypeOf(request), targetPeerID)
+			return
 		}
+		defer stream.Close() //nolint:errcheck
 
 		// write the request to the stream
 		_, err = stream.Write(data)
 		if err != nil {
+			stream.Reset() //nolint:errcheck
 			log.Ctx(ctx).Error().Err(err).Msgf("%s: failed to write request to peer %s", reflect.TypeOf(request), targetPeerID)
 			return
 		}

--- a/pkg/transport/simulator/compute_proxy.go
+++ b/pkg/transport/simulator/compute_proxy.go
@@ -138,16 +138,19 @@ func proxyRequest[Request any, Response any](
 	if err != nil {
 		return *response, fmt.Errorf("%s: failed to open stream to peer %s: %w", reflect.TypeOf(request), destPeerID, err)
 	}
+	defer stream.Close() //nolint:errcheck
 
 	// write the request to the stream
 	_, err = stream.Write(data)
 	if err != nil {
+		stream.Reset() //nolint:errcheck
 		return *response, fmt.Errorf("%s: failed to write request to peer %s: %w", reflect.TypeOf(request), destPeerID, err)
 	}
 
 	// Now we read the response that was sent from the dest peer
 	err = json.NewDecoder(stream).Decode(response)
 	if err != nil {
+		stream.Reset() //nolint:errcheck
 		return *response, fmt.Errorf("%s: failed to decode response from peer %s: %w", reflect.TypeOf(request), destPeerID, err)
 	}
 


### PR DESCRIPTION
Fixes `cannot reserve stream: resource limit exceeded` issue observed by staging canary when trying to ask other nodes to bid.

Opened a thread with libp2p if caching of streams is needed:
https://filecoinproject.slack.com/archives/C03K82MU486/p1674758141100389