### PR TITLE
add a pre-prod manual approval step in the canary

### DIFF
--- a/ops/aws/canary/lib/pipeline-stack.ts
+++ b/ops/aws/canary/lib/pipeline-stack.ts
@@ -62,7 +62,7 @@ export class PipelineStack extends cdk.Stack {
                     ],
                 },
                 {
-                    stageName: 'TestStaging',
+                    stageName: 'PreStagingVerification',
                     actions: [
                         new codepipeline_actions.CodeBuildAction({
                             actionName: 'IntegrationTest',
@@ -88,12 +88,16 @@ export class PipelineStack extends cdk.Stack {
                     ],
                 },
                 {
-                    stageName: 'TestProd',
+                    stageName: 'PreProdVerification',
                     actions: [
                         new codepipeline_actions.CodeBuildAction({
                             actionName: 'IntegrationTest',
                             project: this.getIntegrationTest(prodConfig),
                             input: sourceOutput,
+                        }),
+                        new codepipeline_actions.ManualApprovalAction({
+                            actionName: 'ManualApproval',
+                            additionalInformation: 'Approve the Canary deployment to production',
                         }),
                     ],
                 },


### PR DESCRIPTION
Helpful when wanting to test canary changes in staging for longer duration before deploying to prod