### PR TITLE
Avoid aws_key precommit false positives with import statements

### DIFF
--- a/.gitprecommit/aws_key_checker.sh
+++ b/.gitprecommit/aws_key_checker.sh
@@ -17,7 +17,7 @@ FILES=$(git diff --cached --name-only "${against}")
 
 if [[ -n "${FILES}" ]]; then
     KEY_ID=$(grep -E --line-number '([^A-Z0-9]|^)[A-Z0-9]{20}([^A-Z0-9]|$)' "${FILES}")
-    KEY=$(grep -E --line-number '([^A-Za-z0-9/+=]|^)[A-Za-z0-9/+=]{40}([^A-Za-z0-9/+=]|$)' "${FILES}")
+    KEY=$(grep -E --line-number '^(?!github)([^A-Za-z0-9/+=]|^)[A-Za-z0-9/+=]{40}([^A-Za-z0-9/+=]|$)' "${FILES}")
 
     if [[ -n "${KEY_ID}" ]] || [[ -n "${KEY}" ]]; then
         echo "=========== Possible AWS Access Key IDs ==========="


### PR DESCRIPTION
Currently the regex used for AWS_SECRET_KEYs will match the string `github.com/filecoin-project/bacalhau/pkg/requester/publicapi` where it is used in an import block.

By ensuring the line does not begin with `github`, the start of an import, we can avoid these matches.