### PR TITLE
Add 'Station Mode' to logging options for integration with Station 

### DIFF
--- a/cmd/bacalhau/flags.go
+++ b/cmd/bacalhau/flags.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/filecoin-project/bacalhau/pkg/job"
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/filecoin-project/bacalhau/pkg/storage/url/urldownload"
 	"github.com/spf13/pflag"
@@ -224,6 +225,15 @@ func NetworkFlag(value *model.Network) *ValueFlag[model.Network] {
 		parser:   model.ParseNetwork,
 		stringer: func(n *model.Network) string { return n.String() },
 		typeStr:  "network-type",
+	}
+}
+
+func LoggingFlag(value *logger.Logmode) *ValueFlag[logger.Logmode] {
+	return &ValueFlag[logger.Logmode]{
+		value:    value,
+		parser:   logger.ParseLogmode,
+		stringer: func(p *logger.Logmode) string { return string(*p) },
+		typeStr:  "logging-mode",
 	}
 }
 

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -25,10 +25,11 @@ func TestConfigureLogging(t *testing.T) {
 	})
 
 	var logging strings.Builder
-	configureLogging(func(w *zerolog.ConsoleWriter) {
+	configureLogging(zerolog.NewConsoleWriter(func(w *zerolog.ConsoleWriter) {
+		defaultLogFormat(w)
 		w.Out = &logging
 		w.NoColor = true
-	})
+	}))
 
 	subsubpackage.TestLog("testing error logging", "testing message")
 
@@ -45,10 +46,11 @@ func TestConfigureLogging(t *testing.T) {
 // TestConfigureIpfsLogging checks that we configure IPFS logging correctly, forwarding logging to zerolog.
 func TestConfigureIpfsLogging(t *testing.T) {
 	var logging strings.Builder
-	configureLogging(func(w *zerolog.ConsoleWriter) {
+	configureLogging(zerolog.NewConsoleWriter(func(w *zerolog.ConsoleWriter) {
+		defaultLogFormat(w)
 		w.Out = &logging
 		w.NoColor = true
-	})
+	}))
 
 	l := ipfslog2.Logger("name")
 	l.With("hello", "world", "err", errors.New("example")).Error("test")

--- a/pkg/transport/bprotocol/compute_handler.go
+++ b/pkg/transport/bprotocol/compute_handler.go
@@ -36,7 +36,7 @@ func NewComputeHandler(params ComputeHandlerParams) *ComputeHandler {
 	handler.host.SetStreamHandler(ResultAcceptedProtocolID, handler.onResultAccepted)
 	handler.host.SetStreamHandler(ResultRejectedProtocolID, handler.onResultRejected)
 	handler.host.SetStreamHandler(CancelProtocolID, handler.onCancelJob)
-	log.Info().Msgf("ComputeHandler started on host %s", handler.host.ID().String())
+	log.Debug().Msgf("ComputeHandler started on host %s", handler.host.ID().String())
 	return handler
 }
 


### PR DESCRIPTION
Add loggingMode flag for station, JSON, combined and event. Station required a different logging format to the default, so a CLI flag was added, rather than an environment variable, which can't be configured differently for each module.
CLI flags take priority over environment variables, which should make life easier for station users.

resolves #1767 