### PR TITLE
Trace SQL commands automatically

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/BTBurke/k8sresource v1.2.0
 	github.com/MakeNowJust/heredoc/v2 v2.0.1
 	github.com/Masterminds/semver v1.5.0
+	github.com/XSAM/otelsql v0.19.0
 	github.com/antihax/optional v1.0.0
 	github.com/application-research/estuary-clients/go v0.0.0-20221129102826-8a9f3452ad5a
 	github.com/bacalhau-project/golang-mutex-tracer v0.0.0-20230214151516-bb996d6e8b46
@@ -83,8 +84,8 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.12.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.7.0
 	go.opentelemetry.io/otel/metric v0.36.0
-	go.opentelemetry.io/otel/sdk v1.12.0
-	go.opentelemetry.io/otel/sdk/metric v0.35.0
+	go.opentelemetry.io/otel/sdk v1.13.0
+	go.opentelemetry.io/otel/sdk/metric v0.36.0
 	go.opentelemetry.io/otel/trace v1.13.0
 	go.ptx.dk/multierrgroup v0.0.2
 	go.uber.org/multierr v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -142,6 +142,8 @@ github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMx
 github.com/Shopify/toxiproxy/v2 v2.1.6-0.20210914104332-15ea381dcdae/go.mod h1:/cvHQkZ1fst0EmZnA5dFtiQdWCNCFYzb+uE2vqVgvx0=
 github.com/Stebalien/go-bitfield v0.0.1/go.mod h1:GNjFpasyUVkHMsfEOk8EFLJ9syQ6SI+XWrX9Wf2XH0s=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
+github.com/XSAM/otelsql v0.19.0 h1:ggoHKrQMT7nBg3zQBDmASeytVp56BpG2yx7T8SXQFYc=
+github.com/XSAM/otelsql v0.19.0/go.mod h1:YlF8cCdVv0Pol37Nsf1UFneWqNOdqK5X1azLJN6c8zA=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
@@ -2520,12 +2522,12 @@ go.opentelemetry.io/otel/sdk v0.20.0/go.mod h1:g/IcepuwNsoiX5Byy2nNV0ySUF1em498m
 go.opentelemetry.io/otel/sdk v1.2.0/go.mod h1:jNN8QtpvbsKhgaC6V5lHiejMoKD+V8uadoSafgHPx1U=
 go.opentelemetry.io/otel/sdk v1.3.0/go.mod h1:rIo4suHNhQwBIPg9axF8V9CA72Wz2mKF1teNrup8yzs=
 go.opentelemetry.io/otel/sdk v1.7.0/go.mod h1:uTEOTwaqIVuTGiJN7ii13Ibp75wJmYUDe374q6cZwUU=
-go.opentelemetry.io/otel/sdk v1.12.0 h1:8npliVYV7qc0t1FKdpU08eMnOjgPFMnriPhn0HH4q3o=
-go.opentelemetry.io/otel/sdk v1.12.0/go.mod h1:WYcvtgquYvgODEvxOry5owO2y9MyciW7JqMz6cpXShE=
+go.opentelemetry.io/otel/sdk v1.13.0 h1:BHib5g8MvdqS65yo2vV1s6Le42Hm6rrw08qU6yz5JaM=
+go.opentelemetry.io/otel/sdk v1.13.0/go.mod h1:YLKPx5+6Vx/o1TCUYYs+bpymtkmazOMT6zoRrC7AQ7I=
 go.opentelemetry.io/otel/sdk/export/metric v0.20.0/go.mod h1:h7RBNMsDJ5pmI1zExLi+bJK+Dr8NQCh0qGhm1KDnNlE=
 go.opentelemetry.io/otel/sdk/metric v0.20.0/go.mod h1:knxiS8Xd4E/N+ZqKmUPf3gTTZ4/0TjTXukfxjzSTpHE=
-go.opentelemetry.io/otel/sdk/metric v0.35.0 h1:gryV4W5GzpOhKK48/lZb8ldyWIs3DRugSVlQZmCwELA=
-go.opentelemetry.io/otel/sdk/metric v0.35.0/go.mod h1:eDyp1GxSiwV98kr7w4pzrszQh/eze9MqBqPd2bCPmyE=
+go.opentelemetry.io/otel/sdk/metric v0.36.0 h1:dEXpkkOAEcHiRiaZdvd63MouV+3bCtAB/bF3jlNKnr8=
+go.opentelemetry.io/otel/sdk/metric v0.36.0/go.mod h1:Lv4HQQPSCSkhyBKzLNtE8YhTSdK4HCwNh3lh7CiR20s=
 go.opentelemetry.io/otel/trace v0.20.0/go.mod h1:6GjCW8zgDjwGHGa6GkyeB8+/5vjT16gUEi0Nf1iBdgw=
 go.opentelemetry.io/otel/trace v1.2.0/go.mod h1:N5FLswTubnxKxOJHM7XZC074qpeEdLy3CgAVsdMucK0=
 go.opentelemetry.io/otel/trace v1.3.0/go.mod h1:c/VDhno8888bvQYmbYLqe41/Ldmr/KKunbvWM4/fEjk=

--- a/pkg/localdb/postgres/postgres.go
+++ b/pkg/localdb/postgres/postgres.go
@@ -3,9 +3,9 @@ package postgres
 import (
 	"fmt"
 
-	"database/sql"
-
+	"github.com/XSAM/otelsql"
 	"github.com/filecoin-project/bacalhau/pkg/localdb/shared"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 
 	_ "github.com/golang-migrate/migrate/v4/database/postgres"
 	_ "github.com/lib/pq"
@@ -20,10 +20,19 @@ func NewPostgresDatastore(
 	autoMigrate bool,
 ) (*shared.GenericSQLDatastore, error) {
 	connectionString := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=disable", username, password, host, port, database)
-	db, err := sql.Open("postgres", connectionString)
+	db, err := otelsql.Open(
+		"postgres",
+		connectionString,
+		otelsql.WithAttributes(semconv.DBSystemPostgreSQL, semconv.HostName(host)),
+	)
 	if err != nil {
 		return nil, err
 	}
+
+	if err := otelsql.RegisterDBStatsMetrics(db, otelsql.WithAttributes(semconv.DBSystemPostgreSQL)); err != nil { //nolint:govet
+		return nil, err
+	}
+
 	datastore, err := shared.NewGenericSQLDatastore(
 		db,
 		"postgres",
@@ -35,7 +44,7 @@ func NewPostgresDatastore(
 	if autoMigrate {
 		err = datastore.MigrateUp()
 		if err != nil {
-			return nil, fmt.Errorf("there was an error doing the migration: %s", err.Error())
+			return nil, fmt.Errorf("there was an error doing the migration: %w", err)
 		}
 	}
 	return datastore, err

--- a/pkg/localdb/postgres/postgres_test.go
+++ b/pkg/localdb/postgres/postgres_test.go
@@ -3,38 +3,71 @@
 package postgres
 
 import (
+	"context"
 	"fmt"
-	"runtime"
+	"strconv"
 	"testing"
 	"time"
 
+	dockertypes "github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/go-connections/nat"
+	"github.com/filecoin-project/bacalhau/pkg/docker"
 	"github.com/filecoin-project/bacalhau/pkg/localdb/shared"
 	_ "github.com/filecoin-project/bacalhau/pkg/logger"
-	"github.com/filecoin-project/bacalhau/pkg/system"
-	"github.com/phayes/freeport"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
-//	docker run -d \
-//	  --name some-postgres \
-//	  -p 5432:5432 \
-//	  -e POSTGRES_DB=postgres \
-//	  -e POSTGRES_USER=postgres \
-//	  -e POSTGRES_PASSWORD=postgres \
-//	  postgres
-
 func TestPostgresSuite(t *testing.T) {
-	port, err := freeport.GetFreePort()
+	docker.MustHaveDocker(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	client, err := docker.NewDockerClient()
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, client.Close())
+	})
+
+	require.NoError(t, docker.PullImage(ctx, client, "postgres"))
+	c, err := client.ContainerCreate(ctx, &container.Config{
+		Image:        "postgres",
+		ExposedPorts: map[nat.Port]struct{}{},
+		Env:          []string{"POSTGRES_DB=postgres", "POSTGRES_USER=postgres", "POSTGRES_PASSWORD=postgres"},
+	}, &container.HostConfig{
+		PortBindings: map[nat.Port][]nat.PortBinding{
+			"5432/tcp": {{}},
+		},
+	}, nil, nil, fmt.Sprintf("postgres-%s", t.Name()))
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		assert.NoError(t, docker.RemoveContainer(context.Background(), client, c.ID))
+	})
+
+	require.NoError(t, client.ContainerStart(ctx, c.ID, dockertypes.ContainerStartOptions{}))
+
+	var status dockertypes.ContainerJSON
+	for {
+		status, err = client.ContainerInspect(ctx, c.ID)
+		require.NoError(t, err)
+
+		if status.State.Status == "running" {
+			break
+		}
+		time.Sleep(1 * time.Second)
+	}
+
+	port, err := strconv.Atoi(status.NetworkSettings.Ports["5432/tcp"][0].HostPort)
+	require.NoError(t, err)
+
 	var datastore *shared.GenericSQLDatastore
 	testingSuite := new(shared.GenericSQLSuite)
 	testingSuite.SetupHandler = func() *shared.GenericSQLDatastore {
-		if runtime.GOOS != "linux" {
-			return nil
-		}
 		if datastore == nil {
-			system.Shellout(fmt.Sprintf("docker run -d --name postgres%d -p %d:5432 -e POSTGRES_DB=postgres -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres postgres", port, port))
 			for {
 				datastore, err = NewPostgresDatastore(
 					"localhost",
@@ -58,11 +91,6 @@ func TestPostgresSuite(t *testing.T) {
 		}
 		return datastore
 	}
-	testingSuite.TeardownHandler = func() {
-		if runtime.GOOS != "linux" {
-			return
-		}
-		system.Shellout(fmt.Sprintf("docker rm -f postgres%d || true", port))
-	}
+
 	suite.Run(t, testingSuite)
 }

--- a/pkg/localdb/shared/genericSQL.go
+++ b/pkg/localdb/shared/genericSQL.go
@@ -1,11 +1,10 @@
 package shared
 
 import (
-	"fmt"
-
 	"context"
 	"embed"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"time"
 
@@ -15,13 +14,11 @@ import (
 	"github.com/filecoin-project/bacalhau/pkg/bacerrors"
 	"github.com/filecoin-project/bacalhau/pkg/localdb"
 	"github.com/filecoin-project/bacalhau/pkg/model"
-	"github.com/filecoin-project/bacalhau/pkg/system"
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/source/iofs"
-	"go.opentelemetry.io/otel/trace"
 )
 
-// so we can pass *sql.DB and *sql.Tx to the same functions
+// SQLClient is so we can pass *sql.DB and *sql.Tx to the same functions
 type SQLClient interface {
 	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
 	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
@@ -30,7 +27,6 @@ type SQLClient interface {
 
 type GenericSQLDatastore struct {
 	mtx              sync.RWMutex
-	name             string
 	connectionString string
 	db               *sql.DB
 }
@@ -41,7 +37,6 @@ func NewGenericSQLDatastore(
 	connectionString string,
 ) (*GenericSQLDatastore, error) {
 	datastore := &GenericSQLDatastore{
-		name:             name,
 		connectionString: connectionString,
 		db:               db,
 	}
@@ -54,10 +49,6 @@ func NewGenericSQLDatastore(
 
 func (d *GenericSQLDatastore) GetDB() *sql.DB {
 	return d.db
-}
-
-func (d *GenericSQLDatastore) GetSpan(ctx context.Context, methodName string) (context.Context, trace.Span) {
-	return system.GetTracer().Start(ctx, fmt.Sprintf("pkg/localdb/shared/GenericSQLDatastore[%s].%s", d.name, methodName))
 }
 
 func getJob(db SQLClient, ctx context.Context, id string) (*model.Job, error) {
@@ -88,9 +79,6 @@ func getJob(db SQLClient, ctx context.Context, id string) (*model.Job, error) {
 func (d *GenericSQLDatastore) GetJob(ctx context.Context, id string) (*model.Job, error) {
 	d.mtx.RLock()
 	defer d.mtx.RUnlock()
-	//nolint:ineffassign,staticcheck
-	ctx, span := d.GetSpan(ctx, "GetJob")
-	defer span.End()
 	return getJob(d.db, ctx, id)
 }
 
@@ -241,8 +229,6 @@ func getJobs(db SQLClient, ctx context.Context, query localdb.JobQuery) ([]*mode
 func (d *GenericSQLDatastore) GetJobs(ctx context.Context, query localdb.JobQuery) ([]*model.Job, error) {
 	d.mtx.RLock()
 	defer d.mtx.RUnlock()
-	ctx, span := d.GetSpan(ctx, "GetJobs")
-	defer span.End()
 	return getJobs(d.db, ctx, query)
 }
 
@@ -316,8 +302,6 @@ order by
 func (d *GenericSQLDatastore) GetJobEvents(ctx context.Context, id string) ([]model.JobEvent, error) {
 	d.mtx.RLock()
 	defer d.mtx.RUnlock()
-	ctx, span := d.GetSpan(ctx, "GetJobEvents")
-	defer span.End()
 	return getJobEvents(d.db, ctx, id)
 }
 
@@ -363,8 +347,6 @@ order by
 func (d *GenericSQLDatastore) GetJobLocalEvents(ctx context.Context, id string) ([]model.JobLocalEvent, error) {
 	d.mtx.RLock()
 	defer d.mtx.RUnlock()
-	ctx, span := d.GetSpan(ctx, "GetJobLocalEvents")
-	defer span.End()
 	return getJobLocalEvents(d.db, ctx, id)
 }
 
@@ -386,8 +368,6 @@ func (d *GenericSQLDatastore) HasLocalEvent(ctx context.Context, jobID string, e
 func (d *GenericSQLDatastore) AddJob(ctx context.Context, j *model.Job) error {
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
-	_, span := d.GetSpan(ctx, "AddJob")
-	defer span.End()
 
 	tx, err := d.db.Begin()
 	if err != nil {
@@ -403,7 +383,8 @@ VALUES ($1, $2, $3, $4, $5, $6)`
 	if err != nil {
 		return err
 	}
-	_, err = tx.Exec(
+	_, err = tx.ExecContext(
+		ctx,
 		sqlStatement,
 		j.Metadata.ID,
 		j.Metadata.CreatedAt.UTC().Format(time.RFC3339),
@@ -419,7 +400,8 @@ VALUES ($1, $2, $3, $4, $5, $6)`
 		sqlStatement := `
 INSERT INTO job_annotation (job_id, annotation)
 VALUES ($1, $2)`
-		_, err = tx.Exec(
+		_, err = tx.ExecContext(
+			ctx,
 			sqlStatement,
 			j.Metadata.ID,
 			annotation,
@@ -435,8 +417,6 @@ func (d *GenericSQLDatastore) AddEvent(ctx context.Context, jobID string, ev mod
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
 	//nolint:ineffassign,staticcheck
-	ctx, span := d.GetSpan(ctx, "AddEvent")
-	defer span.End()
 	sqlStatement := `
 INSERT INTO job_event (job_id, created, apiversion, eventdata)
 VALUES ($1, $2, $3, $4)`
@@ -444,7 +424,8 @@ VALUES ($1, $2, $3, $4)`
 	if err != nil {
 		return err
 	}
-	_, err = d.db.Exec(
+	_, err = d.db.ExecContext(
+		ctx,
 		sqlStatement,
 		jobID,
 		ev.EventTime.UTC().Format(time.RFC3339),
@@ -461,8 +442,6 @@ func (d *GenericSQLDatastore) AddLocalEvent(ctx context.Context, jobID string, e
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
 	//nolint:ineffassign,staticcheck
-	ctx, span := d.GetSpan(ctx, "AddLocalEvent")
-	defer span.End()
 	sqlStatement := `
 INSERT INTO local_event (job_id, created, apiversion, eventdata)
 VALUES ($1, $2, $3, $4)`
@@ -470,7 +449,8 @@ VALUES ($1, $2, $3, $4)`
 	if err != nil {
 		return err
 	}
-	_, err = d.db.Exec(
+	_, err = d.db.ExecContext(
+		ctx,
 		sqlStatement,
 		jobID,
 		time.Now().UTC().Format(time.RFC3339),
@@ -487,8 +467,6 @@ func (d *GenericSQLDatastore) UpdateJobDeal(ctx context.Context, jobID string, d
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
 	//nolint:ineffassign,staticcheck
-	ctx, span := d.GetSpan(ctx, "UpdateJobDeal")
-	defer span.End()
 	tx, err := d.db.Begin()
 	if err != nil {
 		return err
@@ -506,7 +484,8 @@ func (d *GenericSQLDatastore) UpdateJobDeal(ctx context.Context, jobID string, d
 	if err != nil {
 		return err
 	}
-	_, err = tx.Exec(
+	_, err = tx.ExecContext(
+		ctx,
 		sqlStatement,
 		string(jobData),
 		model.APIVersionLatest().String(),
@@ -543,8 +522,6 @@ func getJobState(db SQLClient, ctx context.Context, jobID string) (model.JobStat
 func (d *GenericSQLDatastore) GetJobState(ctx context.Context, jobID string) (model.JobState, error) {
 	d.mtx.RLock()
 	defer d.mtx.RUnlock()
-	ctx, span := d.GetSpan(ctx, "GetJobState")
-	defer span.End()
 	return getJobState(d.db, ctx, jobID)
 }
 
@@ -556,8 +533,6 @@ func (d *GenericSQLDatastore) UpdateShardState(
 ) error {
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
-	ctx, span := d.GetSpan(ctx, "UpdateShardState")
-	defer span.End()
 	tx, err := d.db.Begin()
 	if err != nil {
 		return err
@@ -578,7 +553,8 @@ func (d *GenericSQLDatastore) UpdateShardState(
 	if err != nil {
 		return err
 	}
-	_, err = tx.Exec(
+	_, err = tx.ExecContext(
+		ctx,
 		sqlStatement,
 		string(stateData),
 		model.APIVersionLatest().String(),

--- a/pkg/localdb/shared/test_utils.go
+++ b/pkg/localdb/shared/test_utils.go
@@ -6,28 +6,16 @@ import (
 	"database/sql"
 	"fmt"
 	"log"
-	"runtime"
-	"testing"
 	"time"
 
 	"github.com/filecoin-project/bacalhau/pkg/localdb"
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 	_ "github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/model"
+	"github.com/filecoin-project/bacalhau/pkg/system"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
-
-const linuxRuntime = "linux"
-
-func skipIfNotLinux(t *testing.T) {
-	if runtime.GOOS != linuxRuntime {
-		t.Skip("Test does not pass natively on non linux")
-	}
-}
-
-func TestExampleTestSuite(t *testing.T) {
-	suite.Run(t, new(GenericSQLSuite))
-}
 
 type GenericSQLSuite struct {
 	suite.Suite
@@ -38,25 +26,20 @@ type GenericSQLSuite struct {
 }
 
 func (suite *GenericSQLSuite) SetupTest() {
-	if runtime.GOOS != linuxRuntime {
-		return
-	}
+	suite.Require().NoError(system.InitConfigForTesting(suite.T()))
+	logger.ConfigureTestLogging(suite.T())
 	datastore := suite.SetupHandler()
 	suite.datastore = datastore
 	suite.db = datastore.GetDB()
 }
 
 func (suite *GenericSQLSuite) TearDownSuite() {
-	if runtime.GOOS != linuxRuntime {
-		return
-	}
 	if suite.TeardownHandler != nil {
 		suite.TeardownHandler()
 	}
 }
 
 func (suite *GenericSQLSuite) TestSQLiteMigrations() {
-	skipIfNotLinux(suite.T())
 	_, err := suite.db.Exec(`
 insert into job (id) values ('123');
 `)
@@ -80,7 +63,6 @@ select id from job;
 }
 
 func (suite *GenericSQLSuite) TestRoundtripJob() {
-	skipIfNotLinux(suite.T())
 	job := &model.Job{
 		Metadata: model.Metadata{
 			ID: "hellojob",
@@ -94,7 +76,6 @@ func (suite *GenericSQLSuite) TestRoundtripJob() {
 }
 
 func (suite *GenericSQLSuite) TestAddingTwoJobs() {
-	skipIfNotLinux(suite.T())
 	err := suite.datastore.AddJob(context.Background(), &model.Job{
 		Metadata: model.Metadata{
 			ID: "hellojob1",
@@ -111,7 +92,6 @@ func (suite *GenericSQLSuite) TestAddingTwoJobs() {
 
 //nolint:funlen
 func (suite *GenericSQLSuite) TestGetJobs() {
-	skipIfNotLinux(suite.T())
 	jobCount := 100
 	dateString := "2021-11-22"
 	date, err := time.Parse("2006-01-02", dateString)
@@ -253,7 +233,6 @@ func (suite *GenericSQLSuite) TestGetJobs() {
 }
 
 func (suite *GenericSQLSuite) TestJobEvents() {
-	skipIfNotLinux(suite.T())
 	eventCount := 5
 	job := &model.Job{
 		Metadata: model.Metadata{
@@ -305,7 +284,6 @@ func (suite *GenericSQLSuite) TestJobEvents() {
 }
 
 func (suite *GenericSQLSuite) TestJobState() {
-	skipIfNotLinux(suite.T())
 	job := &model.Job{
 		Metadata: model.Metadata{
 			ID: "hellojob",
@@ -336,7 +314,6 @@ func (suite *GenericSQLSuite) TestJobState() {
 }
 
 func (suite *GenericSQLSuite) TestUpdateDeal() {
-	skipIfNotLinux(suite.T())
 	job := &model.Job{
 		Metadata: model.Metadata{
 			ID: "hellojob",

--- a/pkg/localdb/sqlite/sqlite.go
+++ b/pkg/localdb/sqlite/sqlite.go
@@ -3,17 +3,20 @@ package sqlite
 import (
 	"fmt"
 
-	"database/sql"
-
+	"github.com/XSAM/otelsql"
 	"github.com/filecoin-project/bacalhau/pkg/localdb/shared"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 
 	_ "github.com/golang-migrate/migrate/v4/database/sqlite"
 	_ "modernc.org/sqlite"
 )
 
 func NewSQLiteDatastore(filename string) (*shared.GenericSQLDatastore, error) {
-	db, err := sql.Open("sqlite", filename)
+	db, err := otelsql.Open("sqlite", filename, otelsql.WithAttributes(semconv.DBSystemSqlite))
 	if err != nil {
+		return nil, err
+	}
+	if err := otelsql.RegisterDBStatsMetrics(db, otelsql.WithAttributes(semconv.DBSystemSqlite)); err != nil { //nolint:govet
 		return nil, err
 	}
 	datastore, err := shared.NewGenericSQLDatastore(

--- a/pkg/localdb/sqlite/sqlite_test.go
+++ b/pkg/localdb/sqlite/sqlite_test.go
@@ -1,10 +1,9 @@
-//go:build integration
+//go:build integration && linux
 
 package sqlite
 
 import (
-	"io/ioutil"
-	"runtime"
+	"os"
 	"testing"
 
 	"github.com/filecoin-project/bacalhau/pkg/localdb/shared"
@@ -16,10 +15,7 @@ import (
 func TestSQLiteSuite(t *testing.T) {
 	testingSuite := new(shared.GenericSQLSuite)
 	testingSuite.SetupHandler = func() *shared.GenericSQLDatastore {
-		if runtime.GOOS != "linux" {
-			return nil
-		}
-		datafile, err := ioutil.TempFile("", "sqlite-test-*.db")
+		datafile, err := os.CreateTemp("", "sqlite-test-*.db")
 		require.NoError(testingSuite.T(), err)
 		datastore, err := NewSQLiteDatastore(datafile.Name())
 		require.NoError(testingSuite.T(), err)

--- a/pkg/system/utils.go
+++ b/pkg/system/utils.go
@@ -2,10 +2,8 @@ package system
 
 import (
 	"bufio"
-	"bytes"
 	"io"
 	"os"
-	"os/exec"
 	"regexp"
 	"strings"
 
@@ -94,16 +92,4 @@ func GetShortID(ID string) string {
 		return ID
 	}
 	return ID[:model.ShortIDLength]
-}
-
-const ShellToUse = "bash"
-
-func Shellout(command string) (string, string, error) {
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	cmd := exec.Command(ShellToUse, "-c", command)
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	err := cmd.Run()
-	return stdout.String(), stderr.String(), err
 }


### PR DESCRIPTION
Add support for automatically tracing SQL commands rather than having to perform them manually. This will produce spans like ones labeled `sql.conn.exec` with the executed SQL as a tag like `INSERT INTO job_annotation (job_id, annotation) VALUES ($1, $2)`.

Part of #1925