### PR TITLE
Ensures makefile build task sees main.go changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ build-bacalhau: ${BINARY_PATH}
 CMD_FILES := $(shell bash -c 'comm -23 <(git ls-files cmd) <(git ls-files cmd --deleted)')
 PKG_FILES := $(shell bash -c 'comm -23 <(git ls-files pkg) <(git ls-files pkg --deleted)')
 
-${BINARY_PATH}: ${CMD_FILES} ${PKG_FILES}
+${BINARY_PATH}: ${CMD_FILES} ${PKG_FILES} main.go
 	${GO} build -gcflags '-N -l' -ldflags "${BUILD_FLAGS}" -trimpath -o ${BINARY_PATH} .
 
 ################################################################################


### PR DESCRIPTION
Currently the makefile does not trigger a build when running `make build` if there are changes in main.go.  Adding main.go to the list of dependencies for the `BINARY_PATH` target ensures that a build is triggered when main.go is changed (without destroying the output).