### PR TITLE
increase canary integration test host capacity

### DIFF
--- a/ops/aws/canary/lib/pipeline-stack.ts
+++ b/ops/aws/canary/lib/pipeline-stack.ts
@@ -222,6 +222,7 @@ export class PipelineStack extends cdk.Stack {
             }),
             environment: {
                 buildImage: codebuild.LinuxBuildImage.AMAZON_LINUX_2_4,
+                computeType: codebuild.ComputeType.MEDIUM,
             },
         });
     }


### PR DESCRIPTION
Increase capacity from `3 GB memory, 2 vCPUs` to `7 GB memory, 4 vCPUs`

Related to https://github.com/filecoin-project/bacalhau/issues/1869
