### PR TITLE
Shares devstack environment vars via a dotenv file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ dist/*.sha256
 dist/*.tar.gz
 env.*
 .env
+.devstack.env
 *.swp
 *.swo
 bin/*/*

--- a/cmd/bacalhau/devstack.go
+++ b/cmd/bacalhau/devstack.go
@@ -134,6 +134,9 @@ func runDevstack(cmd *cobra.Command, ODs *devstack.DevStackOptions, OS *ServeOpt
 	ctx, rootSpan := system.NewRootSpan(ctx, system.GetTracer(), "cmd/bacalhau.runDevstack")
 	defer rootSpan.End()
 
+	if config.DevstackShouldWriteEnvFile() {
+		cm.RegisterCallback(cleanupDevstackDotEnv)
+	}
 	cm.RegisterCallback(telemetry.Cleanup)
 
 	config.DevstackSetShouldPrintInfo()
@@ -214,5 +217,12 @@ func runDevstack(cmd *cobra.Command, ODs *devstack.DevStackOptions, OS *ServeOpt
 	<-ctx.Done() // block until killed
 
 	cmd.Println("Shutting down devstack")
+	return nil
+}
+
+func cleanupDevstackDotEnv() error {
+	if _, err := os.Stat(config.DevstackEnvFile()); err == nil {
+		return os.Remove(config.DevstackEnvFile())
+	}
 	return nil
 }

--- a/docs/running_locally.md
+++ b/docs/running_locally.md
@@ -57,15 +57,28 @@ export BACALHAU_API_HOST=0.0.0.0
 export BACALHAU_API_PORT=39763
 
 By default devstack is not running on public IPFS network.
-If you wish to connect devstack to public IPFS network consider running new IPFS node daemon localy
-and then connecting it to bacalhau using command bellow or by adding --public-ipfs flag:
+If you wish to connect devstack to public IPFS network consider running new IPFS node daemon locally
+and then connecting it to bacalhau using the command below or by adding --public-ipfs flag:
 
 ipfs swarm connect $BACALHAU_IPFS_SWARM_ADDRESSES
 ```
 
-Message contains environment variables you need for a new window.
+The message above contains the environment variables you need for a new window. 
+You can paste these into a new terminal so that bacalhau will use your local devstack.
+
+Alternatively, to remove the need to copy and paste, you can set `DEVSTACK_ENV_FILE` 
+environment variable to the name of a .env file that devstack will write to,
+and bacalhau commands will read from, before launching the devstack e.g.: 
+
+```bash
+DEVSTACK_ENV_FILE=.devstack.env bacalhau devstack
+```
+
+When the devstack is shut down, the local env file (if configured) will be removed.
+It is suggested you use `.devstack.env` to avoid clashing with longer lived `.env` files.
 
 ## New Terminal Window
+
 * Open an additional terminal window to be used for submitting jobs.
 * Copy and paste environment variables from previous message into this window. EG:
 

--- a/main.go
+++ b/main.go
@@ -3,9 +3,11 @@ package main
 import (
 	"os"
 
+	"github.com/filecoin-project/bacalhau/pkg/config"
 	_ "github.com/filecoin-project/bacalhau/pkg/version"
 
 	"github.com/filecoin-project/bacalhau/cmd/bacalhau"
+
 	"github.com/filecoin-project/bacalhau/pkg/system"
 	"github.com/joho/godotenv"
 	"github.com/rs/zerolog/log"
@@ -13,6 +15,13 @@ import (
 
 func main() {
 	_ = godotenv.Load()
+
+	devstackEnvFile := config.DevstackEnvFile()
+	if _, err := os.Stat(devstackEnvFile); err == nil {
+		log.Debug().Msgf("Loading environment from %s", devstackEnvFile)
+		_ = godotenv.Overload(devstackEnvFile)
+	}
+
 	if err := system.InitConfig(); err != nil {
 		log.Error().Msgf("Failed to initialize config: %s", err)
 		os.Exit(1)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,6 +15,14 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+func DevstackShouldWriteEnvFile() bool {
+	return DevstackEnvFile() != ""
+}
+
+func DevstackEnvFile() string {
+	return os.Getenv("DEVSTACK_ENV_FILE")
+}
+
 func DevstackGetShouldPrintInfo() bool {
 	return os.Getenv("DEVSTACK_PRINT_INFO") != ""
 }

--- a/pkg/devstack/devstack.go
+++ b/pkg/devstack/devstack.go
@@ -430,6 +430,14 @@ export LOTUS_PATH=%s
 export LOTUS_UPLOAD_DIR=%s`, stack.Lotus.PathDir, stack.Lotus.UploadDir)
 	}
 
+	if config.DevstackShouldWriteEnvFile() {
+		err := os.WriteFile(config.DevstackEnvFile(), []byte(summaryShellVariablesString), 0600) //nolint:gomnd
+		if err != nil {
+			log.Err(err).Msgf("Failed to write file %s", config.DevstackEnvFile())
+			return "", err
+		}
+	}
+
 	if !stack.PublicIPFSMode {
 		summaryShellVariablesString += `
 


### PR DESCRIPTION
Each time a developer runs the bacalhau devstack, they are presented with a few environment variables that they need to set in another window to configure the bacalhau command to connect to the local devstack.  It is possible to keep a persistent port, but the IPFS Swarm addresses do change.  If work there is a need to restart the devstack, the details have to be set again.

Bacalhau already has support for loading `.env` files, and this PR extends the functionality to allow for it to load a .env file created by the devstack.

When the devstack is launched, if it is able to find a value for the environment variable `DEVSTACK_ENV_FILE` then it will write the required environment files into the file described within.  This file will be cleaned up when the devstack is shut down.

If `DEVSTACK_ENV_FILE` is present when running a normal bacalhau command, it will use the details found within.  This means that if the developer were to define something like `DEVSTACK_ENV_FILE=.devstack.env` then there is no further need to keep copying and pasting environment variables between terminals.

The filename `.devstack.env` is recommended in the running_locally documentation as this is now ignored by git to avoid accidentally committing it.