### PR TITLE
Make sure files are written to the correct dir

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/filecoin-project/go-address v1.1.0
 	github.com/filecoin-project/go-jsonrpc v0.1.9
 	github.com/filecoin-project/go-state-types v0.9.9
-	github.com/go-resty/resty/v2 v2.7.0
 	github.com/go-test/deep v1.1.0
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/golang-migrate/migrate/v4 v4.15.2
@@ -29,6 +28,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.5.0
 	github.com/hashicorp/go-multierror v1.1.1
+	github.com/hashicorp/go-retryablehttp v0.7.2
 	github.com/imdario/mergo v0.3.13
 	github.com/invopop/jsonschema v0.7.0
 	github.com/ipfs/go-cid v0.3.2
@@ -162,6 +162,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 // indirect
 	github.com/hannahhoward/go-pubsub v0.0.0-20200423002714-8d62886cc36e // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/huin/goupnp v1.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -681,8 +681,6 @@ github.com/go-openapi/swag v0.22.3/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+
 github.com/go-pkgz/expirable-cache v0.1.0/go.mod h1:GTrEl0X+q0mPNqN6dtcQXksACnzCBQ5k/k1SwXJsZKs=
 github.com/go-pkgz/expirable-cache v1.0.0 h1:ns5+1hjY8hntGv8bPaQd9Gr7Jyo+Uw5SLyII40aQdtA=
 github.com/go-pkgz/expirable-cache v1.0.0/go.mod h1:GTrEl0X+q0mPNqN6dtcQXksACnzCBQ5k/k1SwXJsZKs=
-github.com/go-resty/resty/v2 v2.7.0 h1:me+K9p3uhSmXtrBZ4k9jcEAfJmuC8IivWHwaLZwPrFY=
-github.com/go-resty/resty/v2 v2.7.0/go.mod h1:9PWDzw47qPphMRFfhsyk0NnSgvluHcljSMVIq3w7q0I=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
@@ -908,6 +906,10 @@ github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
+github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
+github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
+github.com/hashicorp/go-hclog v1.2.0 h1:La19f8d7WIlm4ogzNHB0JGqs5AUDAZ2UfCY4sJXcJdM=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v0.0.0-20161216184304-ed905158d874/go.mod h1:JMRHfdO9jKNzS/+BTlxCjKNQHg/jZAft8U7LloJvN7I=
@@ -915,6 +917,8 @@ github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHh
 github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
+github.com/hashicorp/go-retryablehttp v0.7.2 h1:AcYqCvkpalPnPF2pn0KamgwamS42TqUDDYFRKq/RAd0=
+github.com/hashicorp/go-retryablehttp v0.7.2/go.mod h1:Jy/gPYAdjqffZ/yFGCFV2doI5wjtH1ewM9u8iYVjtX8=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
@@ -2767,7 +2771,6 @@ golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210825183410-e898025ed96a/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210917221730-978cfadd31cf/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20211029224645-99673261e6eb/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211209124913-491a49abca63/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211216030914-fe4d6282115f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220111093109-d55c255bac03/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=

--- a/pkg/storage/url/urldownload/storage.go
+++ b/pkg/storage/url/urldownload/storage.go
@@ -16,9 +16,12 @@ import (
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/filecoin-project/bacalhau/pkg/storage"
 	"github.com/filecoin-project/bacalhau/pkg/system"
-	"github.com/go-resty/resty/v2"
+	"github.com/filecoin-project/bacalhau/pkg/util/closer"
 	"github.com/google/uuid"
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
 // a storage driver runs the downloads content
@@ -27,8 +30,8 @@ import (
 // a job to run - it will remove the folder/file once complete
 
 type StorageProvider struct {
-	LocalDir   string
-	HTTPClient *resty.Client
+	localDir string
+	client   *retryablehttp.Client
 }
 
 func NewStorage(cm *system.CleanupManager) (*StorageProvider, error) {
@@ -45,21 +48,42 @@ func NewStorage(cm *system.CleanupManager) (*StorageProvider, error) {
 		return nil
 	})
 
-	client := resty.New()
-	// Setting output directory path, If directory not exists then resty creates one
-	client.SetOutputDirectory(dir)
-	// Setting the number of times to try downloading the URL
-	client.SetRetryCount(config.GetDownloadURLRequestRetries())
-	client.SetRetryWaitTime(time.Second * 1)
-	client.AddRetryAfterErrorCondition()
+	log.Debug().Str("dir", dir).Msg("URL download driver created with output dir")
 
-	storageHandler := &StorageProvider{
-		HTTPClient: client,
-		LocalDir:   dir,
+	return newStorage(dir), nil
+}
+
+func newStorage(dir string) *StorageProvider {
+	client := retryablehttp.NewClient()
+	client.HTTPClient = &http.Client{
+		Timeout: config.GetDownloadURLRequestTimeout(),
+		Transport: otelhttp.NewTransport(nil, otelhttp.WithSpanNameFormatter(func(operation string, r *http.Request) string {
+			return fmt.Sprintf("%s %s", r.Method, r.URL.Path)
+		})),
+	}
+	client.RetryMax = config.GetDownloadURLRequestRetries()
+	client.RetryWaitMax = time.Second * 1
+	client.Logger = retryLogger{}
+	client.CheckRetry = func(ctx context.Context, resp *http.Response, err error) (bool, error) {
+		if err := ctx.Err(); err != nil { //nolint:govet
+			return false, err
+		}
+		if err == nil {
+			// Existing behavior around retrying is to retry on _all_ non 2xx status codes. This includes codes that would have no
+			// realistic hope of succeeding like `Unauthorized` or `Gone`
+			if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusBadRequest {
+				return false, nil
+			}
+			return true, nil
+		}
+
+		return retryablehttp.DefaultRetryPolicy(ctx, resp, err)
 	}
 
-	log.Debug().Msgf("URL download driver created with output dir: %s", dir)
-	return storageHandler, nil
+	return &StorageProvider{
+		localDir: dir,
+		client:   client,
+	}
 }
 
 func (sp *StorageProvider) IsInstalled(context.Context) (bool, error) {
@@ -70,48 +94,38 @@ func (sp *StorageProvider) HasStorageLocally(context.Context, model.StorageSpec)
 	return false, nil
 }
 
-// Could do a HEAD request and check Content-Length, but in some cases that's not guaranteed to be the real end file size
 func (sp *StorageProvider) GetVolumeSize(context.Context, model.StorageSpec) (uint64, error) {
+	// Could do a HEAD request and check Content-Length, but in some cases that's not guaranteed to be the real end file size
 	return 0, nil
 }
 
-// For the urldownload storage provider, PrepareStorage will download the file from the URL
-//
-//nolint:funlen,gocyclo // TODO: refactor this function
+// PrepareStorage will download the file from the URL
 func (sp *StorageProvider) PrepareStorage(ctx context.Context, storageSpec model.StorageSpec) (storage.StorageVolume, error) {
 	u, err := IsURLSupported(storageSpec.URL)
 	if err != nil {
 		return storage.StorageVolume{}, err
 	}
 
-	outputPath, err := os.MkdirTemp(sp.LocalDir, "*")
+	outputPath, err := os.MkdirTemp(sp.localDir, "*")
 	if err != nil {
 		return storage.StorageVolume{}, err
 	}
 
-	sp.HTTPClient.SetTimeout(config.GetDownloadURLRequestTimeout())
-	sp.HTTPClient.SetOutputDirectory(outputPath)
-	sp.HTTPClient.SetDoNotParseResponse(true) // We want to stream the response to disk directly
-
-	// Trying a check for head - just trying to fail quickly if the site is clearly wrong.
-	// This MAY fail with 405 (method not allowed) if the server doesn't support HEAD which is generally
-	// OK because we will fail if the server is down - so it is a best effort.
-	req := sp.HTTPClient.R().SetContext(ctx)
-	req = req.SetContext(ctx)
-	r, err := req.Head(u.String())
-	log.Debug().Msgf("HEAD request to %s returned status code %d", u.String(), r.StatusCode())
+	req, err := retryablehttp.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	if err != nil {
-		return storage.StorageVolume{}, fmt.Errorf("failed to get headers from url (%s): %s", u.String(), err)
+		return storage.StorageVolume{}, err
+	}
+	res, err := sp.client.Do(req) //nolint:bodyclose // this is being closed - golangci-lint is wrong again
+	if err != nil {
+		return storage.StorageVolume{}, fmt.Errorf("failed to begin download from url %s: %w", u, err)
+	}
+	defer closer.DrainAndCloseWithLogOnError(ctx, "response", res.Body)
+
+	if res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusMultipleChoices {
+		return storage.StorageVolume{}, fmt.Errorf("non-200 response from URL (%s): %s", storageSpec.URL, res.Status)
 	}
 
-	// Checking to see about redirect here (does not 100% work because could have rejected the HEAD request)
-	finalURL := r.RawResponse.Request.URL
-	if finalURL != u {
-		log.Debug().Msgf("URL %s redirected to %s", u.String(), finalURL.String())
-	}
-
-	// Create a new file based on the URL
-	baseName := path.Base(finalURL.Path)
+	baseName := path.Base(res.Request.URL.Path)
 	var fileName string
 	if baseName == "." || baseName == "/" {
 		// There is no filename in the URL, so we need to a temp one
@@ -120,70 +134,31 @@ func (sp *StorageProvider) PrepareStorage(ctx context.Context, storageSpec model
 		fileName = baseName
 	}
 
-	log.Trace().Msgf("Beginning get %s to %s", finalURL, outputPath)
-	r, err = req.Get(finalURL.String())
-	if err != nil {
-		return storage.StorageVolume{},
-			fmt.Errorf("failed to begin download from url %s: %s", finalURL, err)
-	}
-
-	if r.StatusCode() != http.StatusOK {
-		return storage.StorageVolume{},
-			fmt.Errorf("non-200 response from URL (%s): %s", storageSpec.URL, r.Status())
-	}
-
 	filePath := filepath.Join(outputPath, fileName)
-	targetPath := filepath.Join(storageSpec.Path, fileName)
 	w, err := os.Create(filePath)
 	if err != nil {
 		return storage.StorageVolume{}, fmt.Errorf("failed to create file %s: %s", filePath, err)
 	}
 
+	defer closer.CloseWithLogOnError("file", w)
+
 	// stream the body to the client without fully loading it into memory
-	n, err := io.Copy(w, r.RawBody())
-	if err != nil {
+	if _, err := io.Copy(w, res.Body); err != nil {
 		return storage.StorageVolume{}, fmt.Errorf("failed to write to file %s: %s", filePath, err)
 	}
 
-	if n == 0 {
-		return storage.StorageVolume{}, fmt.Errorf("no bytes written to file %s", filePath)
+	if err := w.Sync(); err != nil {
+		return storage.StorageVolume{}, fmt.Errorf("failed to sync file %s: %w", filePath, err)
 	}
 
-	log.Trace().Msgf("Wrote %d bytes to %s", n, filePath)
+	targetPath := filepath.Join(storageSpec.Path, fileName)
 
-	// Closing everything
-	err = w.Sync()
-	if err != nil {
-		return storage.StorageVolume{}, fmt.Errorf("failed to sync file %s: %s", filePath, err)
-	}
-
-	// If path.Base isn't empty, we'll see if it got redirected to a different file name
-	// and if so, we'll rename it to the original file name from the URL
-	// Otherwise, we'll just use the filename we created
-	var finalFileName string
-	if baseName != "." && baseName != "/" {
-		finalFileName = filepath.Join(outputPath, path.Base(r.RawResponse.Request.URL.Path))
-	} else {
-		finalFileName = filePath
-	}
-
-	fileWriteName := w.Name()
-	log.Debug().Msgf("Final file name based on URL: %s", finalFileName)
-	log.Debug().Msgf("Final written name: %s", fileWriteName)
-	if finalFileName != fileWriteName {
-		log.Debug().Msgf("Downloaded file has different name than final name - renaming: %s to %s", w.Name(), finalFileName)
-		err = os.Rename(w.Name(), finalFileName)
-		if err != nil {
-			return storage.StorageVolume{}, fmt.Errorf("failed to rename file %s to %s: %s", w.Name(), finalFileName, err)
-		}
-
-		// Need to update filePath and targetPath to accommodate the rename
-		filePath = filepath.Join(outputPath, filepath.Base(finalFileName))
-		targetPath = filepath.Join(storageSpec.Path, filepath.Base(finalFileName))
-	}
-
-	r.RawBody().Close()
-	w.Close()
+	log.Ctx(ctx).Debug().
+		Stringer("url", u).
+		Stringer("final-url", res.Request.URL).
+		Str("file", filePath).
+		Str("targetFile", targetPath).
+		Msg("Downloaded file")
 
 	volume := storage.StorageVolume{
 		Type:   storage.StorageVolumeConnectorBind,
@@ -204,14 +179,14 @@ func (sp *StorageProvider) CleanupStorage(
 	return os.RemoveAll(pathToCleanup)
 }
 
-// we don't "upload" anything to a URL
 func (sp *StorageProvider) Upload(context.Context, string) (model.StorageSpec, error) {
+	// we don't "upload" anything to a URL
 	return model.StorageSpec{}, fmt.Errorf("not implemented")
 }
 
-// for the url download - explode will always result in a single item
-// mounted at the path specified in the spec
 func (sp *StorageProvider) Explode(_ context.Context, spec model.StorageSpec) ([]model.StorageSpec, error) {
+	// for the url download - explode will always result in a single item
+	// mounted at the path specified in the spec
 	return []model.StorageSpec{
 		{
 			Name:          spec.Name,
@@ -243,5 +218,44 @@ func IsURLSupported(rawURL string) (*url.URL, error) {
 	return u, nil
 }
 
-// Compile time interface check:
 var _ storage.Storage = (*StorageProvider)(nil)
+
+var _ retryablehttp.LeveledLogger = retryLogger{}
+
+type retryLogger struct {
+}
+
+func (r retryLogger) Error(msg string, keysAndValues ...interface{}) {
+	parseKeysAndValues(log.Error(), keysAndValues...).Msg(msg)
+}
+
+func (r retryLogger) Info(msg string, keysAndValues ...interface{}) {
+	parseKeysAndValues(log.Info(), keysAndValues...).Msg(msg)
+}
+
+func (r retryLogger) Debug(msg string, keysAndValues ...interface{}) {
+	parseKeysAndValues(log.Debug(), keysAndValues...).Msg(msg)
+}
+
+func (r retryLogger) Warn(msg string, keysAndValues ...interface{}) {
+	parseKeysAndValues(log.Warn(), keysAndValues...).Msg(msg)
+}
+
+func parseKeysAndValues(e *zerolog.Event, keysAndValues ...interface{}) *zerolog.Event {
+	for i := 0; i < len(keysAndValues); i = i + 2 {
+		name := keysAndValues[i].(string)
+		value := keysAndValues[i+1]
+		if v, ok := value.(string); ok {
+			e = e.Str(name, v)
+		} else if v, ok := value.(error); ok {
+			e = e.AnErr(name, v)
+		} else if v, ok := value.(fmt.Stringer); ok {
+			e = e.Stringer(name, v)
+		} else if v, ok := value.(int); ok {
+			e = e.Int(name, v)
+		} else {
+			e = e.Interface(name, value)
+		}
+	}
+	return e
+}

--- a/pkg/storage/url/urldownload/storage_test.go
+++ b/pkg/storage/url/urldownload/storage_test.go
@@ -5,19 +5,16 @@ package urldownload
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"regexp"
 	"testing"
 
 	"github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/filecoin-project/bacalhau/pkg/system"
 	"github.com/spf13/cobra"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -36,35 +33,28 @@ func TestStorageSuite(t *testing.T) {
 // Before each test
 func (s *StorageSuite) SetupTest() {
 	logger.ConfigureTestLogging(s.T())
-	require.NoError(s.T(), system.InitConfigForTesting(s.T()))
+	s.Require().NoError(system.InitConfigForTesting(s.T()))
 }
 
 func (s *StorageSuite) TestNewStorageProvider() {
 	cm := system.NewCleanupManager()
 
 	sp, err := NewStorage(cm)
-	require.NoError(s.T(), err, "failed to create storage provider")
+	s.Require().NoError(err, "failed to create storage provider")
 
 	// is dir writable?
-	fmt.Println(sp.LocalDir)
-	f, err := os.Create(filepath.Join(sp.LocalDir, "data.txt"))
-	require.NoError(s.T(), err, "failed to create file")
+	f, err := os.Create(filepath.Join(sp.localDir, "data.txt"))
+	s.Require().NoError(err, "failed to create file")
 
 	_, err = f.WriteString("test\n")
-	require.NoError(s.T(), err, "failed to write to file")
+	s.Require().NoError(err, "failed to write to file")
 
-	f.Close()
-	if sp.HTTPClient == nil {
-		require.Fail(s.T(), "HTTPClient is nil")
-	}
+	s.NoError(f.Close())
+	s.Require().NotNil(sp.client, "HTTPClient is nil")
 }
 
 func (s *StorageSuite) TestHasStorageLocally() {
-	cm := system.NewCleanupManager()
-	ctx := context.Background()
-
-	sp, err := NewStorage(cm)
-	require.NoError(s.T(), err, "failed to create storage provider")
+	sp := newStorage(s.T().TempDir())
 
 	spec := model.StorageSpec{
 		StorageSource: model.StorageSourceURLDownload,
@@ -72,236 +62,180 @@ func (s *StorageSuite) TestHasStorageLocally() {
 		Path:          "foo",
 	}
 	// files are not cached thus shall never return true
-	locally, err := sp.HasStorageLocally(ctx, spec)
-	require.NoError(s.T(), err, "failed to check if storage is locally available")
+	locally, err := sp.HasStorageLocally(context.Background(), spec)
+	s.Require().NoError(err, "failed to check if storage is locally available")
 
-	if locally != false {
-		require.Fail(s.T(), "storage should not be locally available")
-	}
+	s.False(locally, "storage should not be locally available")
 }
 
 func (s *StorageSuite) TestPrepareStorageURL() {
-	fileName := "testfile.py"
-	_ = fileName
-	testString := "Here's your data"
-
-	redirectCases := map[string]struct {
-		redirect bool
+	type dummyRequest struct {
+		path    string
+		code    int
+		content string
+	}
+	tests := []struct {
+		name             string
+		requests         []dummyRequest
+		expectedContent  string
+		expectedFilename string
 	}{
-		"No-redirect": {
-			redirect: false,
+		{
+			name: "follows-redirect",
+			requests: []dummyRequest{
+				{
+					path:    "/initial",
+					code:    302,
+					content: "/second.png",
+				},
+				{
+					path:    "/second.png",
+					code:    302,
+					content: "/third.txt",
+				},
+				{
+					path:    "/third.txt",
+					code:    200,
+					content: "this is from the final redirect",
+				},
+			},
+			expectedContent:  "this is from the final redirect",
+			expectedFilename: "third.txt",
 		},
-		"Redirect": {
-			redirect: true,
+		{
+			name: "retries",
+			requests: []dummyRequest{
+				{
+					path:    "/initial",
+					code:    500,
+					content: "",
+				},
+				{
+					path:    "/initial",
+					code:    500,
+					content: "",
+				},
+				{
+					path:    "/initial",
+					code:    200,
+					content: "got there eventually",
+				},
+			},
+			expectedContent:  "got there eventually",
+			expectedFilename: "initial",
+		},
+		{
+			name: "retry-anything",
+			requests: []dummyRequest{
+				{
+					path:    "/initial",
+					code:    401,
+					content: "not allowed",
+				},
+				{
+					path:    "/initial",
+					code:    401,
+					content: "not allowed",
+				},
+				{
+					path:    "/initial",
+					code:    200,
+					content: "changed my mind",
+				},
+			},
+			expectedContent:  "changed my mind",
+			expectedFilename: "initial",
+		},
+		{
+			name: "generates-name",
+			requests: []dummyRequest{
+				{
+					path:    "/",
+					code:    200,
+					content: "name should be a UUID",
+				},
+			},
+			expectedContent:  "name should be a UUID",
+			expectedFilename: "",
+		},
+		{
+			name: "no-content",
+			requests: []dummyRequest{
+				{
+					path:    "/nothing.txt",
+					code:    204,
+					content: "",
+				},
+			},
+			expectedContent:  "",
+			expectedFilename: "nothing.txt",
+		},
+		{
+			name: "picsum.photos",
+			requests: []dummyRequest{
+				{
+					path:    "/200/300",
+					code:    302,
+					content: "/id/568/200/300.jpg",
+				},
+				{
+					path:    "/id/568/200/300.jpg",
+					code:    200,
+					content: "i'm not putting an image here",
+				},
+			},
+			expectedContent:  "i'm not putting an image here",
+			expectedFilename: "300.jpg",
 		},
 	}
 
-	filetypeCases := map[string]struct {
-		fileName      string
-		content       string
-		valid         bool
-		errorContains string
-		errorMsg      string
-	}{
-		"Test-Valid": {fileName: fileName,
-			content:       testString,
-			valid:         true,
-			errorContains: "",
-			errorMsg:      "TYPE: Valid"},
-		"Test-No Filename": {fileName: "",
-			content:       testString,
-			valid:         true,
-			errorContains: "",
-			errorMsg:      "TYPE: Valid (create file with random name)"},
-		"Test-No Content": {fileName: fileName,
-			content:       "",
-			valid:         false,
-			errorContains: "no bytes written",
-			errorMsg:      "TYPE: Invalid (no content)"},
-	}
+	for _, test := range tests {
+		s.Run(test.name, func() {
+			responseCount := 0
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				response := test.requests[responseCount]
+				responseCount++
 
-	for redirectName, rc := range redirectCases {
-		for filetypeName, ftc := range filetypeCases {
-			name := fmt.Sprintf("%s-%s", redirectName, filetypeName)
-
-			content, err := func() (string, error) {
-				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					if rc.redirect && r.URL.Path == "/redirect" {
-						http.Redirect(w, r, "/"+ftc.fileName, http.StatusFound)
-					} else {
-						if r.URL.String() == ("/" + ftc.fileName) {
-							w.Write([]byte(ftc.content))
-						}
-					}
-				}))
-				defer ts.Close()
-
-				cm := system.NewCleanupManager()
-				ctx := context.Background()
-				sp, err := NewStorage(cm)
-				if err != nil {
-					return "", fmt.Errorf("%s: failed to create storage provider", name)
+				if r.URL.Path != response.path {
+					http.Error(w, fmt.Sprintf("invalid path: %s should be %s", r.URL.Path, response.path), 999)
+					return
 				}
 
-				serverURL := ts.URL
-				finalURL := ""
-				if rc.redirect {
-					finalURL = ts.URL + "/redirect"
-				} else {
-					finalURL = serverURL + "/" + ftc.fileName
+				if response.code == http.StatusFound {
+					http.Redirect(w, r, response.content, http.StatusFound)
+					return
 				}
 
-				spec := model.StorageSpec{
-					StorageSource: model.StorageSourceURLDownload,
-					URL:           finalURL,
-					Path:          "/inputs",
-				}
+				w.WriteHeader(response.code)
+				_, err := w.Write([]byte(response.content))
+				s.NoError(err)
+			}))
+			s.T().Cleanup(ts.Close)
 
-				volume, err := sp.PrepareStorage(ctx, spec)
-				if err != nil {
-					return "", fmt.Errorf("%s: failed to prepare storage: %+v", name, err)
-				}
+			subject := newStorage(s.T().TempDir())
 
-				// If we have a filename, it should exist in the spec
-				if ftc.fileName != "" {
-					require.Equalf(s.T(), filepath.Join(spec.Path, ftc.fileName), volume.Target, "%s: expected valid to be %t", name, ftc.valid)
-				} else {
-					// The spec should end with a UUID after /inputs
-					re := regexp.MustCompile(`[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$`)
-					require.Regexpf(s.T(), re, volume.Target, "%s: expected target name to end with <UUID>. Actual ending: ", name, volume.Target)
-				}
+			vol, err := subject.PrepareStorage(context.Background(), model.StorageSpec{
+				URL:  fmt.Sprintf("%s%s", ts.URL, test.requests[0].path),
+				Path: "/inputs",
+			})
+			s.Require().NoError(err)
 
-				file, err := os.Open(volume.Source)
-				if err != nil {
-					return "", fmt.Errorf("%s: failed to open file: %+v", name, err)
-				}
-
-				defer func() {
-					if err = file.Close(); err != nil {
-						require.Fail(s.T(), "failed to close file: %s", name)
-					}
-				}()
-
-				content, err := ioutil.ReadAll(file)
-				if err != nil {
-					return "", fmt.Errorf("%s: failed to read file: %+v", name, err)
-				}
-
-				if len(content) == 0 {
-					return "", fmt.Errorf("%s: file is empty", name)
-				}
-
-				return string(content), nil
-			}()
-
-			if ftc.valid {
-				text := string(content)
-				require.Equal(s.T(), ftc.content, text, "%s: content of file does not match", name)
+			actualFilename := filepath.Base(vol.Source)
+			if test.expectedFilename == "" {
+				s.Regexp(`[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$`, actualFilename,
+					"Filename should be a UUID if it can't come from the HTTP response ")
+				s.Regexp(`[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$`, filepath.Base(vol.Target))
+				s.Equal(fmt.Sprintf("%s%s", string(os.PathSeparator), "inputs"), filepath.Dir(vol.Target))
 			} else {
-				require.Error(s.T(), err, "%s: expected error", name)
-				require.Contains(s.T(),
-					err.Error(),
-					ftc.errorContains,
-					"%s: error does not contain expected string",
-					name)
-			}
-		}
-	}
-}
-
-func (s *StorageSuite) TestImageDownloaderLiveRedirectURL() {
-	// This test will fail when offline - we should build a checker to see if someone
-	// is connected to the internet and skip this test if they are not.
-	// This test will also fail if the URL is not reachable.
-	// Using -test.short flag for now
-	if testing.Short() {
-		s.T().Skip("Skipping test that requires internet connection")
-	}
-
-	filetypeCases := map[string]struct {
-		URL           string
-		fileName      string
-		content       string
-		valid         bool
-		errorContains string
-		errorMsg      string
-	}{
-		"PicSum": {URL: "https://picsum.photos/200/300",
-			fileName:      "300.jpg",
-			content:       "",
-			valid:         true,
-			errorContains: "",
-			errorMsg:      "TYPE: Valid"},
-	}
-
-	for filetypeName, ftc := range filetypeCases {
-		name := fmt.Sprintf("%s-%s", filetypeName, ftc.URL)
-
-		content, err := func() (string, error) {
-			cm := system.NewCleanupManager()
-			ctx := context.Background()
-			sp, err := NewStorage(cm)
-			if err != nil {
-				return "", fmt.Errorf("%s: failed to create storage provider", name)
+				s.Equal(test.expectedFilename, actualFilename)
+				s.Equal(filepath.Join("/inputs", test.expectedFilename), vol.Target)
 			}
 
-			spec := model.StorageSpec{
-				StorageSource: model.StorageSourceURLDownload,
-				URL:           ftc.URL,
-				Path:          "/inputs",
-			}
+			s.FileExists(vol.Source)
+			actualContent, err := os.ReadFile(vol.Source)
+			s.Require().NoError(err)
 
-			volume, err := sp.PrepareStorage(ctx, spec)
-			if err != nil {
-				return "", fmt.Errorf("%s: failed to prepare storage: %+v", name, err)
-			}
-
-			// If we have a filename, it should exist in the spec
-			if ftc.fileName != "" {
-				require.Equalf(s.T(), filepath.Join(spec.Path, ftc.fileName), volume.Target, "%s: expected valid to be %t", name, ftc.valid)
-			} else {
-				// The spec should end with a UUID after /inputs
-				re := regexp.MustCompile(`[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$`)
-				require.Regexpf(s.T(), re, volume.Target, "%s: expected target name to end with <UUID>. Actual ending: ", name, volume.Target)
-			}
-
-			file, err := os.Open(volume.Source)
-			if err != nil {
-				return "", fmt.Errorf("%s: failed to open file: %+v", name, err)
-			}
-
-			defer func() {
-				if err = file.Close(); err != nil {
-					require.Fail(s.T(), "failed to close file: %s", name)
-				}
-			}()
-
-			content, err := ioutil.ReadAll(file)
-			if err != nil {
-				return "", fmt.Errorf("%s: failed to read file: %+v", name, err)
-			}
-
-			if len(content) == 0 {
-				return "", fmt.Errorf("%s: file is empty", name)
-			}
-
-			return string(content), nil
-		}()
-
-		if ftc.valid {
-			// For non-deterministic files (eg from live, changing URLs), we won't know what the content
-			// is, so we'll just skip the content check - we've gotten enough tests until now
-			if ftc.content != "" {
-				text := string(content)
-				require.Equal(s.T(), ftc.content, text, "%s: content of file does not match", name)
-			}
-		} else {
-			require.Error(s.T(), err, "%s: expected error", name)
-			require.Contains(s.T(),
-				err.Error(),
-				ftc.errorContains,
-				"%s: error does not contain expected string",
-				name)
-		}
+			s.Equal(test.expectedContent, string(actualContent))
+		})
 	}
 }


### PR DESCRIPTION
The URL download storage provider needed to be rewritten to drop the use of resty as the library didn't provide a way to save arbitrary files into a directory on a per-request basis. Attempting to call `SetOutputDirectory` on the client would modify the client so that _all_ users of the client at that time would output to that directory, rather than just for the current request.

Also adds tracing to URL downloads.

Fixes #1978
Part of #1925