### PR TITLE
Trace remote IPFS queries

### DIFF
--- a/pkg/docker/tracing/traced.go
+++ b/pkg/docker/tracing/traced.go
@@ -186,6 +186,7 @@ func (c TracedClient) span(ctx context.Context, name string) (context.Context, t
 		ctx,
 		system.GetTracer(),
 		fmt.Sprintf("docker.%s", name),
-		trace.WithAttributes(semconv.HostName(c.hostname)),
+		trace.WithAttributes(semconv.HostName(c.hostname), semconv.PeerService("docker")),
+		trace.WithSpanKind(trace.SpanKindClient),
 	)
 }

--- a/pkg/ipfs/tree.go
+++ b/pkg/ipfs/tree.go
@@ -13,14 +13,14 @@ type IPLDTreeNode struct {
 	Children []IPLDTreeNode
 }
 
-func GetTreeNode(ctx context.Context, navNode ipld.NavigableNode, path []string) (IPLDTreeNode, error) {
-	children := []IPLDTreeNode{}
+func getTreeNode(ctx context.Context, navNode ipld.NavigableNode, path []string) (IPLDTreeNode, error) {
+	var children []IPLDTreeNode
 	for i, link := range navNode.GetIPLDNode().Links() {
 		childNavNode, err := navNode.FetchChild(ctx, uint(i))
 		if err != nil {
 			return IPLDTreeNode{}, err
 		}
-		childTreeNode, err := GetTreeNode(ctx, childNavNode, append(path, link.Name))
+		childTreeNode, err := getTreeNode(ctx, childNavNode, append(path, link.Name))
 		if err != nil {
 			return IPLDTreeNode{}, err
 		}

--- a/pkg/localdb/postgres/postgres.go
+++ b/pkg/localdb/postgres/postgres.go
@@ -23,7 +23,7 @@ func NewPostgresDatastore(
 	db, err := otelsql.Open(
 		"postgres",
 		connectionString,
-		otelsql.WithAttributes(semconv.DBSystemPostgreSQL, semconv.HostName(host)),
+		otelsql.WithAttributes(semconv.DBSystemPostgreSQL, semconv.HostName(host), semconv.PeerService("postgres")),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/localdb/sqlite/sqlite.go
+++ b/pkg/localdb/sqlite/sqlite.go
@@ -12,7 +12,11 @@ import (
 )
 
 func NewSQLiteDatastore(filename string) (*shared.GenericSQLDatastore, error) {
-	db, err := otelsql.Open("sqlite", filename, otelsql.WithAttributes(semconv.DBSystemSqlite))
+	db, err := otelsql.Open(
+		"sqlite",
+		filename,
+		otelsql.WithAttributes(semconv.DBSystemSqlite, semconv.PeerService("sqlite")),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/publisher/estuary/endpoints.go
+++ b/pkg/publisher/estuary/endpoints.go
@@ -6,6 +6,8 @@ import (
 
 	estuary_client "github.com/application-research/estuary-clients/go"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+	"go.opentelemetry.io/otel/trace"
 )
 
 const gatewayEndpoint string = "https://api.estuary.tech"
@@ -17,7 +19,7 @@ func getAPIConfig(baseURL string, apiKey string) *estuary_client.Configuration {
 	config.HTTPClient = &http.Client{
 		Transport: otelhttp.NewTransport(nil, otelhttp.WithSpanNameFormatter(func(operation string, r *http.Request) string {
 			return fmt.Sprintf("%s %s", r.Method, r.URL.Path)
-		})),
+		}), otelhttp.WithSpanOptions(trace.WithAttributes(semconv.PeerService("estuary")))),
 	}
 	return config
 }

--- a/pkg/publisher/filecoin_lotus/api/api.go
+++ b/pkg/publisher/filecoin_lotus/api/api.go
@@ -251,7 +251,8 @@ func (a *api) span(ctx context.Context, method string) (context.Context, trace.S
 		ctx,
 		system.GetTracer(),
 		fmt.Sprintf("pkg/publisher/filecoin_lotus/api.api.%s", method),
-		trace.WithAttributes(semconv.HostName(a.hostname)),
+		trace.WithAttributes(semconv.HostName(a.hostname), semconv.PeerService("lotus")),
+		trace.WithSpanKind(trace.SpanKindClient),
 	)
 }
 

--- a/pkg/storage/url/urldownload/storage.go
+++ b/pkg/storage/url/urldownload/storage.go
@@ -22,6 +22,8 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // a storage driver runs the downloads content
@@ -59,7 +61,7 @@ func newStorage(dir string) *StorageProvider {
 		Timeout: config.GetDownloadURLRequestTimeout(),
 		Transport: otelhttp.NewTransport(nil, otelhttp.WithSpanNameFormatter(func(operation string, r *http.Request) string {
 			return fmt.Sprintf("%s %s", r.Method, r.URL.Path)
-		})),
+		}), otelhttp.WithSpanOptions(trace.WithAttributes(semconv.PeerService("url-download")))),
 	}
 	client.RetryMax = config.GetDownloadURLRequestRetries()
 	client.RetryWaitMax = time.Second * 1

--- a/pkg/telemetry/context.go
+++ b/pkg/telemetry/context.go
@@ -1,0 +1,35 @@
+package telemetry
+
+import (
+	"context"
+	"time"
+)
+
+// NewDetachedContext produces a new context that has a separate cancellation mechanism from its parent. This should be
+// used when having to continue using a context after it has been canceled, such as cleaning up Docker resources
+// after the context has been canceled but want to keep work associated with the same trace.
+func NewDetachedContext(parent context.Context) context.Context {
+	return detachedContext{parent: parent}
+}
+
+var _ context.Context = detachedContext{}
+
+type detachedContext struct {
+	parent context.Context
+}
+
+func (d detachedContext) Deadline() (deadline time.Time, ok bool) {
+	return time.Time{}, false
+}
+
+func (d detachedContext) Done() <-chan struct{} {
+	return nil
+}
+
+func (d detachedContext) Err() error {
+	return nil
+}
+
+func (d detachedContext) Value(key any) any {
+	return d.parent.Value(key)
+}

--- a/pkg/telemetry/context_test.go
+++ b/pkg/telemetry/context_test.go
@@ -1,0 +1,33 @@
+package telemetry
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestDetachedContext_Value_valuesPassedThrough(t *testing.T) {
+	expectedKey := "dummy"
+	expectedValue := "value"
+
+	ctx := NewDetachedContext(context.WithValue(context.Background(), expectedKey, expectedValue))
+
+	actualValue := ctx.Value(expectedKey)
+
+	assert.Equal(t, expectedValue, actualValue)
+}
+
+func TestDetachedContext_Deadline_separateFromParent(t *testing.T) {
+	parentCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ctx := NewDetachedContext(parentCtx)
+
+	assert.NoError(t, parentCtx.Err())
+	assert.NoError(t, ctx.Err())
+
+	cancel()
+
+	assert.Error(t, parentCtx.Err())
+	assert.NoError(t, ctx.Err())
+}


### PR DESCRIPTION
Ensure communications with a remote IPFS daemon are traced properly. The spans within `pkg/ipfs.Client` are removed as the IPFS client will handle this.

Also use a detached context rather than a brand new one so values, which would include logging information and tracing spans, can be still passed along.

Part of #1925