### PR TITLE
fix IPFS canary timeout values

### DIFF
--- a/ops/aws/canary/lambda/pkg/scenarios/submitDockerIPFSJobAndGet.go
+++ b/ops/aws/canary/lambda/pkg/scenarios/submitDockerIPFSJobAndGet.go
@@ -62,7 +62,7 @@ func SubmitDockerIPFSJobAndGet(ctx context.Context) error {
 		return fmt.Errorf("getting download settings: %s", err)
 	}
 	downloadSettings.OutputDir = outputDir
-	downloadSettings.Timeout = 600 * time.Second
+	downloadSettings.Timeout = 300 * time.Second
 
 	downloaderProvider := util.NewStandardDownloaders(cm, downloadSettings)
 	if err != nil {

--- a/ops/aws/canary/lib/canary-stack.ts
+++ b/ops/aws/canary/lib/canary-stack.ts
@@ -55,7 +55,7 @@ export class CanaryStack extends cdk.Stack {
         this.createLambdaScenarioFunc({ ...DEFAULT_SCENARIO_PROPS, ...{action: "submitWithConcurrency"}});
         this.createLambdaScenarioFunc({ ...DEFAULT_SCENARIO_PROPS, ...{action: "submitWithConcurrencyOwnedNodes"}});
         this.createLambdaScenarioFunc({ ...DEFAULT_SCENARIO_PROPS, ...{
-                action: "submitDockerIPFSJobAndGet", timeoutMinutes: 5, memorySize: 4096, storageSize: 5012,
+                action: "submitDockerIPFSJobAndGet", timeoutMinutes: 6, memorySize: 5120, storageSize: 5012,
                 datapointsToAlarm: 4, evaluationPeriods: 6}});
 
         if (config.createOperators) {


### PR DESCRIPTION
Increase lambda timeout value from 5 to 6 minutes, and reduce download timeout value to be less than lambda so it times out earlier 