### PR TITLE
fix(docker): run binary from location on path

### DIFF
--- a/docker/bacalhau-image/Dockerfile
+++ b/docker/bacalhau-image/Dockerfile
@@ -8,8 +8,9 @@ RUN make build-bacalhau
 RUN find ./bin -name 'bacalhau' -exec mv -t ./bin {} +
 
 FROM cgr.dev/chainguard/static:latest
-COPY --from=build /work/bin/bacalhau /bacalhau
-ENTRYPOINT ["/bacalhau"]
+COPY --from=build /work/bin/bacalhau /usr/local/bin/bacalhau
+ENV PATH="/usr/local/bin"
+ENTRYPOINT ["bacalhau"]
 LABEL org.opencontainers.image.source https://github.com/filecoin-project/bacalhau
 LABEL org.opencontainers.image.title "Bacalhau"
 LABEL org.opencontainers.image.description "The Bacalhau network provices decentralised compute for compute over data. See https://bacalhau.org for more info."


### PR DESCRIPTION
Fixes #1838

Once this merges, I will backport this fix to all published container versions.