### PR TITLE
Implement job cancellation for all executors

### DIFF
--- a/pkg/compute/executor.go
+++ b/pkg/compute/executor.go
@@ -7,6 +7,7 @@ import (
 	"github.com/filecoin-project/bacalhau/pkg/executor"
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/filecoin-project/bacalhau/pkg/publisher"
+	"github.com/filecoin-project/bacalhau/pkg/util/generic"
 	"github.com/filecoin-project/bacalhau/pkg/verifier"
 	"github.com/rs/zerolog/log"
 )
@@ -27,6 +28,7 @@ type BaseExecutor struct {
 	ID              string
 	callback        Callback
 	store           store.ExecutionStore
+	cancellers      generic.SyncMap[store.Execution, context.CancelFunc]
 	executors       executor.ExecutorProvider
 	verifiers       verifier.VerifierProvider
 	publishers      publisher.PublisherProvider
@@ -46,7 +48,7 @@ func NewBaseExecutor(params BaseExecutorParams) *BaseExecutor {
 }
 
 // Run the execution of a shard after it has been accepted, and propose a result to the requester to be verified.
-func (e BaseExecutor) Run(ctx context.Context, execution store.Execution) (err error) {
+func (e *BaseExecutor) Run(ctx context.Context, execution store.Execution) (err error) {
 	ctx = log.Ctx(ctx).With().
 		Str("Shard", execution.Shard.ID()).
 		Str("ExecutionID", execution.ID).
@@ -55,6 +57,15 @@ func (e BaseExecutor) Run(ctx context.Context, execution store.Execution) (err e
 	defer func() {
 		if err != nil {
 			e.handleFailure(ctx, execution, err, "Running")
+		}
+	}()
+
+	ctx, cancel := context.WithCancel(ctx)
+	e.cancellers.Put(execution, cancel)
+	defer func() {
+		if cancel, found := e.cancellers.Get(execution); found {
+			e.cancellers.Delete(execution)
+			cancel()
 		}
 	}()
 
@@ -126,7 +137,7 @@ func (e BaseExecutor) Run(ctx context.Context, execution store.Execution) (err e
 }
 
 // Publish the result of a shard execution after it has been verified.
-func (e BaseExecutor) Publish(ctx context.Context, execution store.Execution) (err error) {
+func (e *BaseExecutor) Publish(ctx context.Context, execution store.Execution) (err error) {
 	defer func() {
 		if err != nil {
 			e.handleFailure(ctx, execution, err, "Publishing")
@@ -179,22 +190,17 @@ func (e BaseExecutor) Publish(ctx context.Context, execution store.Execution) (e
 }
 
 // Cancel the execution of a running shard.
-func (e BaseExecutor) Cancel(ctx context.Context, execution store.Execution) (err error) {
+func (e *BaseExecutor) Cancel(ctx context.Context, execution store.Execution) (err error) {
 	defer func() {
 		if err != nil {
 			e.handleFailure(ctx, execution, err, "Canceling")
 		}
 	}()
 
-	log.Ctx(ctx).Debug().Msgf("Canceling execution %s", execution.ID)
-	// check that we have the executor to cancel this job
-	jobExecutor, err := e.executors.Get(ctx, execution.Shard.Job.Spec.Engine)
-	if err != nil {
-		return
-	}
-	err = jobExecutor.CancelShard(ctx, execution.Shard)
-	if err != nil {
-		return err
+	log.Ctx(ctx).Debug().Str("execution", execution.ID).Msg("Canceling execution")
+	if cancel, found := e.cancellers.Get(execution); found {
+		e.cancellers.Delete(execution)
+		cancel()
 	}
 
 	err = e.store.UpdateExecutionState(ctx, store.UpdateExecutionStateRequest{
@@ -216,7 +222,7 @@ func (e BaseExecutor) Cancel(ctx context.Context, execution store.Execution) (er
 	return err
 }
 
-func (e BaseExecutor) handleFailure(ctx context.Context, execution store.Execution, err error, operation string) {
+func (e *BaseExecutor) handleFailure(ctx context.Context, execution store.Execution, err error, operation string) {
 	log.Ctx(ctx).Error().Err(err).Msgf("%s execution %s failed", operation, execution.ID)
 	updateError := e.store.UpdateExecutionState(ctx, store.UpdateExecutionStateRequest{
 		ExecutionID: execution.ID,

--- a/pkg/executor/docker/executor.go
+++ b/pkg/executor/docker/executor.go
@@ -308,10 +308,6 @@ func (e *Executor) RunShard(
 	)
 }
 
-func (e *Executor) CancelShard(ctx context.Context, shard model.JobShard) error {
-	return docker.RemoveObjectsWithLabel(ctx, e.Client, labelJobName, e.labelJobValue(shard))
-}
-
 func (e *Executor) cleanupJob(ctx context.Context, shard model.JobShard) {
 	// Use a separate context in case the current one has already been canceled
 	separateCtx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)

--- a/pkg/executor/language/executor.go
+++ b/pkg/executor/language/executor.go
@@ -66,14 +66,6 @@ func (e *Executor) RunShard(
 	return executor.RunShard(ctx, shard, jobResultsDir)
 }
 
-func (e *Executor) CancelShard(ctx context.Context, shard model.JobShard) error {
-	executor, err := e.getDelegateExecutor(ctx, shard)
-	if err != nil {
-		return err
-	}
-	return executor.CancelShard(ctx, shard)
-}
-
 func (e *Executor) getDelegateExecutor(ctx context.Context, shard model.JobShard) (executor.Executor, error) {
 	requiredLang := LanguageSpec{
 		Language: shard.Job.Spec.Language.Language,

--- a/pkg/executor/noop/executor.go
+++ b/pkg/executor/noop/executor.go
@@ -78,9 +78,5 @@ func (e *NoopExecutor) RunShard(
 	return &model.RunCommandResult{}, nil
 }
 
-func (e *NoopExecutor) CancelShard(ctx context.Context, shard model.JobShard) error {
-	return nil
-}
-
 // Compile-time check that Executor implements the Executor interface.
 var _ executor.Executor = (*NoopExecutor)(nil)

--- a/pkg/executor/python_wasm/executor.go
+++ b/pkg/executor/python_wasm/executor.go
@@ -83,13 +83,5 @@ func (e *Executor) RunShard(ctx context.Context, shard model.JobShard, resultsDi
 	return dockerExecutor.RunShard(ctx, shard, resultsDir)
 }
 
-func (e *Executor) CancelShard(ctx context.Context, shard model.JobShard) error {
-	dockerExecutor, err := e.executors.Get(ctx, model.EngineDocker)
-	if err != nil {
-		return err
-	}
-	return dockerExecutor.CancelShard(ctx, shard)
-}
-
 // Compile-time check that Executor implements the Executor interface.
 var _ executor.Executor = (*Executor)(nil)

--- a/pkg/executor/types.go
+++ b/pkg/executor/types.go
@@ -31,10 +31,4 @@ type Executor interface {
 		shard model.JobShard,
 		resultsDir string,
 	) (*model.RunCommandResult, error)
-
-	// Cancel a running shard.
-	CancelShard(
-		ctx context.Context,
-		shard model.JobShard,
-	) error
 }

--- a/pkg/executor/wasm/executor.go
+++ b/pkg/executor/wasm/executor.go
@@ -263,10 +263,5 @@ func (e *Executor) RunShard(
 	return executor.WriteJobResults(jobResultsDir, stdout, stderr, exitCode, wasmErr)
 }
 
-func (e *Executor) CancelShard(ctx context.Context, shard model.JobShard) error {
-	// TODO: Implement CancelShard for WASM executor #1060
-	return nil
-}
-
 // Compile-time check that Executor implements the Executor interface.
 var _ executor.Executor = (*Executor)(nil)


### PR DESCRIPTION
Our previous approach to cancellation required a CancelShard method to be defined for all executors. One thing this doesn't allow is cancelling jobs by cancelling the supplied context. For the Docker executor this works fine because stopping the Docker container will trigger an error that ends the waiting. For other executors this isn't generically possible.

This commit implements generic cancellation by just cancelling the shard's context. This has the added benefit of also cancelling any the shard during set up if we are still doing that.