### PR TITLE
Improve IPFS logging output

### DIFF
--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -3,12 +3,16 @@
 package logger
 
 import (
+	"errors"
+	"regexp"
+	"strings"
+	"testing"
+
 	"github.com/filecoin-project/bacalhau/pkg/logger/testpackage/subpackage/subsubpackage"
+	ipfslog2 "github.com/ipfs/go-log/v2"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
-	"strings"
-	"testing"
 )
 
 func TestConfigureLogging(t *testing.T) {
@@ -36,4 +40,25 @@ func TestConfigureLogging(t *testing.T) {
 	assert.Contains(t, actual, `error="testing error logging"`, "Log statement doesn't contain the logged error")
 	assert.Contains(t, actual, "pkg/logger/testpackage/subpackage/subsubpackage/testutil.go", "Log statement doesn't contain the full package path")
 	assert.Contains(t, actual, `stack:[{"func":"TestLog","line":`, "Log statement didn't automatically include the error's stacktrace")
+}
+
+// TestConfigureIpfsLogging checks that we configure IPFS logging correctly, forwarding logging to zerolog.
+func TestConfigureIpfsLogging(t *testing.T) {
+	var logging strings.Builder
+	configureLogging(func(w *zerolog.ConsoleWriter) {
+		w.Out = &logging
+		w.NoColor = true
+	})
+
+	l := ipfslog2.Logger("name")
+	l.With("hello", "world", "err", errors.New("example")).Error("test")
+
+	actual := logging.String()
+	// Like 12:06:50.55 | ERR pkg/logger/logger_test.go:52 > test [err:example] [hello:world] [logger-name:name]
+	t.Log(actual)
+
+	assert.Regexp(t, regexp.MustCompile(`ERR pkg/logger/logger_test.go:\d* > test`), actual)
+	assert.Contains(t, actual, "[hello:world]")
+	assert.Contains(t, actual, "[logger-name:name]")
+	assert.Contains(t, actual, "[err:example]")
 }

--- a/pkg/logger/trim_repository_root_other.go
+++ b/pkg/logger/trim_repository_root_other.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package logger
+
+func trimRepositoryRootDir(root string) string {
+	return root
+}

--- a/pkg/logger/trim_repository_root_windows.go
+++ b/pkg/logger/trim_repository_root_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package logger
+
+import "strings"
+
+func trimRepositoryRootDir(root string) string {
+	return strings.ReplaceAll(root, "\\", "/")
+}


### PR DESCRIPTION
This changes the IPFS logging so that zerolog understands the information being logged, such as log level or message, and can be correctly formatted for parsing/reading.

Example before:
```
11:10:07.274 | ??? github.com/libp2p/go-libp2p-kad-dht@v0.18.0/providers/providers_manager.go:145 > ERROR providers failed to flush datastore: committing batch to datastore at /: leveldb: closed
```

Example after
```
10:49:28.15 | ERR github.com/libp2p/go-libp2p@v0.23.4/config/config.go:120 > tried to create a libp2p node with no Private Network Protector but usage of Private Networks is forced by the enviroment
```

Fixes #1800