### PR TITLE
Improve the naming of the distributed traces

### DIFF
--- a/cmd/bacalhau/create.go
+++ b/cmd/bacalhau/create.go
@@ -87,7 +87,7 @@ func create(cmd *cobra.Command, cmdArgs []string, OC *CreateOptions) error { //n
 	defer cm.Cleanup()
 	ctx := cmd.Context()
 
-	ctx, rootSpan := system.NewRootSpan(ctx, system.GetTracer(), "cmd/bacalhau/create")
+	ctx, rootSpan := system.NewRootSpan(ctx, system.GetTracer(), "cmd/bacalhau.create")
 	defer rootSpan.End()
 	cm.RegisterCallback(telemetry.Cleanup)
 

--- a/cmd/bacalhau/describe.go
+++ b/cmd/bacalhau/describe.go
@@ -86,7 +86,7 @@ func describe(cmd *cobra.Command, cmdArgs []string, OD *DescribeOptions) error {
 		Fatal(cmd, fmt.Sprintf("Failed to parse flags: %v\n", err), 1)
 	}
 
-	ctx, rootSpan := system.NewRootSpan(ctx, system.GetTracer(), "cmd/bacalhau/describe")
+	ctx, rootSpan := system.NewRootSpan(ctx, system.GetTracer(), "cmd/bacalhau.describe")
 	defer rootSpan.End()
 	cm.RegisterCallback(telemetry.Cleanup)
 

--- a/cmd/bacalhau/devstack.go
+++ b/cmd/bacalhau/devstack.go
@@ -131,7 +131,7 @@ func runDevstack(cmd *cobra.Command, ODs *devstack.DevStackOptions, OS *ServeOpt
 	defer cm.Cleanup()
 	ctx := cmd.Context()
 
-	ctx, rootSpan := system.NewRootSpan(ctx, system.GetTracer(), "cmd/bacalhau/devstack")
+	ctx, rootSpan := system.NewRootSpan(ctx, system.GetTracer(), "cmd/bacalhau.runDevstack")
 	defer rootSpan.End()
 
 	cm.RegisterCallback(telemetry.Cleanup)

--- a/cmd/bacalhau/docker_run.go
+++ b/cmd/bacalhau/docker_run.go
@@ -1,7 +1,6 @@
 package bacalhau
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -285,11 +284,11 @@ func dockerRun(cmd *cobra.Command, cmdArgs []string, ODR *DockerRunOptions) erro
 	defer cm.Cleanup()
 	ctx := cmd.Context()
 
-	ctx, rootSpan := system.NewRootSpan(ctx, system.GetTracer(), "cmd/bacalhau/dockerRun")
+	ctx, rootSpan := system.NewRootSpan(ctx, system.GetTracer(), "cmd/bacalhau.dockerRun")
 	defer rootSpan.End()
 	cm.RegisterCallback(telemetry.Cleanup)
 
-	j, err := CreateJob(ctx, cmdArgs, ODR)
+	j, err := CreateJob(cmdArgs, ODR)
 	if err != nil {
 		Fatal(cmd, fmt.Sprintf("Error creating job: %s", err), 1)
 		return nil
@@ -335,13 +334,7 @@ func dockerRun(cmd *cobra.Command, cmdArgs []string, ODR *DockerRunOptions) erro
 }
 
 // CreateJob creates a job object from the given command line arguments and options.
-func CreateJob(ctx context.Context,
-	cmdArgs []string,
-	odr *DockerRunOptions) (*model.Job, error) {
-	//nolint:ineffassign,staticcheck
-	_, span := system.GetTracer().Start(ctx, "cmd/bacalhau/dockerRun.ProcessAndExecuteJob")
-	defer span.End()
-
+func CreateJob(cmdArgs []string, odr *DockerRunOptions) (*model.Job, error) {
 	odr.Image = cmdArgs[0]
 	odr.Entrypoint = cmdArgs[1:]
 

--- a/cmd/bacalhau/get.go
+++ b/cmd/bacalhau/get.go
@@ -64,7 +64,7 @@ func get(cmd *cobra.Command, cmdArgs []string, OG *GetOptions) error {
 	defer cm.Cleanup()
 	ctx := cmd.Context()
 
-	ctx, span := system.NewRootSpan(ctx, system.GetTracer(), "cmd/bacalhau/get")
+	ctx, span := system.NewRootSpan(ctx, system.GetTracer(), "cmd/bacalhau.get")
 	defer span.End()
 	cm.RegisterCallback(telemetry.Cleanup)
 

--- a/cmd/bacalhau/list.go
+++ b/cmd/bacalhau/list.go
@@ -1,7 +1,6 @@
 package bacalhau
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -153,7 +152,7 @@ func list(cmd *cobra.Command, OL *ListOptions) error {
 	defer cm.Cleanup()
 	ctx := cmd.Context()
 
-	ctx, rootSpan := system.NewRootSpan(ctx, system.GetTracer(), "cmd/bacalhau/list")
+	ctx, rootSpan := system.NewRootSpan(ctx, system.GetTracer(), "cmd/bacalhau.list")
 	defer rootSpan.End()
 	cm.RegisterCallback(telemetry.Cleanup)
 
@@ -203,7 +202,7 @@ func list(cmd *cobra.Command, OL *ListOptions) error {
 		var rows []table.Row
 		for _, j := range jobs {
 			var summaryRow table.Row
-			summaryRow, err = summarizeJob(ctx, j, OL)
+			summaryRow, err = summarizeJob(j, OL)
 			if err != nil {
 				Fatal(cmd, fmt.Sprintf("Error summarizing job: %s", err), 1)
 			}
@@ -241,11 +240,7 @@ func list(cmd *cobra.Command, OL *ListOptions) error {
 }
 
 // Renders job details into a table row
-func summarizeJob(ctx context.Context, j *model.Job, OL *ListOptions) (table.Row, error) {
-	//nolint:ineffassign,staticcheck // For tracing
-	ctx, span := system.GetTracer().Start(ctx, "cmd/bacalhau/list.summarizeJob")
-	defer span.End()
-
+func summarizeJob(j *model.Job, OL *ListOptions) (table.Row, error) {
 	jobDesc := []string{
 		j.Spec.Engine.String(),
 	}

--- a/cmd/bacalhau/run_python.go
+++ b/cmd/bacalhau/run_python.go
@@ -169,7 +169,7 @@ func runPython(cmd *cobra.Command, cmdArgs []string, OLR *LanguageRunOptions) er
 	defer cm.Cleanup()
 	ctx := cmd.Context()
 
-	ctx, rootSpan := system.NewRootSpan(ctx, system.GetTracer(), "cmd/bacalhau/list")
+	ctx, rootSpan := system.NewRootSpan(ctx, system.GetTracer(), "cmd/bacalhau.runPython")
 	defer rootSpan.End()
 	cm.RegisterCallback(telemetry.Cleanup)
 

--- a/cmd/bacalhau/serve.go
+++ b/cmd/bacalhau/serve.go
@@ -314,7 +314,7 @@ func serve(cmd *cobra.Command, OS *ServeOptions) error {
 	ctx, cancel := signal.NotifyContext(cmd.Context(), ShutdownSignals...)
 	defer cancel()
 
-	ctx, rootSpan := system.NewRootSpan(ctx, system.GetTracer(), "cmd/bacalhau/serve")
+	ctx, rootSpan := system.NewRootSpan(ctx, system.GetTracer(), "cmd/bacalhau.serve")
 	defer rootSpan.End()
 
 	isComputeNode, isRequesterNode := false, false

--- a/cmd/bacalhau/utils.go
+++ b/cmd/bacalhau/utils.go
@@ -293,8 +293,6 @@ func ExecuteJob(ctx context.Context,
 	downloadSettings model.DownloaderSettings,
 ) error {
 	var apiClient *publicapi.RequesterAPIClient
-	ctx, span := system.GetTracer().Start(ctx, "cmd/bacalhau/utils.ExecuteJob")
-	defer span.End()
 
 	if runtimeSettings.IsLocal {
 		stack, errLocalDevStack := devstack.NewDevStackForRunLocal(ctx, cm, 1, capacity.ConvertGPUString(j.Spec.Resources.GPU))
@@ -497,9 +495,6 @@ func submitJob(ctx context.Context,
 	apiClient *publicapi.RequesterAPIClient,
 	j *model.Job,
 ) (*model.Job, error) {
-	ctx, span := system.GetTracer().Start(ctx, "cmd/bacalhau/utils.submitJob")
-	defer span.End()
-
 	j, err := apiClient.Submit(ctx, j)
 	if err != nil {
 		return &model.Job{}, errors.Wrap(err, "failed to submit job")

--- a/cmd/bacalhau/version.go
+++ b/cmd/bacalhau/version.go
@@ -70,7 +70,7 @@ func runVersion(cmd *cobra.Command, oV *VersionOptions) error {
 	defer cm.Cleanup()
 	ctx := cmd.Context()
 
-	ctx, rootSpan := system.NewRootSpan(ctx, system.GetTracer(), "cmd/bacalhau/version")
+	ctx, rootSpan := system.NewRootSpan(ctx, system.GetTracer(), "cmd/bacalhau.version")
 	defer rootSpan.End()
 	cm.RegisterCallback(telemetry.Cleanup)
 

--- a/cmd/bacalhau/wasm_run.go
+++ b/cmd/bacalhau/wasm_run.go
@@ -162,7 +162,7 @@ func runWasm(
 	cm := system.NewCleanupManager()
 	defer cm.Cleanup()
 
-	ctx, rootSpan := system.NewRootSpan(cmd.Context(), system.GetTracer(), "cmd/bacalhau/wasm_run.runWasmCommand")
+	ctx, rootSpan := system.NewRootSpan(cmd.Context(), system.GetTracer(), "cmd/bacalhau.runWasm")
 	defer rootSpan.End()
 	cm.RegisterCallback(telemetry.Cleanup)
 
@@ -258,7 +258,7 @@ func validateWasm(cmd *cobra.Command, args []string, wasmJob *model.Job) error {
 	cm := system.NewCleanupManager()
 	defer cm.Cleanup()
 
-	ctx, rootSpan := system.NewRootSpan(cmd.Context(), system.GetTracer(), "cmd/bacalhau/wasm_run.validateWasmCommand")
+	ctx, rootSpan := system.NewRootSpan(cmd.Context(), system.GetTracer(), "cmd/bacalhau.validateWasm")
 	defer rootSpan.End()
 	cm.RegisterCallback(telemetry.Cleanup)
 

--- a/dashboard/api/cmd/dashboard/serve.go
+++ b/dashboard/api/cmd/dashboard/serve.go
@@ -88,7 +88,7 @@ func serve(cmd *cobra.Command, options *ServeOptions) error {
 	ctx, cancel := signal.NotifyContext(ctx, os.Interrupt)
 	defer cancel()
 
-	ctx, rootSpan := system.NewRootSpan(ctx, system.GetTracer(), "dashboard/api/cmd/dashboard/serve")
+	ctx, rootSpan := system.NewRootSpan(ctx, system.GetTracer(), "dashboard/api/cmd/dashboard.serve")
 	defer rootSpan.End()
 
 	model, err := model.NewModelAPI(options.ModelOptions)

--- a/pkg/compute/endpoint.go
+++ b/pkg/compute/endpoint.go
@@ -46,7 +46,7 @@ func (s BaseEndpoint) GetNodeID() string {
 }
 
 func (s BaseEndpoint) AskForBid(ctx context.Context, request AskForBidRequest) (AskForBidResponse, error) {
-	ctx, span := s.newSpan(ctx, "AskForBid")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/compute.BaseEndpoint.AskForBid", trace.WithSpanKind(trace.SpanKindInternal))
 	defer span.End()
 	log.Ctx(ctx).Debug().Msgf("asked to bid on: %+v", request)
 	jobsReceived.Add(ctx, 1)
@@ -271,12 +271,6 @@ func (s BaseEndpoint) CancelExecution(ctx context.Context, request CancelExecuti
 	return CancelExecutionResponse{
 		ExecutionMetadata: NewExecutionMetadata(execution),
 	}, nil
-}
-
-func (s BaseEndpoint) newSpan(ctx context.Context, name string) (context.Context, trace.Span) {
-	return system.Span(ctx, "pkg/compute/node", name,
-		trace.WithSpanKind(trace.SpanKindInternal),
-	)
 }
 
 // Compile-time interface check:

--- a/pkg/compute/executor_buffer.go
+++ b/pkg/compute/executor_buffer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/filecoin-project/bacalhau/pkg/compute/capacity"
 	"github.com/filecoin-project/bacalhau/pkg/compute/store"
 	"github.com/filecoin-project/bacalhau/pkg/logger"
+	"github.com/filecoin-project/bacalhau/pkg/system"
 )
 
 type bufferTask struct {
@@ -121,6 +122,11 @@ func (s *ExecutorBuffer) Run(ctx context.Context, execution store.Execution) (er
 
 // doRun triggers the execution by the delegate backend.Executor and frees up the capacity when the execution is done.
 func (s *ExecutorBuffer) doRun(ctx context.Context, task *bufferTask) {
+	ctx = system.AddJobIDToBaggage(ctx, task.execution.Shard.Job.Metadata.ID)
+	ctx = system.AddNodeIDToBaggage(ctx, s.ID)
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/compute.ExecutorBuffer.Run")
+	defer span.End()
+
 	timeout := task.execution.Shard.Job.Spec.GetTimeout()
 	if timeout == 0 {
 		timeout = s.defaultJobExecutionTimeout
@@ -186,18 +192,28 @@ func (s *ExecutorBuffer) deque() {
 	s.backoffUntil = time.Now().Add(s.backoffDuration)
 }
 
-func (s *ExecutorBuffer) Publish(ctx context.Context, execution store.Execution) error {
+func (s *ExecutorBuffer) Publish(_ context.Context, execution store.Execution) error {
 	// TODO: Enqueue publish tasks
 	go func() {
-		_ = s.delegateService.Publish(logger.ContextWithNodeIDLogger(context.Background(), s.ID), execution)
+		ctx := logger.ContextWithNodeIDLogger(context.Background(), s.ID)
+		ctx = system.AddJobIDToBaggage(ctx, execution.Shard.Job.Metadata.ID)
+		ctx = system.AddNodeIDToBaggage(ctx, s.ID)
+		ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/compute.ExecutorBuffer.Publish")
+		defer span.End()
+		_ = s.delegateService.Publish(ctx, execution)
 	}()
 	return nil
 }
 
-func (s *ExecutorBuffer) Cancel(ctx context.Context, execution store.Execution) error {
+func (s *ExecutorBuffer) Cancel(_ context.Context, execution store.Execution) error {
 	// TODO: Enqueue cancel tasks
 	go func() {
-		_ = s.delegateService.Cancel(logger.ContextWithNodeIDLogger(context.Background(), s.ID), execution)
+		ctx := logger.ContextWithNodeIDLogger(context.Background(), s.ID)
+		ctx = system.AddJobIDToBaggage(ctx, execution.Shard.Job.Metadata.ID)
+		ctx = system.AddNodeIDToBaggage(ctx, s.ID)
+		ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/compute.ExecutorBuffer.Cancel")
+		defer span.End()
+		_ = s.delegateService.Cancel(ctx, execution)
 	}()
 	return nil
 }

--- a/pkg/compute/publicapi/client.go
+++ b/pkg/compute/publicapi/client.go
@@ -26,7 +26,7 @@ func NewComputeAPIClientFromClient(baseClient *publicapi.APIClient) *ComputeAPIC
 }
 
 func (apiClient *ComputeAPIClient) Debug(ctx context.Context) (map[string]model.DebugInfo, error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/publicapi.Debug")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/compute/publicapi.ComputeAPIClient.Debug")
 	defer span.End()
 
 	req := struct{}{}

--- a/pkg/compute/publicapi/endpoint_debug.go
+++ b/pkg/compute/publicapi/endpoint_debug.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/filecoin-project/bacalhau/pkg/system"
 	"github.com/rs/zerolog/log"
 )
 
@@ -18,14 +17,11 @@ import (
 //	@Failure	500	{object}	string
 //	@Router		/debug [get]
 func (s *ComputeAPIServer) debug(res http.ResponseWriter, req *http.Request) {
-	ctx, span := system.GetSpanFromRequest(req, "apiServer/debug")
-	defer span.End()
-
 	debugInfoMap := make(map[string]interface{})
 	for _, provider := range s.debugInfoProviders {
 		debugInfo, err := provider.GetDebugInfo()
 		if err != nil {
-			log.Ctx(ctx).Error().Msgf("could not get debug info from some providers: %s", err)
+			log.Ctx(req.Context()).Error().Msgf("could not get debug info from some providers: %s", err)
 			continue
 		}
 		debugInfoMap[debugInfo.Component] = debugInfo.Info

--- a/pkg/devstack/devstack.go
+++ b/pkg/devstack/devstack.go
@@ -106,7 +106,7 @@ func NewDevStack(
 	injector node.NodeDependencyInjector,
 	nodeOverrides ...node.NodeConfig,
 ) (*DevStack, error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/devstack.newdevstack")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/devstack.NewDevStack")
 	defer span.End()
 
 	var nodes []*node.Node
@@ -346,7 +346,7 @@ func createIPFSNode(ctx context.Context,
 	cm *system.CleanupManager,
 	publicIPFSMode bool,
 	ipfsSwarmAddrs []string) (*ipfs.Node, error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/devstack.createipfsnode")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/devstack.createIPFSNode")
 	defer span.End()
 	//////////////////////////////////////
 	// IPFS

--- a/pkg/devstack/lotus.go
+++ b/pkg/devstack/lotus.go
@@ -16,7 +16,6 @@ import (
 	"github.com/docker/go-connections/nat"
 	"github.com/filecoin-project/bacalhau/pkg/docker"
 	"github.com/filecoin-project/bacalhau/pkg/storage/util"
-	"github.com/filecoin-project/bacalhau/pkg/system"
 	"github.com/filecoin-project/bacalhau/pkg/util/closer"
 	"github.com/hashicorp/go-multierror"
 	"github.com/rs/zerolog/log"
@@ -37,9 +36,6 @@ type LotusNode struct {
 }
 
 func newLotusNode(ctx context.Context) (*LotusNode, error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/devstack.newlotusnode")
-	defer span.End()
-
 	image := defaultImage
 	if e, ok := os.LookupEnv("LOTUS_TEST_IMAGE"); ok {
 		image = e
@@ -64,9 +60,6 @@ func newLotusNode(ctx context.Context) (*LotusNode, error) {
 // start performs the work of actually starting the Lotus container. This is separated from the constructor so the user
 // can cancel and still have the container, which may not be healthy yet, cleaned up via Close.
 func (l *LotusNode) start(ctx context.Context) error {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/devstack.start")
-	defer span.End()
-
 	uploadDir, err := os.MkdirTemp("", "bacalhau-lotus-upload-dir")
 	if err != nil {
 		return err
@@ -129,9 +122,6 @@ func (l *LotusNode) start(ctx context.Context) error {
 }
 
 func (l *LotusNode) waitForLotusToBeHealthy(ctx context.Context) error {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/devstack.waitforlotustobehealthy")
-	defer span.End()
-
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute) //nolint:gomnd
 	defer cancel()
 

--- a/pkg/downloader/download.go
+++ b/pkg/downloader/download.go
@@ -42,7 +42,7 @@ func DownloadJob( //nolint:funlen,gocyclo
 	downloadProvider DownloaderProvider,
 	settings *model.DownloaderSettings,
 ) error {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/ipfs.DownloadJob")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/downloader.DownloadJob")
 	defer span.End()
 
 	if len(publishedShardResults) == 0 {

--- a/pkg/downloader/estuary/downloader.go
+++ b/pkg/downloader/estuary/downloader.go
@@ -32,7 +32,7 @@ func (downloader *Downloader) IsInstalled(ctx context.Context) (bool, error) {
 }
 
 func (downloader *Downloader) FetchResult(ctx context.Context, result model.PublishedResult, downloadPath string) error {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/downloader.estuary.FetchResult")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/downloader.estuary.FetchResult")
 	defer span.End()
 
 	// fallback to ipfs download for old results without URL

--- a/pkg/downloader/ipfs/downloader.go
+++ b/pkg/downloader/ipfs/downloader.go
@@ -25,12 +25,12 @@ func NewIPFSDownloader(cm *system.CleanupManager, settings *model.DownloaderSett
 	}
 }
 
-func (ipfsDownloader *Downloader) IsInstalled(ctx context.Context) (bool, error) {
+func (ipfsDownloader *Downloader) IsInstalled(context.Context) (bool, error) {
 	return true, nil
 }
 
 func (ipfsDownloader *Downloader) FetchResult(ctx context.Context, result model.PublishedResult, downloadPath string) error {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/downloadClient.ipfs.FetchResult")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/downloader/ipfs.Downloader.FetchResult")
 	defer span.End()
 
 	// NOTE: we have to spin up a temporary IPFS node as we don't
@@ -76,9 +76,6 @@ func spinUpIPFSNode(
 	cm *system.CleanupManager,
 	ipfsSwarmAddrs string,
 ) (*ipfs.Node, error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/ipfs.DownloadJob.SpinningUpIPFS")
-	defer span.End()
-
 	log.Ctx(ctx).Debug().Msg("Spinning up IPFS node...")
 	n, err := ipfs.NewNode(ctx, cm, strings.Split(ipfsSwarmAddrs, ","))
 	if err != nil {

--- a/pkg/eventhandler/chained_handlers.go
+++ b/pkg/eventhandler/chained_handlers.go
@@ -16,10 +16,10 @@ import (
 // TODO: use generics when they are available instead of two separate types for local and job event handlers.
 type ChainedLocalEventHandler struct {
 	eventHandlers   []LocalEventHandler
-	contextProvider system.ContextProvider
+	contextProvider ContextProvider
 }
 
-func NewChainedLocalEventHandler(contextProvider system.ContextProvider) *ChainedLocalEventHandler {
+func NewChainedLocalEventHandler(contextProvider ContextProvider) *ChainedLocalEventHandler {
 	return &ChainedLocalEventHandler{contextProvider: contextProvider}
 }
 
@@ -46,10 +46,10 @@ func (r *ChainedLocalEventHandler) HandleLocalEvent(ctx context.Context, event m
 // Job event handler chain
 type ChainedJobEventHandler struct {
 	eventHandlers   []JobEventHandler
-	contextProvider system.ContextProvider
+	contextProvider ContextProvider
 }
 
-func NewChainedJobEventHandler(contextProvider system.ContextProvider) *ChainedJobEventHandler {
+func NewChainedJobEventHandler(contextProvider ContextProvider) *ChainedJobEventHandler {
 	return &ChainedJobEventHandler{contextProvider: contextProvider}
 }
 

--- a/pkg/executor/docker/executor.go
+++ b/pkg/executor/docker/executor.go
@@ -81,7 +81,7 @@ func (e *Executor) IsInstalled(ctx context.Context) (bool, error) {
 
 func (e *Executor) HasStorageLocally(ctx context.Context, volume model.StorageSpec) (bool, error) {
 	//nolint:ineffassign,staticcheck
-	ctx, span := system.GetTracer().Start(ctx, "pkg/executor/docker/Executor.HasStorageLocally")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/executor/docker.Executor.HasStorageLocally")
 	defer span.End()
 
 	s, err := e.getStorage(ctx, volume.StorageSource)
@@ -107,10 +107,8 @@ func (e *Executor) RunShard(
 	jobResultsDir string,
 ) (*model.RunCommandResult, error) {
 	//nolint:ineffassign,staticcheck
-	ctx, span := system.GetTracer().Start(ctx, "pkg/executor/docker.RunShard")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/executor/docker.Executor.RunShard")
 	defer span.End()
-	system.AddJobIDFromBaggageToSpan(ctx, span)
-	system.AddNodeIDFromBaggageToSpan(ctx, span)
 	defer e.cleanupJob(ctx, shard)
 
 	shardStorageSpec, err := jobutils.GetShardStorageSpec(ctx, shard, e.StorageProvider)

--- a/pkg/executor/util/utils.go
+++ b/pkg/executor/util/utils.go
@@ -17,6 +17,7 @@ import (
 	"github.com/filecoin-project/bacalhau/pkg/storage/inline"
 	ipfs_storage "github.com/filecoin-project/bacalhau/pkg/storage/ipfs"
 	noop_storage "github.com/filecoin-project/bacalhau/pkg/storage/noop"
+	"github.com/filecoin-project/bacalhau/pkg/storage/tracing"
 	"github.com/filecoin-project/bacalhau/pkg/storage/url/urldownload"
 	"github.com/filecoin-project/bacalhau/pkg/system"
 )
@@ -33,7 +34,7 @@ type StandardExecutorOptions struct {
 }
 
 func NewStandardStorageProvider(
-	ctx context.Context,
+	_ context.Context,
 	cm *system.CleanupManager,
 	options StandardStorageProviderOptions,
 ) (storage.StorageProvider, error) {
@@ -92,10 +93,10 @@ func NewStandardStorageProvider(
 	}
 
 	return model.NewMappedProvider(map[model.StorageSourceType]storage.Storage{
-		model.StorageSourceIPFS:             useIPFSDriver,
-		model.StorageSourceURLDownload:      urlDownloadStorage,
-		model.StorageSourceFilecoinUnsealed: filecoinUnsealedStorage,
-		model.StorageSourceInline:           inlineStorage,
+		model.StorageSourceIPFS:             tracing.Wrap(useIPFSDriver),
+		model.StorageSourceURLDownload:      tracing.Wrap(urlDownloadStorage),
+		model.StorageSourceFilecoinUnsealed: tracing.Wrap(filecoinUnsealedStorage),
+		model.StorageSourceInline:           tracing.Wrap(inlineStorage),
 	}), nil
 }
 

--- a/pkg/executor/wasm/executor.go
+++ b/pkg/executor/wasm/executor.go
@@ -32,14 +32,12 @@ type Executor struct {
 }
 
 func NewExecutor(
-	ctx context.Context,
+	_ context.Context,
 	storageProvider storage.StorageProvider,
 ) (*Executor, error) {
-	executor := &Executor{
+	return &Executor{
 		StorageProvider: storageProvider,
-	}
-
-	return executor, nil
+	}, nil
 }
 
 func (e *Executor) IsInstalled(context.Context) (bool, error) {
@@ -48,7 +46,7 @@ func (e *Executor) IsInstalled(context.Context) (bool, error) {
 }
 
 func (e *Executor) HasStorageLocally(ctx context.Context, volume model.StorageSpec) (bool, error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/executor/wasm/Executor.HasStorageLocally")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/executor/wasm.Executor.HasStorageLocally")
 	defer span.End()
 
 	s, err := e.StorageProvider.Get(ctx, volume.StorageSource)
@@ -60,7 +58,7 @@ func (e *Executor) HasStorageLocally(ctx context.Context, volume model.StorageSp
 }
 
 func (e *Executor) GetVolumeSize(ctx context.Context, volume model.StorageSpec) (uint64, error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/executor/wasm/Executor.GetVolumeSize")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/executor/wasm.Executor.GetVolumeSize")
 	defer span.End()
 
 	storageProvider, err := e.StorageProvider.Get(ctx, volume.StorageSource)
@@ -139,7 +137,7 @@ func (e *Executor) RunShard(
 	shard model.JobShard,
 	jobResultsDir string,
 ) (*model.RunCommandResult, error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/executor/wasm/Executor.RunShard")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/executor/wasm.Executor.RunShard")
 	defer span.End()
 
 	engineConfig := wazero.NewRuntimeConfig()

--- a/pkg/ipfs/client.go
+++ b/pkg/ipfs/client.go
@@ -90,7 +90,7 @@ func (cl Client) WaitUntilAvailable(ctx context.Context) error {
 
 // ID returns the node's ipfs ID.
 func (cl Client) ID(ctx context.Context) (string, error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/ipfs.ID")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/ipfs.Client.ID")
 	defer span.End()
 
 	key, err := cl.API.Key().Self(ctx)
@@ -107,7 +107,7 @@ func (cl Client) APIAddress() string {
 }
 
 func (cl Client) SwarmMultiAddresses(ctx context.Context) ([]ma.Multiaddr, error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/ipfs.SwarmMultiAddresses")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/ipfs.Client.SwarmMultiAddresses")
 	defer span.End()
 
 	id, err := cl.API.Key().Self(ctx)
@@ -148,7 +148,7 @@ func (cl Client) SwarmAddresses(ctx context.Context) ([]string, error) {
 
 // Get fetches a file or directory from the ipfs network.
 func (cl Client) Get(ctx context.Context, cid, outputPath string) error {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/ipfs.Get")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/ipfs.Client.Get")
 	defer span.End()
 
 	// Output path is required to not exist yet:
@@ -175,7 +175,7 @@ func (cl Client) Get(ctx context.Context, cid, outputPath string) error {
 // Put uploads and pins a file or directory to the ipfs network. Timeouts and
 // cancellation should be handled by passing an appropriate context value.
 func (cl Client) Put(ctx context.Context, inputPath string) (string, error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/ipfs.Put")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/ipfs.Client.Put")
 	defer span.End()
 
 	st, err := os.Stat(inputPath)
@@ -216,7 +216,7 @@ type StatResult struct {
 
 // Stat returns information about an IPLD CID on the ipfs network.
 func (cl Client) Stat(ctx context.Context, cid string) (*StatResult, error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/ipfs.Stat")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/ipfs.Client.Stat")
 	defer span.End()
 
 	node, err := cl.API.ResolveNode(ctx, icorepath.New(cid))
@@ -235,7 +235,7 @@ func (cl Client) Stat(ctx context.Context, cid string) (*StatResult, error) {
 }
 
 func (cl Client) GetCidSize(ctx context.Context, cid string) (uint64, error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/ipfs.GetCidSize")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/ipfs.Client.GetCidSize")
 	defer span.End()
 
 	stat, err := cl.API.Object().Stat(ctx, icorepath.New(cid))
@@ -248,7 +248,7 @@ func (cl Client) GetCidSize(ctx context.Context, cid string) (uint64, error) {
 
 // NodesWithCID returns the ipfs ids of nodes that have the given CID pinned.
 func (cl Client) NodesWithCID(ctx context.Context, cid string) ([]string, error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/ipfs.NodesWithCID")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/ipfs.Client.NodesWithCID")
 	defer span.End()
 
 	ch, err := cl.API.Dht().FindProviders(ctx, icorepath.New(cid))
@@ -266,7 +266,7 @@ func (cl Client) NodesWithCID(ctx context.Context, cid string) ([]string, error)
 
 // HasCID returns true if the node has the given CID locally, whether pinned or not.
 func (cl Client) HasCID(ctx context.Context, cid string) (bool, error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/ipfs.HasCID")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/ipfs.Client.HasCID")
 	defer span.End()
 
 	id, err := cl.ID(ctx)
@@ -289,7 +289,7 @@ func (cl Client) HasCID(ctx context.Context, cid string) (bool, error) {
 }
 
 func (cl Client) GetTreeNode(ctx context.Context, cid string) (IPLDTreeNode, error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/ipfs.GetTreeNode")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/ipfs.Client.GetTreeNode")
 	defer span.End()
 
 	ipldNode, err := cl.API.ResolveNode(ctx, icorepath.New(cid))

--- a/pkg/localdb/inmemory/inmemory.go
+++ b/pkg/localdb/inmemory/inmemory.go
@@ -47,8 +47,7 @@ func NewInMemoryDatastore() (*InMemoryDatastore, error) {
 //
 //   - error-job-not-found        		  -- if the job is not found
 func (d *InMemoryDatastore) GetJob(ctx context.Context, id string) (*model.Job, error) {
-	//nolint:ineffassign,staticcheck
-	ctx, span := system.GetTracer().Start(ctx, "pkg/localdb/inmemory/InMemoryDatastore.GetJob")
+	_, span := system.NewSpan(ctx, system.GetTracer(), "pkg/localdb/inmemory.InMemoryDatastore.GetJob")
 	defer span.End()
 
 	d.mtx.RLock()
@@ -62,8 +61,7 @@ func (d *InMemoryDatastore) GetJob(ctx context.Context, id string) (*model.Job, 
 //
 //   - error-job-not-found        		  -- if the job is not found
 func (d *InMemoryDatastore) GetJobEvents(ctx context.Context, id string) ([]model.JobEvent, error) {
-	//nolint:ineffassign,staticcheck
-	ctx, span := system.GetTracer().Start(ctx, "pkg/localdb/inmemory/InMemoryDatastore.GetJobEvents")
+	_, span := system.NewSpan(ctx, system.GetTracer(), "pkg/localdb/inmemory.InMemoryDatastore.GetJobEvents")
 	defer span.End()
 
 	d.mtx.RLock()
@@ -80,8 +78,7 @@ func (d *InMemoryDatastore) GetJobEvents(ctx context.Context, id string) ([]mode
 }
 
 func (d *InMemoryDatastore) GetJobLocalEvents(ctx context.Context, id string) ([]model.JobLocalEvent, error) {
-	//nolint:ineffassign,staticcheck
-	ctx, span := system.GetTracer().Start(ctx, "pkg/localdb/inmemory/InMemoryDatastore.GetJobLocalEvents")
+	_, span := system.NewSpan(ctx, system.GetTracer(), "pkg/localdb/inmemory.InMemoryDatastore.GetJobLocalEvents")
 	defer span.End()
 
 	d.mtx.RLock()
@@ -98,7 +95,7 @@ func (d *InMemoryDatastore) GetJobLocalEvents(ctx context.Context, id string) ([
 }
 
 func (d *InMemoryDatastore) GetJobs(ctx context.Context, query localdb.JobQuery) ([]*model.Job, error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/localdb/inmemory/InMemoryDatastore.GetJobs")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/localdb/inmemory.InMemoryDatastore.GetJobs")
 	defer span.End()
 
 	d.mtx.RLock()
@@ -196,7 +193,7 @@ func (d *InMemoryDatastore) HasLocalEvent(ctx context.Context, jobID string, eve
 
 func (d *InMemoryDatastore) AddJob(ctx context.Context, j *model.Job) error {
 	//nolint:ineffassign,staticcheck
-	ctx, span := system.GetTracer().Start(ctx, "pkg/localdb/inmemory/InMemoryDatastore.AddJob")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/localdb/inmemory.InMemoryDatastore.AddJob")
 	defer span.End()
 
 	d.mtx.Lock()
@@ -214,7 +211,7 @@ func (d *InMemoryDatastore) AddJob(ctx context.Context, j *model.Job) error {
 
 func (d *InMemoryDatastore) AddEvent(ctx context.Context, jobID string, ev model.JobEvent) error {
 	//nolint:ineffassign,staticcheck
-	ctx, span := system.GetTracer().Start(ctx, "pkg/localdb/inmemory/InMemoryDatastore.AddEvent")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/localdb/inmemory.InMemoryDatastore.AddEvent")
 	defer span.End()
 
 	d.mtx.Lock()
@@ -234,7 +231,7 @@ func (d *InMemoryDatastore) AddEvent(ctx context.Context, jobID string, ev model
 
 func (d *InMemoryDatastore) AddLocalEvent(ctx context.Context, jobID string, ev model.JobLocalEvent) error {
 	//nolint:ineffassign,staticcheck
-	ctx, span := system.GetTracer().Start(ctx, "pkg/localdb/inmemory/InMemoryDatastore.AddLocalEvent")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/localdb/inmemory.InMemoryDatastore.AddLocalEvent")
 	defer span.End()
 
 	d.mtx.Lock()
@@ -253,8 +250,7 @@ func (d *InMemoryDatastore) AddLocalEvent(ctx context.Context, jobID string, ev 
 }
 
 func (d *InMemoryDatastore) UpdateJobDeal(ctx context.Context, jobID string, deal model.Deal) error {
-	//nolint:ineffassign,staticcheck
-	ctx, span := system.GetTracer().Start(ctx, "pkg/localdb/inmemory/InMemoryDatastore.UpdateJobDeal")
+	_, span := system.NewSpan(ctx, system.GetTracer(), "pkg/localdb/inmemory.InMemoryDatastore.UpdateJobDeal")
 	defer span.End()
 
 	d.mtx.Lock()
@@ -268,10 +264,8 @@ func (d *InMemoryDatastore) UpdateJobDeal(ctx context.Context, jobID string, dea
 }
 
 func (d *InMemoryDatastore) GetJobState(ctx context.Context, jobID string) (model.JobState, error) {
-	//nolint:ineffassign,staticcheck
-	ctx, span := system.GetTracer().Start(ctx, "pkg/localdb/inmemory/InMemoryDatastore.GetJobState")
+	_, span := system.NewSpan(ctx, system.GetTracer(), "pkg/localdb/inmemory.InMemoryDatastore.GetJobState")
 	defer span.End()
-	system.AddJobIDFromBaggageToSpan(ctx, span)
 
 	d.mtx.RLock()
 	defer d.mtx.RUnlock()
@@ -294,8 +288,7 @@ func (d *InMemoryDatastore) UpdateShardState(
 	shardIndex int,
 	update model.JobShardState,
 ) error {
-	//nolint:ineffassign,staticcheck
-	ctx, span := system.GetTracer().Start(ctx, "pkg/localdb/inmemory/InMemoryDatastore.UpdateShardState")
+	_, span := system.NewSpan(ctx, system.GetTracer(), "pkg/localdb/inmemory.InMemoryDatastore.UpdateShardState")
 	defer span.End()
 
 	d.mtx.Lock()

--- a/pkg/node/requester.go
+++ b/pkg/node/requester.go
@@ -54,7 +54,7 @@ func NewRequesterNode(
 	nodeInfoStore routing.NodeInfoStore,
 ) (*Requester, error) {
 	// prepare event handlers
-	tracerContextProvider := system.NewTracerContextProvider(host.ID().String())
+	tracerContextProvider := eventhandler.NewTracerContextProvider(host.ID().String())
 	localJobEventConsumer := eventhandler.NewChainedJobEventHandler(tracerContextProvider)
 
 	// compute proxy
@@ -215,7 +215,7 @@ func NewRequesterNode(
 	)
 
 	// register consumers of job events publishes over gossipSub
-	networkJobEventConsumer := eventhandler.NewChainedJobEventHandler(system.NewNoopContextProvider())
+	networkJobEventConsumer := eventhandler.NewChainedJobEventHandler(eventhandler.NewNoopContextProvider())
 	networkJobEventConsumer.AddHandlers(
 		// update the job state in the local DB
 		localDBEventHandler,

--- a/pkg/publicapi/client.go
+++ b/pkg/publicapi/client.go
@@ -48,7 +48,7 @@ func NewAPIClient(baseURI string) *APIClient {
 
 // Alive calls the node's API server health check.
 func (apiClient *APIClient) Alive(ctx context.Context) (bool, error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/publicapi.Alive")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/publicapi.Client.Alive")
 	defer span.End()
 
 	var body io.Reader
@@ -66,7 +66,7 @@ func (apiClient *APIClient) Alive(ctx context.Context) (bool, error) {
 }
 
 func (apiClient *APIClient) Version(ctx context.Context) (*model.BuildVersionInfo, error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/publicapi.Version")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/publicapi.Client.Version")
 	defer span.End()
 
 	req := VersionRequest{
@@ -82,7 +82,7 @@ func (apiClient *APIClient) Version(ctx context.Context) (*model.BuildVersionInf
 }
 
 func (apiClient *APIClient) Post(ctx context.Context, api string, reqData, resData interface{}) error {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/publicapi.Post")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/publicapi.Client.Post")
 	defer span.End()
 
 	var body bytes.Buffer

--- a/pkg/publicapi/endpoint_id.go
+++ b/pkg/publicapi/endpoint_id.go
@@ -3,8 +3,6 @@ package publicapi
 import (
 	"encoding/json"
 	"net/http"
-
-	"github.com/filecoin-project/bacalhau/pkg/system"
 )
 
 // id godoc
@@ -16,10 +14,7 @@ import (
 //	@Success	200	{object}	string
 //	@Failure	500	{object}	string
 //	@Router		/id [get]
-func (apiServer *APIServer) id(res http.ResponseWriter, req *http.Request) {
-	_, span := system.GetSpanFromRequest(req, "apiServer/id")
-	defer span.End()
-
+func (apiServer *APIServer) id(res http.ResponseWriter, _ *http.Request) {
 	res.WriteHeader(http.StatusOK)
 	err := json.NewEncoder(res).Encode(apiServer.host.ID().String())
 	if err != nil {

--- a/pkg/publicapi/endpoint_node_info.go
+++ b/pkg/publicapi/endpoint_node_info.go
@@ -3,8 +3,6 @@ package publicapi
 import (
 	"encoding/json"
 	"net/http"
-
-	"github.com/filecoin-project/bacalhau/pkg/system"
 )
 
 // nodeInfo godoc
@@ -17,8 +15,6 @@ import (
 //	@Failure	500	{object}	string
 //	@Router		/node_info [get]
 func (apiServer *APIServer) nodeInfo(res http.ResponseWriter, req *http.Request) {
-	_, span := system.GetSpanFromRequest(req, "apiServer/node_info")
-	defer span.End()
 	res.WriteHeader(http.StatusOK)
 	err := json.NewEncoder(res).Encode(apiServer.nodeInfoProvider.GetNodeInfo(req.Context()))
 	if err != nil {

--- a/pkg/publicapi/endpoint_peers.go
+++ b/pkg/publicapi/endpoint_peers.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/filecoin-project/bacalhau/pkg/system"
 	"github.com/libp2p/go-libp2p/core/peer"
 )
 
@@ -18,9 +17,7 @@ import (
 //	@Success				200	{object}	[]peer.AddrInfo
 //	@Failure				500	{object}	string
 //	@Router					/peers [get]
-func (apiServer *APIServer) peers(res http.ResponseWriter, req *http.Request) {
-	_, span := system.GetSpanFromRequest(req, "apiServer/peers")
-	defer span.End()
+func (apiServer *APIServer) peers(res http.ResponseWriter, _ *http.Request) {
 	res.WriteHeader(http.StatusOK)
 	var peerInfos []peer.AddrInfo
 	for _, p := range apiServer.host.Peerstore().Peers() {

--- a/pkg/publicapi/endpoint_version.go
+++ b/pkg/publicapi/endpoint_version.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 
 	"github.com/filecoin-project/bacalhau/pkg/model"
-	"github.com/filecoin-project/bacalhau/pkg/system"
 	"github.com/filecoin-project/bacalhau/pkg/version"
 )
 
@@ -33,21 +32,13 @@ type VersionResponse struct {
 //
 //nolint:lll
 func (apiServer *APIServer) version(res http.ResponseWriter, req *http.Request) {
-	ctx, span := system.GetSpanFromRequest(req, "apiServer/version")
-	defer span.End()
-
-	t := system.GetTracer()
-
-	_, unMarshallSpan := t.Start(ctx, "unmarshallingversionrequest")
 	var versionReq VersionRequest
 	err := json.NewDecoder(req.Body).Decode(&versionReq)
 	if err != nil {
 		http.Error(res, err.Error(), http.StatusBadRequest)
 		return
 	}
-	unMarshallSpan.End()
 
-	_, respondingSpan := t.Start(ctx, "encodingversionresponse")
 	res.WriteHeader(http.StatusOK)
 	err = json.NewEncoder(res).Encode(VersionResponse{
 		VersionInfo: version.Get(),
@@ -56,5 +47,4 @@ func (apiServer *APIServer) version(res http.ResponseWriter, req *http.Request) 
 		http.Error(res, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	respondingSpan.End()
 }

--- a/pkg/publicapi/server.go
+++ b/pkg/publicapi/server.go
@@ -214,7 +214,12 @@ func (apiServer *APIServer) registerHandler(config HandlerConfig) error {
 	handler := config.Handler
 	if !config.Raw {
 		// otel handler
-		handler = otelhttp.NewHandler(config.Handler, fmt.Sprintf("pkg/publicapi%s", config.URI))
+		handler = otelhttp.NewHandler(config.Handler, config.URI,
+			otelhttp.WithPublicEndpoint(),
+			otelhttp.WithSpanNameFormatter(func(operation string, r *http.Request) string {
+				return fmt.Sprintf("%s %s", r.Method, operation)
+			}),
+		)
 
 		// throttling handler
 		handler = tollbooth.LimitHandler(

--- a/pkg/publisher/filecoin_lotus/api/api.go
+++ b/pkg/publisher/filecoin_lotus/api/api.go
@@ -157,79 +157,79 @@ type api struct {
 }
 
 func (a *api) ClientDealPieceCID(ctx context.Context, root cid.Cid) (DataCIDSize, error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/publisher/filecoin_lotus/api/ClientDealPieceCID")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/publisher/filecoin_lotus/api.api.ClientDealPieceCID")
 	defer span.End()
 	return a.internal.ClientDealPieceCID(ctx, root)
 }
 
 func (a *api) ClientExport(ctx context.Context, exportRef ExportRef, fileRef FileRef) error {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/publisher/filecoin_lotus/api/ClientExport")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/publisher/filecoin_lotus/api.api.ClientExport")
 	defer span.End()
 	return a.internal.ClientExport(ctx, exportRef, fileRef)
 }
 
 func (a *api) ClientGetDealUpdates(ctx context.Context) (<-chan DealInfo, error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/publisher/filecoin_lotus/api/ClientGetDealUpdates")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/publisher/filecoin_lotus/api.api.ClientGetDealUpdates")
 	defer span.End()
 	return a.internal.ClientGetDealUpdates(ctx)
 }
 
 func (a *api) ClientListImports(ctx context.Context) ([]Import, error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/publisher/filecoin_lotus/api/ClientListImports")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/publisher/filecoin_lotus/api.api.ClientListImports")
 	defer span.End()
 	return a.internal.ClientListImports(ctx)
 }
 
 func (a *api) ClientImport(ctx context.Context, ref FileRef) (*ImportRes, error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/publisher/filecoin_lotus/api/ClientImport")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/publisher/filecoin_lotus/api.api.ClientImport")
 	defer span.End()
 	return a.internal.ClientImport(ctx, ref)
 }
 
 func (a *api) ClientQueryAsk(ctx context.Context, p peer.ID, miner address.Address) (*StorageAsk, error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/publisher/filecoin_lotus/api/ClientQueryAsk")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/publisher/filecoin_lotus/api.api.ClientQueryAsk")
 	defer span.End()
 	return a.internal.ClientQueryAsk(ctx, p, miner)
 }
 
 func (a *api) ClientStartDeal(ctx context.Context, params *StartDealParams) (*cid.Cid, error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/publisher/filecoin_lotus/api/ClientStartDeal")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/publisher/filecoin_lotus/api.api.ClientStartDeal")
 	defer span.End()
 	return a.internal.ClientStartDeal(ctx, params)
 }
 
 func (a *api) StateGetNetworkParams(ctx context.Context) (*NetworkParams, error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/publisher/filecoin_lotus/api/StateGetNetworkParams")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/publisher/filecoin_lotus/api.api.StateGetNetworkParams")
 	defer span.End()
 	return a.internal.StateGetNetworkParams(ctx)
 }
 
 func (a *api) StateListMiners(ctx context.Context, key TipSetKey) ([]address.Address, error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/publisher/filecoin_lotus/api/StateListMiners")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/publisher/filecoin_lotus/api.api.StateListMiners")
 	defer span.End()
 	return a.internal.StateListMiners(ctx, key)
 }
 
 func (a *api) StateMinerInfo(ctx context.Context, a2 address.Address, key TipSetKey) (MinerInfo, error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/publisher/filecoin_lotus/api/StateMinerInfo")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/publisher/filecoin_lotus/api.api.StateMinerInfo")
 	defer span.End()
 	return a.internal.StateMinerInfo(ctx, a2, key)
 }
 
 func (a *api) StateMinerPower(ctx context.Context, a2 address.Address, key TipSetKey) (*MinerPower, error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/publisher/filecoin_lotus/api/StateMinerPower")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/publisher/filecoin_lotus/api.api.StateMinerPower")
 	defer span.End()
 	return a.internal.StateMinerPower(ctx, a2, key)
 }
 
 func (a *api) Version(ctx context.Context) (APIVersion, error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/publisher/filecoin_lotus/api/Version")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/publisher/filecoin_lotus/api.api.Version")
 	defer span.End()
 	return a.internal.Version(ctx)
 }
 
 func (a *api) WalletDefaultAddress(ctx context.Context) (address.Address, error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/publisher/filecoin_lotus/api/WalletDefaultAddress")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/publisher/filecoin_lotus/api.api.WalletDefaultAddress")
 	defer span.End()
 	return a.internal.WalletDefaultAddress(ctx)
 }

--- a/pkg/publisher/filecoin_lotus/publisher.go
+++ b/pkg/publisher/filecoin_lotus/publisher.go
@@ -44,9 +44,6 @@ func NewPublisher(
 	cm *system.CleanupManager,
 	config PublisherConfig,
 ) (*Publisher, error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/publisher/filecoin_lotus/NewPublisher")
-	defer span.End()
-
 	if config.StorageDuration == time.Duration(0) {
 		return nil, errors.New("StorageDuration is required")
 	}

--- a/pkg/publisher/ipfs/publisher.go
+++ b/pkg/publisher/ipfs/publisher.go
@@ -17,7 +17,7 @@ type IPFSPublisher struct {
 
 func NewIPFSPublisher(
 	ctx context.Context,
-	cm *system.CleanupManager,
+	_ *system.CleanupManager,
 	cl ipfs.Client,
 ) (*IPFSPublisher, error) {
 	log.Ctx(ctx).Debug().Msgf("IPFS publisher initialized for node: %s", cl.APIAddress())
@@ -37,8 +37,6 @@ func (publisher *IPFSPublisher) PublishShardResult(
 	hostID string,
 	shardResultPath string,
 ) (model.StorageSpec, error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/publisher/ipfs.PublishShardResult")
-	defer span.End()
 	cid, err := publisher.IPFSClient.Put(ctx, shardResultPath)
 	if err != nil {
 		return model.StorageSpec{}, err

--- a/pkg/publisher/noop/publisher.go
+++ b/pkg/publisher/noop/publisher.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/filecoin-project/bacalhau/pkg/publisher"
-	"github.com/filecoin-project/bacalhau/pkg/system"
 )
 
 type NoopPublisher struct{}
@@ -18,16 +17,7 @@ func (publisher *NoopPublisher) IsInstalled(context.Context) (bool, error) {
 	return true, nil
 }
 
-func (publisher *NoopPublisher) PublishShardResult(
-	ctx context.Context,
-	_ model.JobShard,
-	_ string,
-	_ string,
-) (model.StorageSpec, error) {
-	//nolint:staticcheck,ineffassign
-	ctx, span := system.GetTracer().Start(ctx, "pkg/publisher/noop.PublishShardResult")
-	defer span.End()
-
+func (publisher *NoopPublisher) PublishShardResult(context.Context, model.JobShard, string, string) (model.StorageSpec, error) {
 	return model.StorageSpec{}, nil
 }
 

--- a/pkg/publisher/tracing/tracing.go
+++ b/pkg/publisher/tracing/tracing.go
@@ -1,0 +1,41 @@
+package tracing
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/filecoin-project/bacalhau/pkg/model"
+	"github.com/filecoin-project/bacalhau/pkg/publisher"
+	"github.com/filecoin-project/bacalhau/pkg/system"
+	"github.com/filecoin-project/bacalhau/pkg/util/reflection"
+)
+
+type tracingPublisher struct {
+	delegate publisher.Publisher
+	name     string
+}
+
+func Wrap(delegate publisher.Publisher) publisher.Publisher {
+	return &tracingPublisher{
+		delegate: delegate,
+		name:     reflection.StructName(delegate),
+	}
+}
+
+func (t *tracingPublisher) IsInstalled(ctx context.Context) (bool, error) {
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), fmt.Sprintf("%s.IsInstalled", t.name))
+	defer span.End()
+
+	return t.delegate.IsInstalled(ctx)
+}
+
+func (t *tracingPublisher) PublishShardResult(
+	ctx context.Context, shard model.JobShard, hostID string, shardResultPath string,
+) (model.StorageSpec, error) {
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), fmt.Sprintf("%s.PublishShardResult", t.name))
+	defer span.End()
+
+	return t.delegate.PublishShardResult(ctx, shard, hostID, shardResultPath)
+}
+
+var _ publisher.Publisher = &tracingPublisher{}

--- a/pkg/publisher/util/utils.go
+++ b/pkg/publisher/util/utils.go
@@ -13,6 +13,7 @@ import (
 	filecoinlotus "github.com/filecoin-project/bacalhau/pkg/publisher/filecoin_lotus"
 	"github.com/filecoin-project/bacalhau/pkg/publisher/ipfs"
 	"github.com/filecoin-project/bacalhau/pkg/publisher/noop"
+	"github.com/filecoin-project/bacalhau/pkg/publisher/tracing"
 	"github.com/filecoin-project/bacalhau/pkg/system"
 )
 
@@ -53,10 +54,10 @@ func NewIPFSPublishers(
 	}
 
 	return model.NewMappedProvider(map[model.Publisher]publisher.Publisher{
-		model.PublisherNoop:     noopPublisher,
-		model.PublisherIpfs:     ipfsPublisher,
-		model.PublisherEstuary:  estuaryPublisher,
-		model.PublisherFilecoin: combo.NewPiggybackedPublisher(ipfsPublisher, lotus),
+		model.PublisherNoop:     tracing.Wrap(noopPublisher),
+		model.PublisherIpfs:     tracing.Wrap(ipfsPublisher),
+		model.PublisherEstuary:  tracing.Wrap(estuaryPublisher),
+		model.PublisherFilecoin: combo.NewPiggybackedPublisher(tracing.Wrap(ipfsPublisher), tracing.Wrap(lotus)),
 	}), nil
 }
 

--- a/pkg/pubsub/buffering_pubsub.go
+++ b/pkg/pubsub/buffering_pubsub.go
@@ -66,7 +66,7 @@ func NewBufferingPubSub[T any](params BufferingPubSubParams) *BufferingPubSub[T]
 }
 
 func (p *BufferingPubSub[T]) Publish(ctx context.Context, message T) error {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/pubsub/Buffering.Publish")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/pubsub.BufferingPubSub.Publish")
 	defer span.End()
 
 	payload, err := model.JSONMarshalWithMax(message)
@@ -161,7 +161,7 @@ func (p *BufferingPubSub[T]) Close(ctx context.Context) (err error) {
 
 // flush the buffer to the delegate pubsub
 func (p *BufferingPubSub[T]) flushBuffer(ctx context.Context, envelope BufferingEnvelope, oldestMessageTime time.Time) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/pubsub/Buffering.Publish")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/pubsub.BufferingPubSub.flushBuffer")
 	defer span.End()
 
 	log.Ctx(ctx).Trace().Msgf("flushing pubsub buffer after %s with %d messages, %d bytes",

--- a/pkg/pubsub/libp2p/pubsub.go
+++ b/pkg/pubsub/libp2p/pubsub.go
@@ -51,7 +51,7 @@ func NewPubSub[T any](params PubSubParams) (*PubSub[T], error) {
 }
 
 func (p *PubSub[T]) Publish(ctx context.Context, message T) error {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/pubsub/libp2p.Publish")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/pubsub/libp2p.Publish.Publish")
 	defer span.End()
 
 	payload, err := model.JSONMarshalWithMax(message)

--- a/pkg/requester/publicapi/client.go
+++ b/pkg/requester/publicapi/client.go
@@ -51,7 +51,7 @@ func (apiClient *RequesterAPIClient) List(
 	sortReverse bool,
 ) (
 	[]*model.Job, error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/publicapi.List")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/requester/publicapi.RequesterAPIClient.List")
 	defer span.End()
 
 	req := listRequest{
@@ -76,7 +76,7 @@ func (apiClient *RequesterAPIClient) List(
 
 // Get returns job data for a particular job ID. If no match is found, Get returns false with a nil error.
 func (apiClient *RequesterAPIClient) Get(ctx context.Context, jobID string) (*model.Job, bool, error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/publicapi.Get")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/requester/publicapi.RequesterAPIClient.Get")
 	defer span.End()
 
 	if jobID == "" {
@@ -96,7 +96,7 @@ func (apiClient *RequesterAPIClient) Get(ctx context.Context, jobID string) (*mo
 }
 
 func (apiClient *RequesterAPIClient) GetJobState(ctx context.Context, jobID string) (model.JobState, error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/publicapi.GetJobState")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/requester/publicapi.RequesterAPIClient.GetJobState")
 	defer span.End()
 
 	if jobID == "" {
@@ -140,7 +140,7 @@ func (apiClient *RequesterAPIClient) GetJobStateResolver() *job.StateResolver {
 }
 
 func (apiClient *RequesterAPIClient) GetEvents(ctx context.Context, jobID string) (events []model.JobEvent, err error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/publicapi.GetEvents")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/requester/publicapi.RequesterAPIClient.GetEvents")
 	defer span.End()
 
 	if jobID == "" {
@@ -174,7 +174,7 @@ func (apiClient *RequesterAPIClient) GetEvents(ctx context.Context, jobID string
 }
 
 func (apiClient *RequesterAPIClient) GetLocalEvents(ctx context.Context, jobID string) (localEvents []model.JobLocalEvent, err error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/publicapi.GetLocalEvents")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/requester/publicapi.RequesterAPIClient.GetLocalEvents")
 	defer span.End()
 
 	if jobID == "" {
@@ -195,7 +195,7 @@ func (apiClient *RequesterAPIClient) GetLocalEvents(ctx context.Context, jobID s
 }
 
 func (apiClient *RequesterAPIClient) GetResults(ctx context.Context, jobID string) (results []model.PublishedResult, err error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/publicapi.GetResults")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/requester/publicapi.RequesterAPIClient.GetResults")
 	defer span.End()
 
 	if jobID == "" {
@@ -220,7 +220,7 @@ func (apiClient *RequesterAPIClient) Submit(
 	ctx context.Context,
 	j *model.Job,
 ) (*model.Job, error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/publicapi.Submit")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/requester/publicapi.RequesterAPIClient.Submit")
 	defer span.End()
 
 	data := model.JobCreatePayload{
@@ -259,7 +259,7 @@ func (apiClient *RequesterAPIClient) Submit(
 }
 
 func (apiClient *RequesterAPIClient) Debug(ctx context.Context) (map[string]model.DebugInfo, error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/publicapi.Debug")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/requester/publicapi.RequesterAPIClient.Debug")
 	defer span.End()
 
 	req := struct{}{}

--- a/pkg/requester/publicapi/endpoint_debug.go
+++ b/pkg/requester/publicapi/endpoint_debug.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/filecoin-project/bacalhau/pkg/system"
 	"github.com/rs/zerolog/log"
 )
 
@@ -18,14 +17,11 @@ import (
 //	@Failure	500	{object}	string
 //	@Router		/requester/debug [get]
 func (s *RequesterAPIServer) debug(res http.ResponseWriter, req *http.Request) {
-	ctx, span := system.GetSpanFromRequest(req, "apiServer/debug")
-	defer span.End()
-
 	debugInfoMap := make(map[string]interface{})
 	for _, provider := range s.debugInfoProviders {
 		debugInfo, err := provider.GetDebugInfo()
 		if err != nil {
-			log.Ctx(ctx).Error().Msgf("could not get debug info from some providers: %s", err)
+			log.Ctx(req.Context()).Error().Msgf("could not get debug info from some providers: %s", err)
 			continue
 		}
 		debugInfoMap[debugInfo.Component] = debugInfo.Info

--- a/pkg/requester/publicapi/endpoints_list.go
+++ b/pkg/requester/publicapi/endpoints_list.go
@@ -9,7 +9,6 @@ import (
 	"github.com/filecoin-project/bacalhau/pkg/localdb"
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/filecoin-project/bacalhau/pkg/publicapi/handlerwrapper"
-	"github.com/filecoin-project/bacalhau/pkg/system"
 	"github.com/rs/zerolog/log"
 )
 
@@ -48,9 +47,7 @@ type ListResponse = listResponse
 //
 //nolint:lll
 func (s *RequesterAPIServer) list(res http.ResponseWriter, req *http.Request) {
-	ctx, span := system.GetSpanFromRequest(req, "pkg/publicapi.list")
-	defer span.End()
-
+	ctx := req.Context()
 	var listReq ListRequest
 	if err := json.NewDecoder(req.Body).Decode(&listReq); err != nil {
 		http.Error(res, err.Error(), http.StatusBadRequest)
@@ -87,9 +84,6 @@ func (s *RequesterAPIServer) list(res http.ResponseWriter, req *http.Request) {
 }
 
 func (s *RequesterAPIServer) getJobsList(ctx context.Context, listReq ListRequest) ([]*model.Job, error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/publicapi.list")
-	defer span.End()
-
 	list, err := s.localDB.GetJobs(ctx, localdb.JobQuery{
 		ClientID:    listReq.ClientID,
 		ID:          listReq.JobID,
@@ -107,9 +101,6 @@ func (s *RequesterAPIServer) getJobsList(ctx context.Context, listReq ListReques
 }
 
 func (s *RequesterAPIServer) getJobStates(ctx context.Context, jobList []*model.Job) error {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/publicapi.getJobStates")
-	defer span.End()
-
 	var err error
 	for k := range jobList {
 		jobList[k].Status.State, err = s.localDB.GetJobState(ctx, jobList[k].Metadata.ID)

--- a/pkg/requester/publicapi/endpoints_results.go
+++ b/pkg/requester/publicapi/endpoints_results.go
@@ -8,6 +8,7 @@ import (
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/filecoin-project/bacalhau/pkg/publicapi/handlerwrapper"
 	"github.com/filecoin-project/bacalhau/pkg/system"
+	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 type resultsRequest struct {
@@ -33,9 +34,7 @@ type resultsResponse struct {
 //	@Failure				500				{object}	string
 //	@Router					/requester/results [post]
 func (s *RequesterAPIServer) results(res http.ResponseWriter, req *http.Request) {
-	ctx, span := system.GetSpanFromRequest(req, "pkg/publicapi.results")
-	defer span.End()
-
+	ctx := req.Context()
 	var stateReq stateRequest
 	if err := json.NewDecoder(req.Body).Decode(&stateReq); err != nil {
 		http.Error(res, err.Error(), http.StatusBadRequest)
@@ -45,7 +44,7 @@ func (s *RequesterAPIServer) results(res http.ResponseWriter, req *http.Request)
 	res.Header().Set(handlerwrapper.HTTPHeaderJobID, stateReq.JobID)
 
 	ctx = system.AddJobIDToBaggage(ctx, stateReq.JobID)
-	system.AddJobIDFromBaggageToSpan(ctx, span)
+	system.AddJobIDFromBaggageToSpan(ctx, oteltrace.SpanFromContext(ctx))
 
 	stateResolver := localdb.GetStateResolver(s.localDB)
 	results, err := stateResolver.GetResults(ctx, stateReq.JobID)

--- a/pkg/requester/publicapi/endpoints_states.go
+++ b/pkg/requester/publicapi/endpoints_states.go
@@ -33,9 +33,7 @@ type stateResponse struct {
 //	@Failure				500				{object}	string
 //	@Router					/requester/states [post]
 func (s *RequesterAPIServer) states(res http.ResponseWriter, req *http.Request) {
-	ctx, span := system.GetSpanFromRequest(req, "pkg/publicapi/states")
-	defer span.End()
-
+	ctx := req.Context()
 	var stateReq stateRequest
 	if err := json.NewDecoder(req.Body).Decode(&stateReq); err != nil {
 		http.Error(res, err.Error(), http.StatusBadRequest)
@@ -62,8 +60,5 @@ func (s *RequesterAPIServer) states(res http.ResponseWriter, req *http.Request) 
 }
 
 func getJobStateFromRequest(ctx context.Context, apiServer *RequesterAPIServer, stateReq stateRequest) (model.JobState, error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/publicapi/getJobStateFromRequest")
-	defer span.End()
-
 	return apiServer.localDB.GetJobState(ctx, stateReq.JobID)
 }

--- a/pkg/requester/publicapi/endpoints_submit.go
+++ b/pkg/requester/publicapi/endpoints_submit.go
@@ -11,7 +11,7 @@ import (
 	"github.com/filecoin-project/bacalhau/pkg/publicapi/handlerwrapper"
 	"github.com/filecoin-project/bacalhau/pkg/system"
 	"github.com/rs/zerolog/log"
-	"go.opentelemetry.io/otel/attribute"
+	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 type submitRequest struct {
@@ -43,9 +43,7 @@ type submitResponse struct {
 //	@Failure				500				{object}	string
 //	@Router					/requester/submit [post]
 func (s *RequesterAPIServer) submit(res http.ResponseWriter, req *http.Request) {
-	ctx, span := system.GetSpanFromRequest(req, "pkg/apiServer.submit")
-	defer span.End()
-
+	ctx := req.Context()
 	if otherJobID := req.Header.Get("X-Bacalhau-Job-ID"); otherJobID != "" {
 		err := fmt.Errorf("rejecting job because HTTP header X-Bacalhau-Job-ID was set")
 		log.Ctx(ctx).Info().Str("X-Bacalhau-Job-ID", otherJobID).Err(err).Send()
@@ -96,7 +94,8 @@ func (s *RequesterAPIServer) submit(res http.ResponseWriter, req *http.Request) 
 		jobCreatePayload,
 	)
 	res.Header().Set(handlerwrapper.HTTPHeaderJobID, j.Metadata.ID)
-	span.SetAttributes(attribute.String(model.TracerAttributeNameJobID, j.Metadata.ID))
+	ctx = system.AddJobIDToBaggage(ctx, j.Metadata.ID)
+	system.AddJobIDFromBaggageToSpan(ctx, oteltrace.SpanFromContext(ctx))
 
 	if err != nil {
 		http.Error(res, err.Error(), http.StatusInternalServerError)

--- a/pkg/requester/shard_fsm.go
+++ b/pkg/requester/shard_fsm.go
@@ -504,7 +504,7 @@ func errorState(ctx context.Context, m *shardStateMachine) stateFn {
 	errMessage := fmt.Sprintf("%s error completing job due to %s", m, m.errorMsg)
 	log.Ctx(ctx).Error().Msgf(errMessage)
 
-	ctx, span := system.GetTracer().Start(ctx, "pkg/requesterNode/ShardFSM.errorState")
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/requester.errorState")
 	defer span.End()
 	ctx = system.AddJobIDToBaggage(ctx, m.shard.Job.Metadata.ID)
 	system.AddJobIDFromBaggageToSpan(ctx, span)

--- a/pkg/storage/combo/storage.go
+++ b/pkg/storage/combo/storage.go
@@ -7,7 +7,6 @@ import (
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/filecoin-project/bacalhau/pkg/storage"
 	"github.com/filecoin-project/bacalhau/pkg/system"
-	"go.opentelemetry.io/otel/trace"
 )
 
 type AllProviderFetcher func(ctx context.Context) ([]storage.Storage, error)
@@ -21,7 +20,7 @@ type ComboStorageProvider struct {
 }
 
 func NewStorage(
-	cm *system.CleanupManager,
+	_ *system.CleanupManager,
 	allFetcher AllProviderFetcher,
 	readFetcher ReadProviderFetcher,
 	writeFetcher WriteProviderFetcher,
@@ -35,8 +34,6 @@ func NewStorage(
 }
 
 func (driver *ComboStorageProvider) IsInstalled(ctx context.Context) (bool, error) {
-	_, span := newSpan(ctx, "IsInstalled")
-	defer span.End()
 	allProviders, err := driver.AllFetcher(ctx)
 	if err != nil {
 		return false, err
@@ -54,8 +51,6 @@ func (driver *ComboStorageProvider) IsInstalled(ctx context.Context) (bool, erro
 }
 
 func (driver *ComboStorageProvider) HasStorageLocally(ctx context.Context, storageSpec model.StorageSpec) (bool, error) {
-	ctx, span := newSpan(ctx, "HasStorageLocally")
-	defer span.End()
 	provider, err := driver.getReadProvider(ctx, storageSpec)
 	if err != nil {
 		return false, err
@@ -64,8 +59,6 @@ func (driver *ComboStorageProvider) HasStorageLocally(ctx context.Context, stora
 }
 
 func (driver *ComboStorageProvider) GetVolumeSize(ctx context.Context, storageSpec model.StorageSpec) (uint64, error) {
-	ctx, span := newSpan(ctx, "GetVolumeSize")
-	defer span.End()
 	provider, err := driver.getReadProvider(ctx, storageSpec)
 	if err != nil {
 		return 0, err
@@ -77,8 +70,6 @@ func (driver *ComboStorageProvider) PrepareStorage(
 	ctx context.Context,
 	storageSpec model.StorageSpec,
 ) (storage.StorageVolume, error) {
-	ctx, span := newSpan(ctx, "PrepareStorage")
-	defer span.End()
 	provider, err := driver.getReadProvider(ctx, storageSpec)
 	if err != nil {
 		return storage.StorageVolume{}, err
@@ -126,10 +117,6 @@ func (driver *ComboStorageProvider) getReadProvider(ctx context.Context, spec mo
 
 func (driver *ComboStorageProvider) getWriteProvider(ctx context.Context) (storage.Storage, error) {
 	return driver.WriteFetcher(ctx)
-}
-
-func newSpan(ctx context.Context, apiName string) (context.Context, trace.Span) {
-	return system.Span(ctx, "storage/combo", apiName)
 }
 
 // Compile time interface check:

--- a/pkg/storage/ipfs/storage.go
+++ b/pkg/storage/ipfs/storage.go
@@ -66,9 +66,6 @@ func (s *StorageProvider) GetVolumeSize(ctx context.Context, volume model.Storag
 }
 
 func (s *StorageProvider) PrepareStorage(ctx context.Context, storageSpec model.StorageSpec) (storage.StorageVolume, error) {
-	ctx, span := system.GetTracer().Start(ctx, "storage/ipfs/StorageProvider.PrepareStorage")
-	defer span.End()
-
 	stat, err := s.ipfsClient.Stat(ctx, storageSpec.CID)
 	if err != nil {
 		return storage.StorageVolume{}, fmt.Errorf("failed to stat %s: %w", storageSpec.CID, err)
@@ -92,9 +89,6 @@ func (s *StorageProvider) CleanupStorage(_ context.Context, storageSpec model.St
 }
 
 func (s *StorageProvider) Upload(ctx context.Context, localPath string) (model.StorageSpec, error) {
-	ctx, span := system.GetTracer().Start(ctx, "storage/ipfs/StorageProvider.Upload")
-	defer span.End()
-
 	cid, err := s.ipfsClient.Put(ctx, localPath)
 	if err != nil {
 		return model.StorageSpec{}, err
@@ -106,9 +100,6 @@ func (s *StorageProvider) Upload(ctx context.Context, localPath string) (model.S
 }
 
 func (s *StorageProvider) Explode(ctx context.Context, spec model.StorageSpec) ([]model.StorageSpec, error) {
-	ctx, span := system.GetTracer().Start(ctx, "storage/ipfs/StorageProvider.Explode")
-	defer span.End()
-
 	treeNode, err := s.ipfsClient.GetTreeNode(ctx, spec.CID)
 	if err != nil {
 		return []model.StorageSpec{}, err
@@ -142,9 +133,6 @@ func (s *StorageProvider) Explode(ctx context.Context, spec model.StorageSpec) (
 }
 
 func (s *StorageProvider) getFileFromIPFS(ctx context.Context, storageSpec model.StorageSpec) (storage.StorageVolume, error) {
-	ctx, span := system.GetTracer().Start(ctx, "storage/ipfs/StorageProvider.copyFile")
-	defer span.End()
-
 	outputPath := filepath.Join(s.localDir, storageSpec.CID)
 
 	// If the output path already exists, we already have the data, as

--- a/pkg/storage/local_directory/storage.go
+++ b/pkg/storage/local_directory/storage.go
@@ -18,7 +18,7 @@ type StorageProvider struct {
 	LocalDirectoryPath string
 }
 
-func NewStorage(cm *system.CleanupManager, localDirectoryPath string) (*StorageProvider, error) {
+func NewStorage(_ *system.CleanupManager, localDirectoryPath string) (*StorageProvider, error) {
 	storageHandler := &StorageProvider{
 		LocalDirectoryPath: localDirectoryPath,
 	}
@@ -32,15 +32,12 @@ func NewStorage(cm *system.CleanupManager, localDirectoryPath string) (*StorageP
 	return storageHandler, nil
 }
 
-func (driver *StorageProvider) IsInstalled(ctx context.Context) (bool, error) {
+func (driver *StorageProvider) IsInstalled(context.Context) (bool, error) {
 	return true, nil
 }
 
-func (driver *StorageProvider) HasStorageLocally(ctx context.Context, volume model.StorageSpec) (bool, error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/storage/local_directory.HasStorageLocally")
-	defer span.End()
-
-	localPath, err := driver.getPathToVolume(ctx, volume)
+func (driver *StorageProvider) HasStorageLocally(_ context.Context, volume model.StorageSpec) (bool, error) {
+	localPath, err := driver.getPathToVolume(volume)
 	if err != nil {
 		return false, err
 	}
@@ -50,10 +47,8 @@ func (driver *StorageProvider) HasStorageLocally(ctx context.Context, volume mod
 	return true, nil
 }
 
-func (driver *StorageProvider) GetVolumeSize(ctx context.Context, volume model.StorageSpec) (uint64, error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/storage/local_directory.GetVolumeSize")
-	defer span.End()
-	localPath, err := driver.getPathToVolume(ctx, volume)
+func (driver *StorageProvider) GetVolumeSize(_ context.Context, volume model.StorageSpec) (uint64, error) {
+	localPath, err := driver.getPathToVolume(volume)
 	if err != nil {
 		return 0, err
 	}
@@ -61,12 +56,10 @@ func (driver *StorageProvider) GetVolumeSize(ctx context.Context, volume model.S
 }
 
 func (driver *StorageProvider) PrepareStorage(
-	ctx context.Context,
+	_ context.Context,
 	storageSpec model.StorageSpec,
 ) (storage.StorageVolume, error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/storage/local_directory.PrepareStorage")
-	defer span.End()
-	localPath, err := driver.getPathToVolume(ctx, storageSpec)
+	localPath, err := driver.getPathToVolume(storageSpec)
 	if err != nil {
 		return storage.StorageVolume{}, err
 	}
@@ -77,28 +70,21 @@ func (driver *StorageProvider) PrepareStorage(
 	}, nil
 }
 
-func (driver *StorageProvider) CleanupStorage(
-	ctx context.Context,
-	storageSpec model.StorageSpec,
-	volume storage.StorageVolume,
-) error {
+func (driver *StorageProvider) CleanupStorage(context.Context, model.StorageSpec, storage.StorageVolume) error {
 	return nil
 }
 
-func (driver *StorageProvider) Upload(
-	ctx context.Context,
-	localPath string,
-) (model.StorageSpec, error) {
+func (driver *StorageProvider) Upload(context.Context, string) (model.StorageSpec, error) {
 	return model.StorageSpec{}, fmt.Errorf("not implemented")
 }
 
-func (driver *StorageProvider) Explode(ctx context.Context, spec model.StorageSpec) ([]model.StorageSpec, error) {
+func (driver *StorageProvider) Explode(_ context.Context, spec model.StorageSpec) ([]model.StorageSpec, error) {
 	return []model.StorageSpec{
 		spec,
 	}, nil
 }
 
-func (driver *StorageProvider) getPathToVolume(ctx context.Context, volume model.StorageSpec) (string, error) {
+func (driver *StorageProvider) getPathToVolume(volume model.StorageSpec) (string, error) {
 	// join the driver.LocalDirectoryPath with the volume.SourcePath
 	// use the os.PathSeparator to make sure we are using the correct separator for the OS
 	localPath := filepath.Join(driver.LocalDirectoryPath, volume.SourcePath)

--- a/pkg/storage/tracing/tracing.go
+++ b/pkg/storage/tracing/tracing.go
@@ -1,0 +1,74 @@
+package tracing
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/filecoin-project/bacalhau/pkg/model"
+	"github.com/filecoin-project/bacalhau/pkg/storage"
+	"github.com/filecoin-project/bacalhau/pkg/system"
+	"github.com/filecoin-project/bacalhau/pkg/util/reflection"
+)
+
+type tracingStorage struct {
+	delegate storage.Storage
+	name     string
+}
+
+func Wrap(delegate storage.Storage) storage.Storage {
+	return &tracingStorage{
+		delegate: delegate,
+		name:     reflection.StructName(delegate),
+	}
+}
+
+func (t *tracingStorage) IsInstalled(ctx context.Context) (bool, error) {
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), fmt.Sprintf("%s.IsInstalled", t.name))
+	defer span.End()
+
+	return t.delegate.IsInstalled(ctx)
+}
+
+func (t *tracingStorage) HasStorageLocally(ctx context.Context, spec model.StorageSpec) (bool, error) {
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), fmt.Sprintf("%s.HasStorageLocally", t.name))
+	defer span.End()
+
+	return t.delegate.HasStorageLocally(ctx, spec)
+}
+
+func (t *tracingStorage) GetVolumeSize(ctx context.Context, spec model.StorageSpec) (uint64, error) {
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), fmt.Sprintf("%s.GetVolumeSize", t.name))
+	defer span.End()
+
+	return t.delegate.GetVolumeSize(ctx, spec)
+}
+
+func (t *tracingStorage) PrepareStorage(ctx context.Context, spec model.StorageSpec) (storage.StorageVolume, error) {
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), fmt.Sprintf("%s.PrepareStorage", t.name))
+	defer span.End()
+
+	return t.delegate.PrepareStorage(ctx, spec)
+}
+
+func (t *tracingStorage) CleanupStorage(ctx context.Context, spec model.StorageSpec, volume storage.StorageVolume) error {
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), fmt.Sprintf("%s.CleanupStorage", t.name))
+	defer span.End()
+
+	return t.delegate.CleanupStorage(ctx, spec, volume)
+}
+
+func (t *tracingStorage) Upload(ctx context.Context, s string) (model.StorageSpec, error) {
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), fmt.Sprintf("%s.Upload", t.name))
+	defer span.End()
+
+	return t.delegate.Upload(ctx, s)
+}
+
+func (t *tracingStorage) Explode(ctx context.Context, spec model.StorageSpec) ([]model.StorageSpec, error) {
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), fmt.Sprintf("%s.Explode", t.name))
+	defer span.End()
+
+	return t.delegate.Explode(ctx, spec)
+}
+
+var _ storage.Storage = &tracingStorage{}

--- a/pkg/storage/url/urldownload/storage.go
+++ b/pkg/storage/url/urldownload/storage.go
@@ -79,9 +79,6 @@ func (sp *StorageProvider) GetVolumeSize(context.Context, model.StorageSpec) (ui
 //
 //nolint:funlen,gocyclo // TODO: refactor this function
 func (sp *StorageProvider) PrepareStorage(ctx context.Context, storageSpec model.StorageSpec) (storage.StorageVolume, error) {
-	_, span := system.GetTracer().Start(ctx, "pkg/storage/url/urldownload.PrepareStorage")
-	defer span.End()
-
 	u, err := IsURLSupported(storageSpec.URL)
 	if err != nil {
 		return storage.StorageVolume{}, err
@@ -202,9 +199,6 @@ func (sp *StorageProvider) CleanupStorage(
 	_ model.StorageSpec,
 	volume storage.StorageVolume,
 ) error {
-	_, span := system.GetTracer().Start(ctx, "pkg/storage/url/urldownload.CleanupStorage")
-	defer span.End()
-
 	pathToCleanup := filepath.Dir(volume.Source)
 	log.Ctx(ctx).Debug().Str("Path", pathToCleanup).Msg("Cleaning up")
 	return os.RemoveAll(pathToCleanup)

--- a/pkg/system/tracer.go
+++ b/pkg/system/tracer.go
@@ -2,8 +2,6 @@ package system
 
 import (
 	"context"
-	"fmt"
-	"net/http"
 
 	_ "github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/model"
@@ -27,19 +25,31 @@ func GetTracer() oteltrace.Tracer {
 // Span helpers
 // ----------------------------------------
 
+func NewSpan(ctx context.Context, t oteltrace.Tracer, name string, opts ...oteltrace.SpanStartOption) (context.Context, oteltrace.Span) {
+	for _, attributeName := range []string{model.TracerAttributeNameJobID, model.TracerAttributeNameNodeID} {
+		if v := baggage.FromContext(ctx).Member(attributeName).Value(); v != "" {
+			opts = append(opts, oteltrace.WithAttributes(
+				attribute.String(attributeName, v),
+			))
+		}
+	}
+	opts = append(opts, oteltrace.WithAttributes(
+		attribute.String("environment", GetEnvironment().String()),
+	))
+
+	return t.Start(ctx, name, opts...)
+}
+
 func NewRootSpan(ctx context.Context, t oteltrace.Tracer, name string) (context.Context, oteltrace.Span) {
 	// Always include environment info in spans:
-	m0, _ := baggage.NewMember("environment", GetEnvironment().String())
+	environment := GetEnvironment().String()
+	m0, _ := baggage.NewMember("environment", environment)
 	b, _ := baggage.New(m0)
 	ctx = baggage.ContextWithBaggage(ctx, b)
 
-	return t.Start(ctx, name)
-}
-
-func GetSpanFromRequest(req *http.Request, name string) (context.Context, oteltrace.Span) {
-	ctx := req.Context()
-	ctx, span := GetTracer().Start(ctx, name)
-	return ctx, span
+	return t.Start(ctx, name, oteltrace.WithAttributes(
+		attribute.String("environment", environment),
+	))
 }
 
 // Span creates and starts a new span, and a context containing it.
@@ -50,14 +60,11 @@ func GetSpanFromRequest(req *http.Request, name string) (context.Context, oteltr
 // Will create a new one if one with the same name does not exist
 // spanName: the name of the span, inside the service
 // opts: additional options to configure the span from trace.SpanStartOption
-func Span(ctx context.Context, tracerName, spanName string,
-	opts ...oteltrace.SpanStartOption) (context.Context, oteltrace.Span) {
+func Span(ctx context.Context, spanName string, opts ...oteltrace.SpanStartOption) (context.Context, oteltrace.Span) {
 	// Always include environment info in spans:
 	opts = append(opts, oteltrace.WithAttributes(
 		attribute.String("environment", GetEnvironment().String()),
 	))
-
-	spanName = fmt.Sprintf("service/%s", spanName)
 
 	return GetTracer().Start(ctx, spanName, opts...)
 }
@@ -90,14 +97,10 @@ func addFieldToBaggage(ctx context.Context, key, value string) context.Context {
 }
 
 func AddJobIDFromBaggageToSpan(ctx context.Context, span oteltrace.Span) {
-	AddAttributeToSpanFromBaggage(ctx, span, model.TracerAttributeNameJobID)
+	addAttributeToSpanFromBaggage(ctx, span, model.TracerAttributeNameJobID)
 }
 
-func AddNodeIDFromBaggageToSpan(ctx context.Context, span oteltrace.Span) {
-	AddAttributeToSpanFromBaggage(ctx, span, model.TracerAttributeNameNodeID)
-}
-
-func AddAttributeToSpanFromBaggage(ctx context.Context, span oteltrace.Span, name string) {
+func addAttributeToSpanFromBaggage(ctx context.Context, span oteltrace.Span, name string) {
 	b := baggage.FromContext(ctx)
 	log.Trace().Msgf("adding %s from baggage to span as attribute: %+v", name, b)
 	m := b.Member(name)

--- a/pkg/system/tracer_test.go
+++ b/pkg/system/tracer_test.go
@@ -25,14 +25,14 @@ func TestTracer(t *testing.T) {
 	tp.RegisterSpanProcessor(&sr)
 
 	ctx := context.Background()
-	ctx, span1 := Span(ctx, "service", "span1")
-	ctx, span2 := Span(ctx, "service", "span2") //lint:ignore SA4006 ok to have extra assignment
+	ctx, span1 := Span(ctx, "span1")
+	_, span2 := Span(ctx, "span2")
 	span2.End()
 	span1.End()
 
 	require.Len(t, sr.traces, 2)
-	require.Equal(t, "service/span1", sr.traces[0].Name())
-	require.Equal(t, "service/span2", sr.traces[1].Name())
+	require.Equal(t, "span1", sr.traces[0].Name())
+	require.Equal(t, "span2", sr.traces[1].Name())
 }
 
 // SpanRecorder is an implementation of sdktrace.SpanProcessor that records

--- a/pkg/test/devstack/combodriver_test.go
+++ b/pkg/test/devstack/combodriver_test.go
@@ -21,8 +21,6 @@ type ComboDriverSuite struct {
 	scenario.ScenarioRunner
 }
 
-var _ scenario.ScenarioTestSuite = (*ComboDriverSuite)(nil)
-
 // In order for 'go test' to run this suite, we need to create
 // a normal test function and pass our suite to suite.Run
 func TestComboDriverSuite(t *testing.T) {
@@ -31,7 +29,7 @@ func TestComboDriverSuite(t *testing.T) {
 
 const exampleText = "hello world"
 
-var testcase scenario.Scenario = scenario.Scenario{
+var testcase = scenario.Scenario{
 	ResultsChecker: scenario.FileEquals(model.DownloadFilenameStdout, exampleText),
 	Spec: model.Spec{
 		Engine:    model.EngineWasm,

--- a/pkg/test/devstack/pythonwasm_test.go
+++ b/pkg/test/devstack/pythonwasm_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/filecoin-project/bacalhau/pkg/ipfs"
 	"github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/node"
-	"github.com/filecoin-project/bacalhau/pkg/telemetry"
 	testutils "github.com/filecoin-project/bacalhau/pkg/test/utils"
 
 	cmd "github.com/filecoin-project/bacalhau/cmd/bacalhau"
@@ -66,14 +65,9 @@ func (s *DevstackPythonWASMSuite) TestPythonWasmVolumes() {
 	fileContents := "pineapples"
 
 	ctx := context.Background()
-	stack, cm := testutils.SetupTest(ctx, s.T(), nodeCount, 0, false,
+	stack, _ := testutils.SetupTest(ctx, s.T(), nodeCount, 0, false,
 		node.NewComputeConfigWithDefaults(),
 		node.NewRequesterConfigWithDefaults())
-
-	t := system.GetTracer()
-	ctx, rootSpan := system.NewRootSpan(ctx, t, "pkg/test/devstack.TestPythonWasmVolumes")
-	defer rootSpan.End()
-	cm.RegisterCallback(telemetry.Cleanup)
 
 	tmpDir := s.T().TempDir()
 
@@ -167,14 +161,9 @@ func (s *DevstackPythonWASMSuite) TestSimplestPythonWasmDashC() {
 	cmd.Fatal = cmd.FakeFatalErrorHandler
 
 	ctx := context.Background()
-	stack, cm := testutils.SetupTest(ctx, s.T(), 1, 0, false,
+	stack, _ := testutils.SetupTest(ctx, s.T(), 1, 0, false,
 		node.NewComputeConfigWithDefaults(),
 		node.NewRequesterConfigWithDefaults())
-
-	t := system.GetTracer()
-	ctx, rootSpan := system.NewRootSpan(ctx, t, "pkg/test/devstack/pythonwasmtest/simplestpythonwasmdashc")
-	defer rootSpan.End()
-	cm.RegisterCallback(telemetry.Cleanup)
 
 	// TODO: see also list_test.go, maybe factor out a common way to do this cli
 	// setup
@@ -211,14 +200,9 @@ func (s *DevstackPythonWASMSuite) TestSimplePythonWasm() {
 	cmd.Fatal = cmd.FakeFatalErrorHandler
 
 	ctx := context.Background()
-	stack, cm := testutils.SetupTest(ctx, s.T(), 1, 0, false,
+	stack, _ := testutils.SetupTest(ctx, s.T(), 1, 0, false,
 		node.NewComputeConfigWithDefaults(),
 		node.NewRequesterConfigWithDefaults())
-
-	t := system.GetTracer()
-	ctx, rootSpan := system.NewRootSpan(ctx, t, "pkg/test/devstack/pythonwasmtest/simplepythonwasm")
-	defer rootSpan.End()
-	cm.RegisterCallback(telemetry.Cleanup)
 
 	tmpDir := s.T().TempDir()
 

--- a/pkg/test/devstack/sharding_test.go
+++ b/pkg/test/devstack/sharding_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/filecoin-project/bacalhau/pkg/requester/publicapi"
 	ipfs_storage "github.com/filecoin-project/bacalhau/pkg/storage/ipfs"
 	"github.com/filecoin-project/bacalhau/pkg/system"
-	"github.com/filecoin-project/bacalhau/pkg/telemetry"
 	"github.com/filecoin-project/bacalhau/pkg/test/scenario"
 	testutils "github.com/filecoin-project/bacalhau/pkg/test/utils"
 	"github.com/stretchr/testify/require"
@@ -72,11 +71,6 @@ func (suite *ShardingSuite) TestExplodeCid() {
 
 	stack, err := devstack.NewDevStackIPFS(ctx, cm, nodeCount)
 	require.NoError(suite.T(), err)
-
-	t := system.GetTracer()
-	ctx, rootSpan := system.NewRootSpan(ctx, t, "pkg/test/devstack/shardingtest/explodecid")
-	defer rootSpan.End()
-	cm.RegisterCallback(telemetry.Cleanup)
 
 	node := stack.IPFSClients[0]
 
@@ -203,7 +197,7 @@ func (suite *ShardingSuite) TestNoShards() {
 	const nodeCount = 1
 	ctx := context.Background()
 
-	stack, cm := testutils.SetupTest(
+	stack, _ := testutils.SetupTest(
 		ctx,
 		suite.T(),
 
@@ -213,11 +207,6 @@ func (suite *ShardingSuite) TestNoShards() {
 		node.NewComputeConfigWithDefaults(),
 		node.NewRequesterConfigWithDefaults(),
 	)
-
-	t := system.GetTracer()
-	ctx, rootSpan := system.NewRootSpan(ctx, t, "pkg/test/devstack/shardingtest/testnoshards")
-	defer rootSpan.End()
-	cm.RegisterCallback(telemetry.Cleanup)
 
 	dirPath := prepareFolderWithFiles(suite.T(), 0)
 	directoryCid, err := ipfs.AddFileToNodes(ctx, dirPath, devstack.ToIPFSClients(stack.Nodes[:nodeCount])...)

--- a/pkg/test/devstack/submit_test.go
+++ b/pkg/test/devstack/submit_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/filecoin-project/bacalhau/pkg/node"
-	"github.com/filecoin-project/bacalhau/pkg/telemetry"
 	testutils "github.com/filecoin-project/bacalhau/pkg/test/utils"
 
 	"github.com/filecoin-project/bacalhau/pkg/logger"
@@ -39,7 +38,7 @@ func (suite *DevstackSubmitSuite) SetupTest() {
 func (suite *DevstackSubmitSuite) TestEmptySpec() {
 	ctx := context.Background()
 
-	stack, cm := testutils.SetupTest(
+	stack, _ := testutils.SetupTest(
 		ctx,
 		suite.T(),
 
@@ -49,11 +48,6 @@ func (suite *DevstackSubmitSuite) TestEmptySpec() {
 		node.NewComputeConfigWithDefaults(),
 		node.NewRequesterConfigWithDefaults(),
 	)
-
-	t := system.GetTracer()
-	ctx, rootSpan := system.NewRootSpan(ctx, t, "pkg/test/devstack/submittest/testemptyspec")
-	defer rootSpan.End()
-	cm.RegisterCallback(telemetry.Cleanup)
 
 	apiUri := stack.Nodes[0].APIServer.GetURI()
 	apiClient := publicapi.NewRequesterAPIClient(apiUri)

--- a/pkg/test/ipfs/ipfs_host_storage_test.go
+++ b/pkg/test/ipfs/ipfs_host_storage_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/filecoin-project/bacalhau/pkg/storage"
 	ipfs_storage "github.com/filecoin-project/bacalhau/pkg/storage/ipfs"
 	"github.com/filecoin-project/bacalhau/pkg/system"
-	"github.com/filecoin-project/bacalhau/pkg/telemetry"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -73,11 +72,6 @@ func runFileTest(t *testing.T, engine model.StorageSourceType, getStorageDriver 
 	stack, cm := SetupTest(ctx, t, 1)
 	defer TeardownTest(stack, cm)
 
-	tr := system.GetTracer()
-	ctx, rootSpan := system.NewRootSpan(ctx, tr, "pkg/test/ipfs/runFolderTest")
-	defer rootSpan.End()
-	cm.RegisterCallback(telemetry.Cleanup)
-
 	// add this file to the server
 	EXAMPLE_TEXT := `hello world`
 	fileCid, err := ipfs.AddTextToNodes(ctx, []byte(EXAMPLE_TEXT), stack.IPFSClients[0])
@@ -117,11 +111,6 @@ func runFolderTest(t *testing.T, engine model.StorageSourceType, getStorageDrive
 	// get a single IPFS server
 	stack, cm := SetupTest(ctx, t, 1)
 	defer TeardownTest(stack, cm)
-
-	tr := system.GetTracer()
-	ctx, rootSpan := system.NewRootSpan(ctx, tr, "pkg/test/ipfs/runFolderTest")
-	defer rootSpan.End()
-	cm.RegisterCallback(telemetry.Cleanup)
 
 	dir := t.TempDir()
 

--- a/pkg/test/requester/publicapi/client_test.go
+++ b/pkg/test/requester/publicapi/client_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/model"
-	"github.com/filecoin-project/bacalhau/pkg/system"
 	testutils "github.com/filecoin-project/bacalhau/pkg/test/utils"
 	"github.com/stretchr/testify/require"
 )
@@ -18,9 +17,7 @@ func TestGet(t *testing.T) {
 	n, c := setupNodeForTest(t)
 	defer n.CleanupManager.Cleanup()
 
-	ctx, span := system.Span(context.Background(),
-		"publicapi/client_test", "TestGet")
-	defer span.End()
+	ctx := context.Background()
 
 	// Submit a few random jobs to the node:
 	var err error

--- a/pkg/test/scenario/suite.go
+++ b/pkg/test/scenario/suite.go
@@ -21,7 +21,6 @@ import (
 	testutils "github.com/filecoin-project/bacalhau/pkg/test/utils"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"go.opentelemetry.io/otel/trace"
 )
 
 type ScenarioTestSuite interface {
@@ -42,23 +41,15 @@ type ScenarioTestSuite interface {
 // their own set up or tear down routines.
 type ScenarioRunner struct {
 	suite.Suite
-	Ctx  context.Context
-	Span trace.Span
+	Ctx context.Context
 }
 
 func (s *ScenarioRunner) SetupTest() {
 	require.NoError(s.T(), system.InitConfigForTesting(s.T()))
 
-	t := system.GetTracer()
-	ctx, rootSpan := system.NewRootSpan(context.Background(), t, s.T().Name())
-	s.Ctx = ctx
-	s.Span = rootSpan
+	s.Ctx = context.Background()
 
 	s.T().Cleanup(func() { _ = telemetry.Cleanup() })
-}
-
-func (s *ScenarioRunner) TearDownTest() {
-	s.Span.End()
 }
 
 func (s *ScenarioRunner) prepareStorage(stack *devstack.DevStack, getStorage SetupStorage) []model.StorageSpec {

--- a/pkg/util/reflection/reflection.go
+++ b/pkg/util/reflection/reflection.go
@@ -1,0 +1,18 @@
+package reflection
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+func StructName(a any) string {
+	delegateType := reflect.Indirect(reflect.ValueOf(a)).Type()
+	path := strings.TrimPrefix(delegateType.PkgPath(), "github.com/filecoin-project/bacalhau/")
+	if path == "" {
+		return delegateType.Name()
+	}
+
+	name := fmt.Sprintf("%s.%s", path, delegateType.Name())
+	return name
+}

--- a/pkg/util/reflection/reflection_test.go
+++ b/pkg/util/reflection/reflection_test.go
@@ -1,0 +1,45 @@
+package reflection
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestStructName(t *testing.T) {
+	tests := []struct {
+		name     string
+		subject  any
+		expected string
+	}{
+		{
+			name:     "handles-pointers",
+			subject:  &foo{},
+			expected: "pkg/util/reflection.foo",
+		},
+		{
+			name:     "handles-bare",
+			subject:  foo{},
+			expected: "pkg/util/reflection.foo",
+		},
+		{
+			name:     "ignore-non-bacalhau-prefix",
+			subject:  assert.New(t),
+			expected: "github.com/stretchr/testify/assert.Assertions",
+		},
+		{
+			name:     "does-not-crash-with-non-structs",
+			subject:  123,
+			expected: "int",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := StructName(test.subject)
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+type foo struct {
+}

--- a/pkg/util/targzip/targzip.go
+++ b/pkg/util/targzip/targzip.go
@@ -51,7 +51,7 @@ func UncompressedSize(src io.Reader) (datasize.ByteSize, error) {
 //
 //nolint:gocyclo
 func compress(ctx context.Context, src string, buf io.Writer, max datasize.ByteSize) error {
-	_, span := system.GetTracer().Start(ctx, "pkg/util/targzip.Compress")
+	_, span := system.NewSpan(ctx, system.GetTracer(), "pkg/util/targzip.compress")
 	defer span.End()
 
 	// tar > gzip > buf

--- a/pkg/verifier/deterministic/verifier.go
+++ b/pkg/verifier/deterministic/verifier.go
@@ -201,7 +201,7 @@ func (deterministicVerifier *DeterministicVerifier) VerifyShard(
 	ctx context.Context,
 	shard model.JobShard,
 ) ([]verifier.VerifierResult, error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/verifier/deterministic.VerifyShard")
+	_, span := system.NewSpan(ctx, system.GetTracer(), "pkg/verifier.DeterministicVerifier.VerifyShard")
 	defer span.End()
 
 	jobState, err := deterministicVerifier.stateResolver.GetJobState(ctx, shard.Job.Metadata.ID)

--- a/pkg/verifier/encrypter.go
+++ b/pkg/verifier/encrypter.go
@@ -23,8 +23,7 @@ func NewEncrypter(privateKey crypto.PrivKey) Encrypter {
 }
 
 func (e Encrypter) Encrypt(ctx context.Context, data, libp2pKeyBytes []byte) ([]byte, error) {
-	//nolint:ineffassign,staticcheck
-	_, span := system.GetTracer().Start(ctx, "pkg/transport/libp2p.Encrypt")
+	_, span := system.NewSpan(ctx, system.GetTracer(), "pkg/verifier.Encrypter.Encrypt")
 	defer span.End()
 
 	unmarshalledPublicKey, err := crypto.UnmarshalPublicKey(libp2pKeyBytes)
@@ -53,7 +52,7 @@ func (e Encrypter) Encrypt(ctx context.Context, data, libp2pKeyBytes []byte) ([]
 }
 
 func (e Encrypter) Decrypt(ctx context.Context, data []byte) ([]byte, error) {
-	_, span := system.GetTracer().Start(ctx, "pkg/transport/libp2p.Decrypt")
+	_, span := system.NewSpan(ctx, system.GetTracer(), "pkg/verifier.Encrypter.Decrypt")
 	defer span.End()
 
 	privateKeyBytes, err := e.privateKey.Raw()

--- a/pkg/verifier/noop/verifier.go
+++ b/pkg/verifier/noop/verifier.go
@@ -74,7 +74,7 @@ func (noopVerifier *NoopVerifier) VerifyShard(
 	ctx context.Context,
 	shard model.JobShard,
 ) ([]verifier.VerifierResult, error) {
-	ctx, span := system.GetTracer().Start(ctx, "pkg/verifier/noop/NoopVerifier.VerifyShard")
+	_, span := system.NewSpan(ctx, system.GetTracer(), "pkg/verifier.NoopVerifier.VerifyShard")
 	defer span.End()
 
 	results := []verifier.VerifierResult{}


### PR DESCRIPTION
This changes the tracing so that:
* Node & job IDs are attributes of as many spans as possible
* Names of non-HTTP spans are standardised on `sub/package.Struct.Method`, which is similar to what Go can auto-generate
* HTTP server spans now follow the recommended naming pattern of `{http.method} {http.route}`
* Publisher and storage services have tracing handled by automatically by be wrapped by a tracing publisher/storage service
* Ensure job ID is present on the critical areas of a job, so that searching for `jobid=...` brings up the submission, running and publishing spans.

Part of #1925