### PR TITLE
Stop Docker tests crashing

### DIFF
--- a/pkg/executor/results.go
+++ b/pkg/executor/results.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -25,6 +26,11 @@ type outputResult struct {
 }
 
 func writeOutputResult(resultsDir string, output outputResult) error {
+	if output.contents == nil {
+		// contents may be nil if something went wrong while trying to get the logs
+		output.contents = bytes.NewReader(nil)
+	}
+
 	var err error
 
 	// Consume the passed buffers up to the limit of the maximum bytes. The

--- a/pkg/executor/results_test.go
+++ b/pkg/executor/results_test.go
@@ -84,7 +84,7 @@ func TestWriteResultLimitsEnforced(t *testing.T) {
 
 func TestWriteResultHandlesNilPointers(t *testing.T) {
 	spec := outputResult{
-		contents:     strings.NewReader("hello world"),
+		contents:     nil,
 		filename:     "whatever",
 		fileLimit:    1024,
 		summary:      nil,


### PR DESCRIPTION
Something can go wrong when running TestDockerRunSuite which causes the `FollowLogs` to return an error. When this happens, the code segfaults as the `executor.WriteJobResults` call expects the stdout & stderr readers to be populated. So this won't fix the flake, it'll make it flake better by outputting the actual error.

Fixes #1875