### PR TITLE
Trace Lotus & Estuary communication

### DIFF
--- a/pkg/publisher/estuary/endpoints.go
+++ b/pkg/publisher/estuary/endpoints.go
@@ -1,9 +1,11 @@
 package estuary
 
 import (
-	"context"
+	"fmt"
+	"net/http"
 
 	estuary_client "github.com/application-research/estuary-clients/go"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
 const gatewayEndpoint string = "https://api.estuary.tech"
@@ -12,10 +14,15 @@ func getAPIConfig(baseURL string, apiKey string) *estuary_client.Configuration {
 	config := estuary_client.NewConfiguration()
 	config.BasePath = baseURL
 	config.AddDefaultHeader("Authorization", "Bearer "+apiKey)
+	config.HTTPClient = &http.Client{
+		Transport: otelhttp.NewTransport(nil, otelhttp.WithSpanNameFormatter(func(operation string, r *http.Request) string {
+			return fmt.Sprintf("%s %s", r.Method, r.URL.Path)
+		})),
+	}
 	return config
 }
 
-func GetClient(ctx context.Context, apiKey string) *estuary_client.APIClient {
+func GetClient(apiKey string) *estuary_client.APIClient {
 	gatewayConfig := getAPIConfig(gatewayEndpoint, apiKey)
 	return estuary_client.NewAPIClient(gatewayConfig)
 }


### PR DESCRIPTION
Ensure we are emitting tracing spans when communicating with Estuary & Lotus. The libraries used by Lotus to provide their API doesn't natively support tracing so this has to be done in our code.

Part of #1925