### PR TITLE
Give more context to single span traces

### DIFF
--- a/cmd/bacalhau/serve.go
+++ b/cmd/bacalhau/serve.go
@@ -500,7 +500,7 @@ func ipfsClient(ctx context.Context, OS *ServeOptions, cm *system.CleanupManager
 		return client, nil
 	}
 
-	client, err := ipfs.NewClientUsingRemoteHandler(OS.IPFSConnect)
+	client, err := ipfs.NewClientUsingRemoteHandler(ctx, OS.IPFSConnect)
 	if err != nil {
 		return ipfs.Client{}, fmt.Errorf("error creating IPFS client: %s", err)
 	}

--- a/pkg/ipfs/client.go
+++ b/pkg/ipfs/client.go
@@ -33,7 +33,7 @@ type Client struct {
 
 // NewClientUsingRemoteHandler creates an API client for the given ipfs node API multiaddress.
 // NOTE: the API address is _not_ the same as the swarm address
-func NewClientUsingRemoteHandler(apiAddr string) (Client, error) {
+func NewClientUsingRemoteHandler(ctx context.Context, apiAddr string) (Client, error) {
 	addr, err := ma.NewMultiaddr(apiAddr)
 	if err != nil {
 		return Client{}, fmt.Errorf("failed to parse api address '%s': %w", apiAddr, err)
@@ -62,7 +62,7 @@ func NewClientUsingRemoteHandler(apiAddr string) (Client, error) {
 		addr: apiAddr,
 	}
 
-	id, err := client.ID(context.Background())
+	id, err := client.ID(ctx)
 	if err != nil {
 		return Client{}, fmt.Errorf("failed to connect to '%s': %w", apiAddr, err)
 	}

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -101,6 +101,9 @@ func NewNode(
 	ctx context.Context,
 	config NodeConfig,
 	injector NodeDependencyInjector) (*Node, error) {
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/node.NewNode")
+	defer span.End()
+
 	identify.ActivationThresh = 2
 
 	err := mergo.Merge(&config.APIServerConfig, publicapi.DefaultAPIServerConfig)

--- a/pkg/routing/node_info_publisher.go
+++ b/pkg/routing/node_info_publisher.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/filecoin-project/bacalhau/pkg/pubsub"
+	"github.com/filecoin-project/bacalhau/pkg/system"
 	"github.com/rs/zerolog/log"
 )
 
@@ -48,10 +49,15 @@ func (n *NodeInfoPublisher) publishBackgroundTask() {
 	for {
 		select {
 		case <-ticker.C:
-			err := n.Publish(ctx)
-			if err != nil {
-				log.Ctx(ctx).Err(err).Msg("failed to publish node info")
-			}
+			func() {
+				ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/routing.NodeInfoPublisher.publishBackgroundTask") //nolint:govet
+				defer span.End()
+
+				err := n.Publish(ctx)
+				if err != nil {
+					log.Ctx(ctx).Err(err).Msg("failed to publish node info")
+				}
+			}()
 		case <-n.stopChannel:
 			log.Ctx(ctx).Info().Msg("stopped publishing node info")
 			ticker.Stop()


### PR DESCRIPTION
Some traces are appearing as a single span, so we need to add further context to allow the work to be tracked back to Bacalhau. Most of the sole spans are `pkg/pubsub/libp2p.Publish.Publish` which is from the publishing of node info.

Part of #1925