### PR TITLE
introduce lite ipfs node for downloading results

### DIFF
--- a/cmd/bacalhau/utils.go
+++ b/cmd/bacalhau/utils.go
@@ -470,7 +470,7 @@ func downloadResultsHandler(
 		return err
 	}
 
-	downloaderProvider := util.NewStandardDownloaders(cm, &processedDownloadSettings)
+	downloaderProvider, err := util.NewStandardDownloaders(ctx, cm, &processedDownloadSettings)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/imdario/mergo v0.3.13
 	github.com/invopop/jsonschema v0.7.0
 	github.com/ipfs/go-cid v0.3.2
+	github.com/ipfs/go-datastore v0.6.0
 	github.com/ipfs/go-ipfs-files v0.2.0
 	github.com/ipfs/go-ipfs-http-client v0.4.0
 	github.com/ipfs/go-ipld-format v0.4.0
@@ -172,7 +173,6 @@ require (
 	github.com/ipfs/go-block-format v0.1.1 // indirect
 	github.com/ipfs/go-blockservice v0.5.0 // indirect
 	github.com/ipfs/go-cidutil v0.1.0 // indirect
-	github.com/ipfs/go-datastore v0.6.0 // indirect
 	github.com/ipfs/go-delegated-routing v0.7.0 // indirect
 	github.com/ipfs/go-ds-badger v0.3.0 // indirect
 	github.com/ipfs/go-ds-flatfs v0.5.1 // indirect

--- a/ops/aws/canary/lambda/pkg/scenarios/submitAndGet.go
+++ b/ops/aws/canary/lambda/pkg/scenarios/submitAndGet.go
@@ -53,7 +53,7 @@ func SubmitAndGet(ctx context.Context) error {
 	}
 	downloadSettings.OutputDir = outputDir
 
-	downloaderProvider := util.NewStandardDownloaders(cm, downloadSettings)
+	downloaderProvider, err := util.NewStandardDownloaders(ctx, cm, downloadSettings)
 	if err != nil {
 		return err
 	}

--- a/ops/aws/canary/lambda/pkg/scenarios/submitDockerIPFSJobAndGet.go
+++ b/ops/aws/canary/lambda/pkg/scenarios/submitDockerIPFSJobAndGet.go
@@ -64,7 +64,7 @@ func SubmitDockerIPFSJobAndGet(ctx context.Context) error {
 	downloadSettings.OutputDir = outputDir
 	downloadSettings.Timeout = 100 * time.Second
 
-	downloaderProvider := util.NewStandardDownloaders(cm, downloadSettings)
+	downloaderProvider, err := util.NewStandardDownloaders(ctx, cm, downloadSettings)
 	if err != nil {
 		return err
 	}

--- a/pkg/downloader/download_test.go
+++ b/pkg/downloader/download_test.go
@@ -45,7 +45,6 @@ func (ds *DownloaderSuite) SetupSuite() {
 	ctx, cancel := context.WithCancel(context.Background())
 	ds.T().Cleanup(cancel)
 
-	// don't use local ipfs node as downloader is using LiteNode which is not compatible with local ipfs node
 	node, err := ipfs.NewLocalNode(ctx, ds.cm, nil)
 	require.NoError(ds.T(), err)
 
@@ -86,7 +85,7 @@ func (ds *DownloaderSuite) TearDownSuite() {
 		_ = ds.ipfsDownloader.Close()
 	}
 	if ds.node != nil {
-		//ds.node.Close()
+		_ = ds.node.Close()
 	}
 	ds.cm.Cleanup()
 	_ = os.RemoveAll(ds.outputDir)

--- a/pkg/downloader/estuary/downloader.go
+++ b/pkg/downloader/estuary/downloader.go
@@ -11,6 +11,11 @@ import (
 	"github.com/filecoin-project/bacalhau/pkg/system"
 )
 
+type DownloaderParams struct {
+	HTTPDownloader *http.Downloader
+	IPFSDownloader *ipfs.Downloader
+}
+
 // Estuary downloader uses HTTP downloader to download result published to Estuary
 // by combining Estuary gateway URL and CID returned by Estuary publisher and passing it for download.
 type Downloader struct {
@@ -18,10 +23,10 @@ type Downloader struct {
 	ipfsDownloader *ipfs.Downloader
 }
 
-func NewEstuaryDownloader(cm *system.CleanupManager, settings *model.DownloaderSettings) *Downloader {
+func NewEstuaryDownloader(params DownloaderParams) *Downloader {
 	return &Downloader{
-		ipfsDownloader: ipfs.NewIPFSDownloader(cm, settings),
-		httpDownloader: http.NewHTTPDownloader(settings),
+		ipfsDownloader: params.IPFSDownloader,
+		httpDownloader: params.HTTPDownloader,
 	}
 }
 

--- a/pkg/downloader/estuary/downloader_test.go
+++ b/pkg/downloader/estuary/downloader_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/filecoin-project/bacalhau/pkg/system"
-
+	"github.com/filecoin-project/bacalhau/pkg/downloader/http"
+	"github.com/filecoin-project/bacalhau/pkg/downloader/ipfs"
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/stretchr/testify/require"
 )
@@ -23,8 +23,15 @@ func TestFetchResult(t *testing.T) {
 	settings := &model.DownloaderSettings{
 		Timeout: time.Second * 60,
 	}
-	cm := system.NewCleanupManager()
-	downloader := NewEstuaryDownloader(cm, settings)
+	ipfsDownloader, err := ipfs.NewIPFSDownloader(context.Background(), settings)
+	require.NoError(t, err)
+	defer func() {
+		_ = ipfsDownloader.Close()
+	}()
+	downloader := NewEstuaryDownloader(DownloaderParams{
+		IPFSDownloader: ipfsDownloader,
+		HTTPDownloader: http.NewHTTPDownloader(settings),
+	})
 
 	tests := []struct {
 		CID  string

--- a/pkg/downloader/ipfs/downloader.go
+++ b/pkg/downloader/ipfs/downloader.go
@@ -22,7 +22,10 @@ type Downloader struct {
 func NewIPFSDownloader(ctx context.Context, settings *model.DownloaderSettings) (*Downloader, error) {
 	var peerAddrs []string
 	for _, addr := range strings.Split(settings.IPFSSwarmAddrs, ",") {
-		peerAddrs = append(peerAddrs, strings.TrimSpace(addr))
+		peerAdr := strings.TrimSpace(addr)
+		if peerAdr != "" {
+			peerAddrs = append(peerAddrs, strings.TrimSpace(addr))
+		}
 	}
 
 	node, err := ipfs.NewLiteNode(ctx, ipfs.LiteNodeParams{

--- a/pkg/ipfs/client.go
+++ b/pkg/ipfs/client.go
@@ -159,25 +159,9 @@ func (cl Client) Get(ctx context.Context, cid, outputPath string) error {
 		return fmt.Errorf("output path '%s' already exists", outputPath)
 	}
 
-	providers, err := cl.NodesWithCID(ctx, cid)
-	if err != nil {
-		log.Warn().Err(err).Msgf("failed to fetch providers for %s. Will still attempt to download", cid)
-	} else {
-		log.Trace().Msgf("Found %d providers for %s", len(providers), cid)
-		for i, provider := range providers {
-			log.Trace().Msgf("Provider %d: %+v", i, provider)
-		}
-	}
-
 	node, err := cl.API.Unixfs().Get(ctx, icorepath.New(cid))
 	if err != nil {
 		return fmt.Errorf("failed to get ipfs cid '%s': %w", cid, err)
-	}
-	size, err := node.Size()
-	if err != nil {
-		return fmt.Errorf("failed to get ipfs cid '%s' size: %w", cid, err)
-	} else {
-		log.Trace().Msgf("downloading from ipfs cid '%s' size: %d", cid, size)
 	}
 
 	if err := files.WriteTo(node, outputPath); err != nil {

--- a/pkg/ipfs/lite_node.go
+++ b/pkg/ipfs/lite_node.go
@@ -1,0 +1,161 @@
+package ipfs
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	ds "github.com/ipfs/go-datastore"
+	dsync "github.com/ipfs/go-datastore/sync"
+	icore "github.com/ipfs/interface-go-ipfs-core"
+	"github.com/ipfs/kubo/repo"
+	"github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/rs/zerolog/log"
+
+	"github.com/ipfs/kubo/config"
+	"github.com/ipfs/kubo/core"
+	"github.com/ipfs/kubo/core/coreapi"
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+type LiteNodeParams struct {
+	// PeerAddrs is a list of peers to connect to.
+	PeerAddrs []string
+}
+
+// LiteNode is a wrapper around an in-process low power IPFS node with limited functionality and nilRepo
+// that should only be used to download content from IPFS.
+type LiteNode struct {
+	api      icore.CoreAPI
+	ipfsNode *core.IpfsNode
+}
+
+type LiteClient interface {
+	Get(ctx context.Context, cid, outputPath string) error
+}
+
+// NewLiteNode creates a new IPFS lite
+func NewLiteNode(ctx context.Context, params LiteNodeParams) (*LiteNode, error) {
+	var err error
+	var ipfsRepo repo.Repo
+	defer func() {
+		if err != nil && ipfsRepo != nil {
+			_ = ipfsRepo.Close()
+		}
+	}()
+
+	ipfsRepo, err = createLiteRepo(params.PeerAddrs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create repo: %w", err)
+	}
+	ipfsNode, err := core.NewNode(ctx, &core.BuildCfg{
+		Repo:   ipfsRepo,
+		Online: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create node: %w", err)
+	}
+
+	api, err := coreapi.NewCoreAPI(ipfsNode)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create coreapi: %w", err)
+	}
+
+	err = connectToPeers(ctx, ipfsNode, params.PeerAddrs)
+	if err != nil {
+		return nil, err
+	}
+	log.Trace().Msgf("IPFS lite node created with ID: %s", ipfsNode.Identity)
+
+	return &LiteNode{
+		api:      api,
+		ipfsNode: ipfsNode,
+	}, nil
+}
+
+func createLiteRepo(peers []string) (repo.Repo, error) {
+	cfg := &config.Config{}
+	profiles := []string{"lowpower", "randomports"}
+
+	for _, profile := range profiles {
+		transformer, ok := config.Profiles[profile]
+		if !ok {
+			return nil, fmt.Errorf("invalid configuration profile: %s", profile)
+		}
+		if err := transformer.Transform(cfg); err != nil { //nolint: govet
+			return nil, err
+		}
+	}
+
+	priv, pub, err := crypto.GenerateKeyPairWithReader(crypto.RSA, defaultKeypairSize, rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+
+	pid, err := peer.IDFromPublicKey(pub)
+	if err != nil {
+		return nil, err
+	}
+
+	privkeyb, err := crypto.MarshalPrivateKey(priv)
+	if err != nil {
+		return nil, err
+	}
+
+	bootstrapPeers := config.DefaultBootstrapAddresses
+	for _, peerAddr := range peers {
+		if peerAddr != "" {
+			bootstrapPeers = append(bootstrapPeers, peerAddr)
+		}
+	}
+	cfg.Bootstrap = bootstrapPeers
+	cfg.Identity.PeerID = pid.String()
+	cfg.Identity.PrivKey = base64.StdEncoding.EncodeToString(privkeyb)
+
+	return &repo.Mock{
+		D: dsync.MutexWrap(ds.NewNullDatastore()),
+		C: *cfg,
+	}, nil
+}
+
+// ID returns the node's ipfs ID.
+func (n *LiteNode) ID() string {
+	return n.ipfsNode.Identity.String()
+}
+
+// SwarmAddresses returns the node's swarm addresses.
+func (n *LiteNode) SwarmAddresses() ([]string, error) {
+	cfg, err := n.ipfsNode.Repo.Config()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get repo config: %w", err)
+	}
+
+	var res []string
+	for _, addr := range cfg.Addresses.Swarm {
+		res = append(res, fmt.Sprintf("%s/p2p/%s", addr, n.ID()))
+	}
+
+	return res, nil
+}
+
+// Client returns an API client for interacting with the node.
+func (n *LiteNode) Client() LiteClient {
+	return NewClient(n.api)
+}
+
+func (n *LiteNode) Close() error {
+	log.Debug().Msgf("Closing IPFS lite node %s", n.ID())
+	var errs *multierror.Error
+	if n.ipfsNode != nil {
+		errs = multierror.Append(errs, n.ipfsNode.Close())
+
+		if n.ipfsNode.Repo != nil {
+			if err := n.ipfsNode.Repo.Close(); err != nil { //nolint:govet
+				errs = multierror.Append(errs, fmt.Errorf("failed to close repo: %w", err))
+			}
+		}
+	}
+	return errs.ErrorOrNil()
+}

--- a/pkg/ipfs/lite_node_test.go
+++ b/pkg/ipfs/lite_node_test.go
@@ -1,0 +1,87 @@
+//go:build unit || !integration
+
+package ipfs
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/filecoin-project/bacalhau/pkg/logger"
+	"github.com/filecoin-project/bacalhau/pkg/system"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/suite"
+)
+
+const testContent = "Hello from IPFS Gateway Checker"
+const testCid = "bafybeifx7yeb55armcsxwwitkymga5xf53dxiarykms3ygqic223w5sk3m"
+
+type LiteNodeSuite struct {
+	suite.Suite
+}
+
+func (s *LiteNodeSuite) SetupTest() {
+	logger.ConfigureTestLogging(s.T())
+	s.Require().NoError(system.InitConfigForTesting(s.T()))
+}
+
+func (s *LiteNodeSuite) TestFunctionality() {
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(10*time.Second))
+	defer cancel()
+
+	n1, err := NewLiteNode(ctx, LiteNodeParams{})
+	s.Require().NoError(err)
+
+	// Create a file in a temp dir to download content to
+	dirPath := s.T().TempDir()
+	filePath := filepath.Join(dirPath, "test.txt")
+
+	n1Client := n1.Client()
+	s.Require().NoError(n1Client.Get(ctx, testCid, filePath))
+
+	// Check that the file was downloaded correctly:
+	data, err := os.ReadFile(filePath)
+	s.Require().NoError(err)
+	s.Require().Equal(testContent, strings.TrimSpace(string(data)))
+
+	// Check that a second node can be created withtin the same process with no errors
+	n1Addrs, err := n1.SwarmAddresses()
+	s.Require().NoError(err)
+	s.Require().NotEmpty(n1Addrs)
+	n2, err := NewLiteNode(ctx, LiteNodeParams{
+		PeerAddrs: n1Addrs[0:1], // only 1 address is enough
+	})
+	s.Require().NoError(err)
+
+	// check the node is connected to the first one
+	// it might take some time for the node 1 info to show up in the peer store of node 2
+	var peer1Info peer.AddrInfo
+	waitUntil := time.Now().Add(2 * time.Second)
+	for time.Now().Before(waitUntil) {
+		peer1Info = n2.ipfsNode.Peerstore.PeerInfo(n1.ipfsNode.Identity)
+		if len(peer1Info.Addrs) > 0 {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	s.Require().NotEmpty(peer1Info.Addrs)
+
+	// Check that the second node can download the same content
+	filePath2 := filepath.Join(dirPath, "test2.txt")
+	s.Require().NoError(n2.Client().Get(ctx, testCid, filePath2))
+	data2, err := os.ReadFile(filePath)
+	s.Require().NoError(err)
+	s.Require().Equal(data, data2)
+
+	// close the nodes
+	s.Require().NoError(n1.Close())
+	s.Require().NoError(n2.Close())
+}
+
+// a normal test function and pass our suite to suite.Run
+func TestLiteNodeSuite(t *testing.T) {
+	suite.Run(t, new(LiteNodeSuite))
+}

--- a/pkg/ipfs/utils.go
+++ b/pkg/ipfs/utils.go
@@ -6,8 +6,12 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/filecoin-project/bacalhau/pkg/storage/util"
+	"github.com/ipfs/kubo/core"
+	"github.com/libp2p/go-libp2p/core/peer"
+	ma "github.com/multiformats/go-multiaddr"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 )
@@ -41,4 +45,45 @@ func AddTextToNodes(ctx context.Context, fileContent []byte, clients ...Client) 
 	}
 
 	return AddFileToNodes(ctx, testFilePath, clients...)
+}
+
+// connectToPeers connects the node to a list of IPFS bootstrap peers.
+func connectToPeers(ctx context.Context, node *core.IpfsNode, peerAddrs []string) error {
+	log.Debug().Msgf("IPFS node %s has current peers: %v", node.Identity, node.Peerstore.Peers())
+	log.Debug().Msgf("IPFS node %s is connecting to new peers: %v", node.Identity, peerAddrs)
+
+	// Parse the bootstrap node multiaddrs and fetch their IPFS peer info:
+	peerInfos := make(map[peer.ID]*peer.AddrInfo)
+	for _, addrStr := range peerAddrs {
+		addr, err := ma.NewMultiaddr(addrStr)
+		if err != nil {
+			return err
+		}
+
+		pii, err := peer.AddrInfoFromP2pAddr(addr)
+		if err != nil {
+			return err
+		}
+
+		peerInfos[pii.ID] = pii
+	}
+
+	// Bootstrap the node's list of peers:
+	var anyErr error
+	var wg sync.WaitGroup
+	wg.Add(len(peerInfos))
+	for _, peerInfo := range peerInfos {
+		go func(peerInfo *peer.AddrInfo) {
+			defer wg.Done()
+			if err := node.PeerHost.Connect(ctx, *peerInfo); err != nil {
+				anyErr = err
+				log.Debug().Msgf(
+					"failed to connect to ipfs peer %s, skipping: %s",
+					peerInfo.ID, err)
+			}
+		}(peerInfo)
+	}
+
+	wg.Wait()
+	return anyErr
 }

--- a/pkg/test/scenario/suite.go
+++ b/pkg/test/scenario/suite.go
@@ -115,7 +115,7 @@ func (s *ScenarioRunner) RunScenario(scenario Scenario) (resultsDir string) {
 	spec := scenario.Spec
 	docker.MaybeNeedDocker(s.T(), spec.Engine == model.EngineDocker)
 
-	stack, cm := s.setupStack(scenario.Stack)
+	stack, _ := s.setupStack(scenario.Stack)
 
 	// Check that the stack has the appropriate executor installed
 	for _, node := range stack.Nodes {
@@ -188,8 +188,11 @@ func (s *ScenarioRunner) RunScenario(scenario Scenario) (resultsDir string) {
 		IPFSSwarmAddrs: strings.Join(swarmAddresses, ","),
 	}
 
-	ipfsDownloader := ipfs.NewIPFSDownloader(cm, downloaderSettings)
+	ipfsDownloader, err := ipfs.NewIPFSDownloader(context.Background(), downloaderSettings)
 	require.NoError(s.T(), err)
+	defer func() {
+		_ = ipfsDownloader.Close()
+	}()
 
 	downloaderProvider := model.NewMappedProvider(map[model.StorageSourceType]downloader.Downloader{
 		model.StorageSourceIPFS: ipfsDownloader,


### PR DESCRIPTION
A kubo node configured with low power and limited functionality for the purpose of downloading results from IPFS. In addition to that, the downloader now is reusing the node instead of spinning up a fresh node for each download request