### PR TITLE
Make it easy to start a private Bacalhau network

### DIFF
--- a/pkg/ipfs/node.go
+++ b/pkg/ipfs/node.go
@@ -113,6 +113,16 @@ func (cfg *Config) getPeerAddrs() []string {
 // repo in a temporary directory, uses the public libp2p nodes as peers and
 // generates a repo keypair with 2048 bits.
 func NewNode(ctx context.Context, cm *system.CleanupManager, peerAddrs []string) (*Node, error) {
+	return newNode(ctx, cm, peerAddrs, ModeDefault)
+}
+
+// NewLocalNode creates a new local IPFS node in local mode, which can be used
+// to create test environments without polluting the public IPFS nodes.
+func NewLocalNode(ctx context.Context, cm *system.CleanupManager, peerAddrs []string) (*Node, error) {
+	return newNode(ctx, cm, peerAddrs, ModeLocal)
+}
+
+func newNode(ctx context.Context, cm *system.CleanupManager, peerAddrs []string, mode NodeMode) (*Node, error) {
 	// filter out any empty peer addresses
 	filteredPeerAddrs := make([]string, 0, len(peerAddrs))
 	for _, addr := range peerAddrs {
@@ -121,17 +131,8 @@ func NewNode(ctx context.Context, cm *system.CleanupManager, peerAddrs []string)
 		}
 	}
 	return tryCreateNode(ctx, cm, Config{
-		Mode:      ModeDefault,
+		Mode:      mode,
 		PeerAddrs: filteredPeerAddrs,
-	})
-}
-
-// NewLocalNode creates a new local IPFS node in local mode, which can be used
-// to create test environments without polluting the public IPFS nodes.
-func NewLocalNode(ctx context.Context, cm *system.CleanupManager, peerAddrs []string) (*Node, error) {
-	return tryCreateNode(ctx, cm, Config{
-		Mode:      ModeLocal,
-		PeerAddrs: peerAddrs,
 	})
 }
 
@@ -487,9 +488,6 @@ func createRepo(path string, mode NodeMode, keypairSize int) error {
 		cfg.Swarm.RelayService.Enabled = config.False
 		cfg.Swarm.Transports.Network.Relay = config.False
 		cfg.Discovery.MDNS.Enabled = false
-		cfg.Addresses.Announce = []string{
-			fmt.Sprintf("/ip4/127.0.0.1/tcp/%d", swarmPort),
-		}
 		cfg.Addresses.Gateway = []string{
 			fmt.Sprintf("/ip4/0.0.0.0/tcp/%d", gatewayPort),
 		}

--- a/pkg/requester/discovery/identity_test.go
+++ b/pkg/requester/discovery/identity_test.go
@@ -37,8 +37,8 @@ func (s *IdentityNodeDiscovererSuite) SetupSuite() {
 	s.node2.SetStreamHandler(bprotocol.AskForBidProtocolID, func(s network.Stream) {})
 
 	// connect all nodes after implementing bprotocol to share the info in the initial handshake
-	s.NoError(s.node2.Connect(ctx, libp2p.ExtractAddrInfoFromHost(s.node1)))
-	s.NoError(s.random3.Connect(ctx, libp2p.ExtractAddrInfoFromHost(s.node1)))
+	s.NoError(s.node2.Connect(ctx, *host.InfoFromHost(s.node1)))
+	s.NoError(s.random3.Connect(ctx, *host.InfoFromHost(s.node1)))
 
 	s.discoverer = NewIdentityNodeDiscoverer(IdentityNodeDiscovererParams{
 		Host: s.node1,

--- a/pkg/util/generic/map.go
+++ b/pkg/util/generic/map.go
@@ -1,0 +1,10 @@
+package generic
+
+// Map transforms a slice into a slice of another type
+func Map[F any, T any](inputs []F, f func(F) T) []T {
+	tees := make([]T, 0, len(inputs))
+	for _, input := range inputs {
+		tees = append(tees, f(input))
+	}
+	return tees
+}

--- a/pkg/util/generic/syncmap.go
+++ b/pkg/util/generic/syncmap.go
@@ -2,7 +2,7 @@ package generic
 
 import "sync"
 
-// A generic.SyncMap is a concurrency-safe sync.Map that uses strongly-typed
+// A SyncMap is a concurrency-safe sync.Map that uses strongly-typed
 // method signatures to ensure the types of its stored data are known.
 type SyncMap[K comparable, V any] struct {
 	sync.Map


### PR DESCRIPTION
This makes it easier to start a private Bacalhau network by being able to configure what the in-process IPFS cluster will connect to and auto-discover.

For example, on a single machine:
```shell
$ bacalhau serve --node-type requester --private-internal-ipfs \
  --peer none # start the first, requester, node
$ bacalhau serve --api-port 1236 --swarm-port 1237 --metrics-port 2113 \
  --private-internal-ipfs \
  --peer \
  /ip6/::1/tcp/1235/p2p/QmWg7m5GyAhocrd8o18dtntua7dQeEHpuHxC3niRH4pnvE \
  --ipfs-swarm-addr \
  /ip6/::1/tcp/52597/p2p/QmPBTv884V3eTRcdCisDXfWgVMfmfQWUACTgp3GbM1Kfs7
  # start the second, compute, node connecting to the first node
```

Using multiple machines:
```shell
$ bacalhau serve --node-type requester --private-internal-ipfs \
  --peer none
$ bacalhau serve --private-internal-ipfs \
  --peer \
  /ip4/192.168.1.224/tcp/1234/p2p/QmWg7m5GyAhocrd8o18dtntua7dQeEHpuHxC3niRH4pnvE \
  --ipfs-swarm-addr \
  /ip4/192.168.1.224/tcp/52597/p2p/QmPBTv884V3eTRcdCisDXfWgVMfmfQWUACTgp3GbM1Kfs7
```

Fixes #1770