### PR TITLE
fail fast in unable to reach --ipfs-connect

### DIFF
--- a/pkg/ipfs/client.go
+++ b/pkg/ipfs/client.go
@@ -40,11 +40,17 @@ func NewClientUsingRemoteHandler(apiAddr string) (Client, error) {
 		return Client{}, fmt.Errorf("failed to connect to '%s': %w", apiAddr, err)
 	}
 
-	log.Debug().Msgf("Created remote IPFS client for node API address: %s", apiAddr)
-	return Client{
+	client := Client{
 		API:  api,
 		addr: apiAddr,
-	}, nil
+	}
+
+	id, err := client.ID(context.Background())
+	if err != nil {
+		return Client{}, fmt.Errorf("failed to connect to '%s': %w", apiAddr, err)
+	}
+	log.Debug().Msgf("Created remote IPFS client for node API address: %s, with id: %s", apiAddr, id)
+	return client, nil
 }
 
 const MagicInternalIPFSAddress = "memory://in-memory-node/"


### PR DESCRIPTION
Today defining an invalid `--ipfs-connect` endpoint will result in the node starting up, but rejecting all jobs with ipfs publisher. Since `--ipfs-connect` is a required argument, we need to make sure it is valid and the ipfs server is running and reachable, which is what this change is doing