### PR TITLE
Add the span, trace & job IDs to log statements

### DIFF
--- a/cmd/bacalhau/list.go
+++ b/cmd/bacalhau/list.go
@@ -156,15 +156,15 @@ func list(cmd *cobra.Command, OL *ListOptions) error {
 	defer rootSpan.End()
 	cm.RegisterCallback(telemetry.Cleanup)
 
-	log.Debug().Msgf("Table filter flag set to: %s", OL.IDFilter)
-	log.Debug().Msgf("Table limit flag set to: %d", OL.MaxJobs)
-	log.Debug().Msgf("Table output format flag set to: %s", OL.OutputFormat)
-	log.Debug().Msgf("Table reverse flag set to: %t", OL.SortReverse)
-	log.Debug().Msgf("Found return all flag: %t", OL.ReturnAll)
-	log.Debug().Msgf("Found sort flag: %s", OL.SortBy)
-	log.Debug().Msgf("Found hide header flag set to: %t", OL.HideHeader)
-	log.Debug().Msgf("Found no-style header flag set to: %t", OL.NoStyle)
-	log.Debug().Msgf("Found output wide flag set to: %t", OL.OutputWide)
+	log.Ctx(ctx).Debug().Msgf("Table filter flag set to: %s", OL.IDFilter)
+	log.Ctx(ctx).Debug().Msgf("Table limit flag set to: %d", OL.MaxJobs)
+	log.Ctx(ctx).Debug().Msgf("Table output format flag set to: %s", OL.OutputFormat)
+	log.Ctx(ctx).Debug().Msgf("Table reverse flag set to: %t", OL.SortReverse)
+	log.Ctx(ctx).Debug().Msgf("Found return all flag: %t", OL.ReturnAll)
+	log.Ctx(ctx).Debug().Msgf("Found sort flag: %s", OL.SortBy)
+	log.Ctx(ctx).Debug().Msgf("Found hide header flag set to: %t", OL.HideHeader)
+	log.Ctx(ctx).Debug().Msgf("Found no-style header flag set to: %t", OL.NoStyle)
+	log.Ctx(ctx).Debug().Msgf("Found output wide flag set to: %t", OL.OutputWide)
 
 	jobs, err := GetAPIClient().List(
 		ctx,
@@ -181,7 +181,7 @@ func list(cmd *cobra.Command, OL *ListOptions) error {
 	}
 
 	numberInTable := system.Min(OL.MaxJobs, len(jobs))
-	log.Debug().Msgf("Number of jobs printing: %d", numberInTable)
+	log.Ctx(ctx).Debug().Msgf("Number of jobs printing: %d", numberInTable)
 
 	var msgBytes []byte
 	if OL.OutputFormat == JSONFormat {

--- a/cmd/bacalhau/serve.go
+++ b/cmd/bacalhau/serve.go
@@ -344,7 +344,7 @@ func serve(cmd *cobra.Command, OS *ServeOptions) error {
 	if err != nil {
 		return err
 	}
-	log.Debug().Msgf("libp2p connecting to: %s", peers)
+	log.Ctx(ctx).Debug().Msgf("libp2p connecting to: %s", peers)
 
 	libp2pHost, err := libp2p.NewHost(OS.SwarmPort, rcmgr.DefaultResourceManager)
 	if err != nil {

--- a/cmd/bacalhau/simulator.go
+++ b/cmd/bacalhau/simulator.go
@@ -44,8 +44,8 @@ func runSimulator(cmd *cobra.Command) error {
 		Fatal(cmd, fmt.Sprintf("Error creating p2p multiaddr: %s", err), 1)
 	}
 	fullAddr := libp2pHost.Addrs()[0].Encapsulate(p2pAddr)
-	log.Info().Msgf("Simulator reachable at: %s", fullAddr)
-	log.Info().Msgf("You can run: bacalhau devstack --simulator-addr \"%s\"", fullAddr)
+	log.Ctx(ctx).Info().Msgf("Simulator reachable at: %s", fullAddr)
+	log.Ctx(ctx).Info().Msgf("You can run: bacalhau devstack --simulator-addr \"%s\"", fullAddr)
 
 	// Create node config from cmd arguments
 	nodeConfig := node.NodeConfig{

--- a/cmd/bacalhau/utils.go
+++ b/cmd/bacalhau/utils.go
@@ -114,31 +114,31 @@ func GetAPIClient() *publicapi.RequesterAPIClient {
 }
 
 // ensureValidVersion checks that the server version is the same or less than the client version
-func ensureValidVersion(_ context.Context, clientVersion, serverVersion *model.BuildVersionInfo) error {
+func ensureValidVersion(ctx context.Context, clientVersion, serverVersion *model.BuildVersionInfo) error {
 	if clientVersion == nil {
-		log.Warn().Msg("Unable to parse nil client version, skipping version check")
+		log.Ctx(ctx).Warn().Msg("Unable to parse nil client version, skipping version check")
 		return nil
 	}
 	if clientVersion.GitVersion == "v0.0.0-xxxxxxx" {
-		log.Debug().Msg("Development client version, skipping version check")
+		log.Ctx(ctx).Debug().Msg("Development client version, skipping version check")
 		return nil
 	}
 	if serverVersion == nil {
-		log.Warn().Msg("Unable to parse nil server version, skipping version check")
+		log.Ctx(ctx).Warn().Msg("Unable to parse nil server version, skipping version check")
 		return nil
 	}
 	if serverVersion.GitVersion == "v0.0.0-xxxxxxx" {
-		log.Debug().Msg("Development server version, skipping version check")
+		log.Ctx(ctx).Debug().Msg("Development server version, skipping version check")
 		return nil
 	}
 	c, err := semver.NewVersion(clientVersion.GitVersion)
 	if err != nil {
-		log.Warn().Err(err).Msg("Unable to parse client version, skipping version check")
+		log.Ctx(ctx).Warn().Err(err).Msg("Unable to parse client version, skipping version check")
 		return nil
 	}
 	s, err := semver.NewVersion(serverVersion.GitVersion)
 	if err != nil {
-		log.Warn().Err(err).Msg("Unable to parse server version, skipping version check")
+		log.Ctx(ctx).Warn().Err(err).Msg("Unable to parse server version, skipping version check")
 		return nil
 	}
 	if s.GreaterThan(c) {
@@ -295,7 +295,7 @@ func ExecuteJob(ctx context.Context,
 
 	err := job.VerifyJob(ctx, j)
 	if err != nil {
-		log.Err(err).Msg("Job failed to validate.")
+		log.Ctx(ctx).Err(err).Msg("Job failed to validate.")
 		return err
 	}
 
@@ -635,12 +635,12 @@ To get more information at any time, run:
 
 	go func() {
 		for {
-			log.Trace().Msgf("Ticker goreturn")
+			log.Ctx(ctx).Trace().Msgf("Ticker goreturn")
 
 			select {
 			case <-tickerDone:
 				ticker.Stop()
-				log.Trace().Msgf("Ticker goreturn done")
+				log.Ctx(ctx).Trace().Msgf("Ticker goreturn done")
 				return
 			case t := <-ticker.C:
 				if !quiet {
@@ -653,11 +653,11 @@ To get more information at any time, run:
 	}()
 
 	go func() {
-		log.Trace().Msgf("Signal goreturn")
+		log.Ctx(ctx).Trace().Msgf("Signal goreturn")
 
 		select {
 		case s := <-signalChan: // first signal, cancel context
-			log.Debug().Msgf("Captured %v. Exiting...", s)
+			log.Ctx(ctx).Debug().Msgf("Captured %v. Exiting...", s)
 			if s == os.Interrupt {
 				// Stop the spinner and let the rest of WaitAndPrintResultsToUser
 				// know that we're going to shut down so that it doesn't try to
@@ -694,14 +694,14 @@ To get more information at any time, run:
 			}
 		}
 
-		log.Trace().Msgf("Job Events:")
+		log.Ctx(ctx).Trace().Msgf("Job Events:")
 		for i := range jobEvents {
-			log.Trace().Msgf("\t%s - %s - %s",
+			log.Ctx(ctx).Trace().Msgf("\t%s - %s - %s",
 				jobEvents[i].NewState,
 				jobEvents[i].Time.UTC().String(),
 				jobEvents[i].Comment)
 		}
-		log.Trace().Msgf("\n")
+		log.Ctx(ctx).Trace().Msgf("\n")
 
 		if err != nil {
 			if _, ok := err.(*bacerrors.JobNotFound); ok {

--- a/cmd/bacalhau/version.go
+++ b/cmd/bacalhau/version.go
@@ -113,7 +113,7 @@ func (oV *VersionOptions) Run(ctx context.Context, cmd *cobra.Command) error {
 	if !oV.ClientOnly {
 		serverVersion, err := GetAPIClient().Version(ctx)
 		if err != nil {
-			log.Error().Err(err).Msgf("could not get server version")
+			log.Ctx(cmd.Context()).Error().Err(err).Msgf("could not get server version")
 			return err
 		}
 

--- a/dashboard/api/cmd/dashboard/serve.go
+++ b/dashboard/api/cmd/dashboard/serve.go
@@ -105,7 +105,7 @@ func serve(cmd *cobra.Command, options *ServeOptions) error {
 	if err != nil {
 		return err
 	}
-	log.Debug().Msgf("libp2p connecting to: %s", peers)
+	log.Ctx(ctx).Debug().Msgf("libp2p connecting to: %s", peers)
 
 	libp2pHost, err := libp2p.NewHost(options.ServerOptions.SwarmPort)
 	if err != nil {
@@ -144,7 +144,7 @@ func serve(cmd *cobra.Command, options *ServeOptions) error {
 		}
 	}()
 
-	log.Info().Msgf("Dashboard server listening on %s:%d", options.ServerOptions.Host, options.ServerOptions.Port)
+	log.Ctx(ctx).Info().Msgf("Dashboard server listening on %s:%d", options.ServerOptions.Host, options.ServerOptions.Port)
 
 	<-ctx.Done() // block until killed
 	return nil

--- a/dashboard/api/pkg/model/api.go
+++ b/dashboard/api/pkg/model/api.go
@@ -154,15 +154,15 @@ func (api *ModelAPI) Start(ctx context.Context) error {
 	api.cleanupFunc = func(ctx context.Context) {
 		cleanupErr := bufferedJobEventPubSub.Close(ctx)
 		if cleanupErr != nil {
-			log.Error().Err(cleanupErr).Msg("failed to close job event pubsub")
+			log.Ctx(ctx).Error().Err(cleanupErr).Msg("failed to close job event pubsub")
 		}
 		cleanupErr = libp2p2JobEventPubSub.Close(ctx)
 		if cleanupErr != nil {
-			log.Error().Err(cleanupErr).Msg("failed to close libp2p job event pubsub")
+			log.Ctx(ctx).Error().Err(cleanupErr).Msg("failed to close libp2p job event pubsub")
 		}
 		cleanupErr = nodeInfoPubSub.Close(ctx)
 		if cleanupErr != nil {
-			log.Error().Err(cleanupErr).Msg("failed to close libp2p node info pubsub")
+			log.Ctx(ctx).Error().Err(cleanupErr).Msg("failed to close libp2p node info pubsub")
 		}
 		cancel()
 	}
@@ -191,11 +191,11 @@ func (api *ModelAPI) GetNodes(ctx context.Context) (map[string]bacalhau_model.No
 }
 
 func (api *ModelAPI) GetJobs(ctx context.Context, query localdb.JobQuery) ([]*bacalhau_model_beta.Job, error) {
-	return api.localDB.GetJobs(context.Background(), query)
+	return api.localDB.GetJobs(ctx, query)
 }
 
 func (api *ModelAPI) GetJobsCount(ctx context.Context, query localdb.JobQuery) (int, error) {
-	return api.localDB.GetJobsCount(context.Background(), query)
+	return api.localDB.GetJobsCount(ctx, query)
 }
 
 func (api *ModelAPI) GetJob(ctx context.Context, id string) (*bacalhau_model_beta.Job, error) {

--- a/dashboard/api/pkg/model/job_event_handler.go
+++ b/dashboard/api/pkg/model/job_event_handler.go
@@ -92,12 +92,12 @@ func (handler *jobEventHandler) readEvent(ctx context.Context, event bacalhau_mo
 		eventBuffer.exists = true
 		err := handler.writeEventToDatabase(ctx, event)
 		if err != nil {
-			log.Error().Msgf("error writing event to database: %s", err.Error())
+			log.Ctx(ctx).Error().Msgf("error writing event to database: %s", err.Error())
 		}
 		for _, bufferedEvent := range eventBuffer.events {
 			err := handler.writeEventToDatabase(ctx, bufferedEvent)
 			if err != nil {
-				log.Error().Msgf("error writing event to database: %s", err.Error())
+				log.Ctx(ctx).Error().Msgf("error writing event to database: %s", err.Error())
 			}
 		}
 	} else if !eventBuffer.exists {
@@ -105,7 +105,7 @@ func (handler *jobEventHandler) readEvent(ctx context.Context, event bacalhau_mo
 	} else {
 		err := handler.writeEventToDatabase(ctx, event)
 		if err != nil {
-			log.Error().Msgf("error writing event to database: %s", err.Error())
+			log.Ctx(ctx).Error().Msgf("error writing event to database: %s", err.Error())
 		}
 	}
 	return nil

--- a/dashboard/api/pkg/server/server.go
+++ b/dashboard/api/pkg/server/server.go
@@ -101,10 +101,10 @@ func (apiServer *DashboardAPIServer) run(res http.ResponseWriter, req *http.Requ
 
 	cid, err := runGenericJob(spec)
 	if err != nil {
-		log.Error().Err(err).Send()
+		log.Ctx(req.Context()).Error().Err(err).Send()
 		_, _ = res.Write([]byte(fmt.Sprintf(`{"error": "%s"}`, strings.Trim(err.Error(), "\n"))))
 	} else {
-		log.Info().Str("CID", cid).Send()
+		log.Ctx(req.Context()).Info().Str("CID", cid).Send()
 		_, _ = res.Write([]byte(fmt.Sprintf(`{"cid": "%s"}`, strings.Trim(cid, "\n"))))
 	}
 }
@@ -124,14 +124,14 @@ func (apiServer *DashboardAPIServer) stablediffusion(res http.ResponseWriter, re
 	// user can pass ?testing=1 to bypass GPU and just return the prompt
 	testing := len(req.URL.Query()["testing"]) > 0
 
-	log.Info().Msgf("--> testing=%t", testing)
+	log.Ctx(req.Context()).Info().Msgf("--> testing=%t", testing)
 
 	cid, err := runStableDiffusion(prompt, testing)
 	if err != nil {
-		log.Error().Err(err).Send()
+		log.Ctx(req.Context()).Error().Err(err).Send()
 		_, _ = res.Write([]byte(fmt.Sprintf(`{"error": "%s"}`, strings.Trim(err.Error(), "\n"))))
 	} else {
-		log.Info().Str("CID", cid).Send()
+		log.Ctx(req.Context()).Info().Str("CID", cid).Send()
 		_, _ = res.Write([]byte(fmt.Sprintf(`{"cid": "%s"}`, strings.Trim(cid, "\n"))))
 	}
 }
@@ -139,13 +139,13 @@ func (apiServer *DashboardAPIServer) stablediffusion(res http.ResponseWriter, re
 func (apiServer *DashboardAPIServer) annotations(res http.ResponseWriter, req *http.Request) {
 	data, err := apiServer.API.GetAnnotationSummary(context.Background())
 	if err != nil {
-		log.Error().Msgf("error for annotations route: %s", err.Error())
+		log.Ctx(req.Context()).Error().Msgf("error for annotations route: %s", err.Error())
 		http.Error(res, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	err = json.NewEncoder(res).Encode(data)
 	if err != nil {
-		log.Error().Msgf("error for annotations route: %s", err.Error())
+		log.Ctx(req.Context()).Error().Msgf("error for annotations route: %s", err.Error())
 		http.Error(res, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -154,13 +154,13 @@ func (apiServer *DashboardAPIServer) annotations(res http.ResponseWriter, req *h
 func (apiServer *DashboardAPIServer) jobmonths(res http.ResponseWriter, req *http.Request) {
 	data, err := apiServer.API.GetJobMonthSummary(context.Background())
 	if err != nil {
-		log.Error().Msgf("error for job months route: %s", err.Error())
+		log.Ctx(req.Context()).Error().Msgf("error for job months route: %s", err.Error())
 		http.Error(res, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	err = json.NewEncoder(res).Encode(data)
 	if err != nil {
-		log.Error().Msgf("error for job months route: %s", err.Error())
+		log.Ctx(req.Context()).Error().Msgf("error for job months route: %s", err.Error())
 		http.Error(res, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -169,13 +169,13 @@ func (apiServer *DashboardAPIServer) jobmonths(res http.ResponseWriter, req *htt
 func (apiServer *DashboardAPIServer) jobexecutors(res http.ResponseWriter, req *http.Request) {
 	data, err := apiServer.API.GetJobExecutorSummary(context.Background())
 	if err != nil {
-		log.Error().Msgf("error for job executors route: %s", err.Error())
+		log.Ctx(req.Context()).Error().Msgf("error for job executors route: %s", err.Error())
 		http.Error(res, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	err = json.NewEncoder(res).Encode(data)
 	if err != nil {
-		log.Error().Msgf("error for job executors route: %s", err.Error())
+		log.Ctx(req.Context()).Error().Msgf("error for job executors route: %s", err.Error())
 		http.Error(res, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -184,13 +184,13 @@ func (apiServer *DashboardAPIServer) jobexecutors(res http.ResponseWriter, req *
 func (apiServer *DashboardAPIServer) totaljobs(res http.ResponseWriter, req *http.Request) {
 	data, err := apiServer.API.GetTotalJobsCount(context.Background())
 	if err != nil {
-		log.Error().Msgf("error for job totals route: %s", err.Error())
+		log.Ctx(req.Context()).Error().Msgf("error for job totals route: %s", err.Error())
 		http.Error(res, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	err = json.NewEncoder(res).Encode(data)
 	if err != nil {
-		log.Error().Msgf("error for job totals route: %s", err.Error())
+		log.Ctx(req.Context()).Error().Msgf("error for job totals route: %s", err.Error())
 		http.Error(res, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -199,13 +199,13 @@ func (apiServer *DashboardAPIServer) totaljobs(res http.ResponseWriter, req *htt
 func (apiServer *DashboardAPIServer) totaljobevents(res http.ResponseWriter, req *http.Request) {
 	data, err := apiServer.API.GetTotalEventCount(context.Background())
 	if err != nil {
-		log.Error().Msgf("error for job event totals route: %s", err.Error())
+		log.Ctx(req.Context()).Error().Msgf("error for job event totals route: %s", err.Error())
 		http.Error(res, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	err = json.NewEncoder(res).Encode(data)
 	if err != nil {
-		log.Error().Msgf("error for job event totals route: %s", err.Error())
+		log.Ctx(req.Context()).Error().Msgf("error for job event totals route: %s", err.Error())
 		http.Error(res, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -214,13 +214,13 @@ func (apiServer *DashboardAPIServer) totaljobevents(res http.ResponseWriter, req
 func (apiServer *DashboardAPIServer) totalusers(res http.ResponseWriter, req *http.Request) {
 	data, err := apiServer.API.GetTotalUserCount(context.Background())
 	if err != nil {
-		log.Error().Msgf("error for job user totals route: %s", err.Error())
+		log.Ctx(req.Context()).Error().Msgf("error for job user totals route: %s", err.Error())
 		http.Error(res, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	err = json.NewEncoder(res).Encode(data)
 	if err != nil {
-		log.Error().Msgf("error for job user totals route: %s", err.Error())
+		log.Ctx(req.Context()).Error().Msgf("error for job user totals route: %s", err.Error())
 		http.Error(res, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -229,13 +229,13 @@ func (apiServer *DashboardAPIServer) totalusers(res http.ResponseWriter, req *ht
 func (apiServer *DashboardAPIServer) totalexecutors(res http.ResponseWriter, req *http.Request) {
 	data, err := apiServer.API.GetTotalExecutorCount(context.Background())
 	if err != nil {
-		log.Error().Msgf("error for job executors totals route: %s", err.Error())
+		log.Ctx(req.Context()).Error().Msgf("error for job executors totals route: %s", err.Error())
 		http.Error(res, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	err = json.NewEncoder(res).Encode(data)
 	if err != nil {
-		log.Error().Msgf("error for job executors totals route: %s", err.Error())
+		log.Ctx(req.Context()).Error().Msgf("error for job executors totals route: %s", err.Error())
 		http.Error(res, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -247,7 +247,7 @@ func (apiServer *DashboardAPIServer) nodes(res http.ResponseWriter, req *http.Re
 		err = json.NewEncoder(res).Encode(nodes)
 	}
 	if err != nil {
-		log.Error().Msgf("error for nodes route: %s", err.Error())
+		log.Ctx(req.Context()).Error().Msgf("error for nodes route: %s", err.Error())
 		http.Error(res, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -256,21 +256,21 @@ func (apiServer *DashboardAPIServer) nodes(res http.ResponseWriter, req *http.Re
 func (apiServer *DashboardAPIServer) jobs(res http.ResponseWriter, req *http.Request) {
 	query, err := GetRequestBody[localdb.JobQuery](res, req)
 	if err != nil {
-		log.Error().Msgf("error for jobs route: %s", err.Error())
+		log.Ctx(req.Context()).Error().Msgf("error for jobs route: %s", err.Error())
 		http.Error(res, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
 	results, err := apiServer.API.GetJobs(context.Background(), *query)
 	if err != nil {
-		log.Error().Msgf("error for jobs route: %s", err.Error())
+		log.Ctx(req.Context()).Error().Msgf("error for jobs route: %s", err.Error())
 		http.Error(res, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
 	err = json.NewEncoder(res).Encode(results)
 	if err != nil {
-		log.Error().Msgf("error for jobs route: %s", err.Error())
+		log.Ctx(req.Context()).Error().Msgf("error for jobs route: %s", err.Error())
 		http.Error(res, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -283,14 +283,14 @@ type jobsCountResponse struct {
 func (apiServer *DashboardAPIServer) jobsCount(res http.ResponseWriter, req *http.Request) {
 	query, err := GetRequestBody[localdb.JobQuery](res, req)
 	if err != nil {
-		log.Error().Msgf("error for jobs route: %s", err.Error())
+		log.Ctx(req.Context()).Error().Msgf("error for jobs route: %s", err.Error())
 		http.Error(res, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
 	count, err := apiServer.API.GetJobsCount(context.Background(), *query)
 	if err != nil {
-		log.Error().Msgf("error for jobsCount route: %s", err.Error())
+		log.Ctx(req.Context()).Error().Msgf("error for jobsCount route: %s", err.Error())
 		http.Error(res, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -299,7 +299,7 @@ func (apiServer *DashboardAPIServer) jobsCount(res http.ResponseWriter, req *htt
 		Count: count,
 	})
 	if err != nil {
-		log.Error().Msgf("error for jobsCount route: %s", err.Error())
+		log.Ctx(req.Context()).Error().Msgf("error for jobsCount route: %s", err.Error())
 		http.Error(res, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -311,14 +311,14 @@ func (apiServer *DashboardAPIServer) job(res http.ResponseWriter, req *http.Requ
 
 	data, err := apiServer.API.GetJob(context.Background(), id)
 	if err != nil {
-		log.Error().Msgf("error for job route: %s", err.Error())
+		log.Ctx(req.Context()).Error().Msgf("error for job route: %s", err.Error())
 		http.Error(res, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
 	err = json.NewEncoder(res).Encode(data)
 	if err != nil {
-		log.Error().Msgf("error for job route: %s", err.Error())
+		log.Ctx(req.Context()).Error().Msgf("error for job route: %s", err.Error())
 		http.Error(res, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -330,14 +330,14 @@ func (apiServer *DashboardAPIServer) jobInfo(res http.ResponseWriter, req *http.
 
 	data, err := apiServer.API.GetJobInfo(context.Background(), id)
 	if err != nil {
-		log.Error().Msgf("error for jobInfo route: %s", err.Error())
+		log.Ctx(req.Context()).Error().Msgf("error for jobInfo route: %s", err.Error())
 		http.Error(res, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
 	err = json.NewEncoder(res).Encode(data)
 	if err != nil {
-		log.Error().Msgf("error for jobInfo route: %s", err.Error())
+		log.Ctx(req.Context()).Error().Msgf("error for jobInfo route: %s", err.Error())
 		http.Error(res, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -352,19 +352,19 @@ func (apiServer *DashboardAPIServer) adminlogin(res http.ResponseWriter, req *ht
 	var loginRequest types.LoginRequest
 	err := json.NewDecoder(req.Body).Decode(&loginRequest)
 	if err != nil {
-		log.Error().Msgf("error for login route: %s", err.Error())
+		log.Ctx(req.Context()).Error().Msgf("error for login route: %s", err.Error())
 		http.Error(res, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	user, err := apiServer.API.Login(context.Background(), loginRequest)
 	if err != nil {
-		log.Error().Msgf("error for login route: %s", err.Error())
+		log.Ctx(req.Context()).Error().Msgf("error for login route: %s", err.Error())
 		http.Error(res, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	token, err := generateJWT(apiServer.Options.JWTSecret, user.Username)
 	if err != nil {
-		log.Error().Msgf("error for login route: %s", err.Error())
+		log.Ctx(req.Context()).Error().Msgf("error for login route: %s", err.Error())
 		http.Error(res, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -372,7 +372,7 @@ func (apiServer *DashboardAPIServer) adminlogin(res http.ResponseWriter, req *ht
 		Token: token,
 	})
 	if err != nil {
-		log.Error().Msgf("error for login route: %s", err.Error())
+		log.Ctx(req.Context()).Error().Msgf("error for login route: %s", err.Error())
 		http.Error(res, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -381,13 +381,13 @@ func (apiServer *DashboardAPIServer) adminlogin(res http.ResponseWriter, req *ht
 func (apiServer *DashboardAPIServer) adminstatus(res http.ResponseWriter, req *http.Request) {
 	user, err := getUserFromRequest(apiServer.API, req, apiServer.Options.JWTSecret)
 	if err != nil {
-		log.Error().Msgf("error for adminstatus route: %s", err.Error())
+		log.Ctx(req.Context()).Error().Msgf("error for adminstatus route: %s", err.Error())
 		http.Error(res, fmt.Sprintf("error for adminstatus route: %s", err.Error()), http.StatusUnauthorized)
 		return
 	}
 	err = json.NewEncoder(res).Encode(user)
 	if err != nil {
-		log.Error().Msgf("error for status route: %s", err.Error())
+		log.Ctx(req.Context()).Error().Msgf("error for status route: %s", err.Error())
 		http.Error(res, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -396,19 +396,19 @@ func (apiServer *DashboardAPIServer) adminstatus(res http.ResponseWriter, req *h
 func (apiServer *DashboardAPIServer) adminmoderate(res http.ResponseWriter, req *http.Request) {
 	user, err := getUserFromRequest(apiServer.API, req, apiServer.Options.JWTSecret)
 	if err != nil || user == nil {
-		log.Error().Msgf("access denied: %s", err.Error())
+		log.Ctx(req.Context()).Error().Msgf("access denied: %s", err.Error())
 		http.Error(res, fmt.Sprintf("access denied: %s", err.Error()), http.StatusUnauthorized)
 		return
 	}
 	data, err := GetRequestBody[types.JobModeration](res, req)
 	if err != nil {
-		log.Error().Msgf("error for adminmoderate route: %s", err.Error())
+		log.Ctx(req.Context()).Error().Msgf("error for adminmoderate route: %s", err.Error())
 		http.Error(res, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	err = apiServer.API.CreateJobModeration(context.Background(), *data)
 	if err != nil {
-		log.Error().Msgf("error for adminmoderate route: %s", err.Error())
+		log.Ctx(req.Context()).Error().Msgf("error for adminmoderate route: %s", err.Error())
 		http.Error(res, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -419,7 +419,7 @@ func (apiServer *DashboardAPIServer) adminmoderate(res http.ResponseWriter, req 
 		Success: true,
 	})
 	if err != nil {
-		log.Error().Msgf("error for adminmoderate route: %s", err.Error())
+		log.Ctx(req.Context()).Error().Msgf("error for adminmoderate route: %s", err.Error())
 		http.Error(res, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/ops/aws/canary/lambda/cmd/scenario_manual_runner/main.go
+++ b/ops/aws/canary/lambda/cmd/scenario_manual_runner/main.go
@@ -46,7 +46,7 @@ func main() {
 }
 
 func run(ctx context.Context, action string, rate float32) {
-	log.Info().Msgf("Starting scenario: %s", action)
+	log.Ctx(ctx).Info().Msgf("Starting scenario: %s", action)
 	for {
 		select {
 		case <-ctx.Done():
@@ -54,7 +54,7 @@ func run(ctx context.Context, action string, rate float32) {
 		default:
 			err := router.Route(ctx, models.Event{Action: action})
 			if err != nil {
-				log.Error().Msg(err.Error())
+				log.Ctx(ctx).Error().Msg(err.Error())
 			}
 		}
 		jitter := rand.Intn(100) - 100 // +- 100ms sleep jitter

--- a/ops/aws/canary/lambda/pkg/scenarios/submitDockerIPFSJobAndGet.go
+++ b/ops/aws/canary/lambda/pkg/scenarios/submitDockerIPFSJobAndGet.go
@@ -35,7 +35,7 @@ func SubmitDockerIPFSJobAndGet(ctx context.Context) error {
 		return err
 	}
 
-	log.Info().Msgf("submitted job: %s", submittedJob.Metadata.ID)
+	log.Ctx(ctx).Info().Msgf("submitted job: %s", submittedJob.Metadata.ID)
 
 	err = waitUntilCompleted(ctx, client, submittedJob)
 	if err != nil {
@@ -81,7 +81,7 @@ func SubmitDockerIPFSJobAndGet(ctx context.Context) error {
 	}
 
 	for _, file := range files {
-		log.Debug().Msgf("downloaded files: %s", file.Name())
+		log.Ctx(ctx).Debug().Msgf("downloaded files: %s", file.Name())
 	}
 	if len(files) != 3 {
 		return fmt.Errorf("expected 3 files in output dir, got %d", len(files))

--- a/pkg/compute/sensors/logging_sensor.go
+++ b/pkg/compute/sensors/logging_sensor.go
@@ -28,7 +28,7 @@ func NewLoggingSensor(params LoggingSensorParams) *LoggingSensor {
 }
 
 func (s LoggingSensor) Start(ctx context.Context) {
-	log.Debug().Msgf("starting new logging sensor with interval %s", s.interval)
+	log.Ctx(ctx).Debug().Msgf("starting new logging sensor with interval %s", s.interval)
 	ticker := time.NewTicker(s.interval)
 
 	for {
@@ -47,6 +47,6 @@ func (s LoggingSensor) sense(ctx context.Context) {
 	if err != nil {
 		log.Ctx(ctx).Err(err).Msg("failed to marshal execution summaries")
 	} else {
-		log.Info().Msgf("%s: %s", debugInfo.Component, debugInfo.Info)
+		log.Ctx(ctx).Info().Msgf("%s: %s", debugInfo.Component, debugInfo.Info)
 	}
 }

--- a/pkg/devstack/devstack.go
+++ b/pkg/devstack/devstack.go
@@ -148,7 +148,7 @@ func NewDevStack(
 	for i := 0; i < totalNodeCount; i++ {
 		isRequesterNode := i < requesterNodeCount
 		isComputeNode := (totalNodeCount - i) <= computeNodeCount
-		log.Debug().Msgf(`Creating Node #%d as {RequesterNode: %t, ComputeNode: %t}`, i+1, isRequesterNode, isComputeNode)
+		log.Ctx(ctx).Debug().Msgf(`Creating Node #%d as {RequesterNode: %t, ComputeNode: %t}`, i+1, isRequesterNode, isComputeNode)
 
 		// -------------------------------------
 		// IPFS
@@ -189,7 +189,7 @@ func NewDevStack(
 		if i == 0 {
 			if options.Peer != "" {
 				// connect 0'th node to external peer if specified
-				log.Debug().Msgf("Connecting 0'th node to remote peer: %s", options.Peer)
+				log.Ctx(ctx).Debug().Msgf("Connecting 0'th node to remote peer: %s", options.Peer)
 				peerAddr, addrErr := multiaddr.NewMultiaddr(options.Peer)
 				if addrErr != nil {
 					return nil, fmt.Errorf("failed to parse peer address: %w", addrErr)
@@ -207,7 +207,7 @@ func NewDevStack(
 			if err != nil {
 				return nil, fmt.Errorf("failed to get libp2p addresses: %w", err)
 			}
-			log.Debug().Msgf("Connecting to first libp2p requester node: %s", libp2pPeer)
+			log.Ctx(ctx).Debug().Msgf("Connecting to first libp2p requester node: %s", libp2pPeer)
 		}
 
 		libp2pHost, err = libp2p.NewHost(libp2pPort)
@@ -454,7 +454,7 @@ export LOTUS_UPLOAD_DIR=%s`, stack.Lotus.PathDir, stack.Lotus.UploadDir)
 	if config.DevstackShouldWriteEnvFile() {
 		err := os.WriteFile(config.DevstackEnvFile(), []byte(summaryShellVariablesString), 0600) //nolint:gomnd
 		if err != nil {
-			log.Err(err).Msgf("Failed to write file %s", config.DevstackEnvFile())
+			log.Ctx(ctx).Err(err).Msgf("Failed to write file %s", config.DevstackEnvFile())
 			return "", err
 		}
 	}
@@ -469,7 +469,7 @@ You can also run a new IPFS daemon locally and connect it to Bacalhau using:
 ipfs swarm connect $BACALHAU_IPFS_SWARM_ADDRESSES`
 	}
 
-	log.Debug().Msg(logString)
+	log.Ctx(ctx).Debug().Msg(logString)
 
 	returnString := fmt.Sprintf(`
 Devstack is ready!

--- a/pkg/devstack/devstack_ipfs.go
+++ b/pkg/devstack/devstack_ipfs.go
@@ -18,7 +18,7 @@ type DevStackIPFS struct {
 func NewDevStackIPFS(ctx context.Context, cm *system.CleanupManager, count int) (*DevStackIPFS, error) {
 	var clients []ipfs.Client
 	for i := 0; i < count; i++ {
-		log.Debug().Msgf(`Creating Node #%d`, i)
+		log.Ctx(ctx).Debug().Msgf(`Creating Node #%d`, i)
 
 		//////////////////////////////////////
 		// IPFS

--- a/pkg/devstack/lotus.go
+++ b/pkg/devstack/lotus.go
@@ -99,7 +99,7 @@ func (l *LotusNode) start(ctx context.Context) error {
 
 	l.container = c.ID
 
-	log.Debug().
+	log.Ctx(ctx).Debug().
 		Str("image", l.image).
 		Str("UploadDir", l.UploadDir).
 		Str("PathDir", l.PathDir).
@@ -112,7 +112,7 @@ func (l *LotusNode) start(ctx context.Context) error {
 
 	if err := l.waitForLotusToBeHealthy(ctx); err != nil {
 		if err := l.Close(); err != nil { //nolint:govet
-			log.Err(err).Msgf(`Problem occurred when giving up waiting for Lotus to become healthy`)
+			log.Ctx(ctx).Err(err).Msgf(`Problem occurred when giving up waiting for Lotus to become healthy`)
 		}
 		return err
 	}
@@ -141,7 +141,7 @@ func (l *LotusNode) waitForLotusToBeHealthy(ctx context.Context) error {
 			break
 		}
 
-		e := log.Debug()
+		e := log.Ctx(ctx).Debug()
 		if len(state.State.Health.Log) != 0 {
 			e = e.Str("last-health-check", strings.TrimSpace(state.State.Health.Log[len(state.State.Health.Log)-1].Output))
 		}

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -163,7 +163,7 @@ func (c *Client) PullImage(ctx context.Context, image string) error {
 		return err
 	}
 
-	log.Debug().Str("image", image).Msg("Pulling image as it wasn't found")
+	log.Ctx(ctx).Debug().Str("image", image).Msg("Pulling image as it wasn't found")
 
 	output, err := c.ImagePull(ctx, image, types.ImagePullOptions{})
 	if err != nil {
@@ -186,7 +186,7 @@ func (c *Client) PullImage(ctx context.Context, image string) error {
 			case <-stop:
 				return
 			case <-t.C:
-				logImagePullStatus(layers)
+				logImagePullStatus(ctx, layers)
 			}
 		}
 	}()
@@ -210,7 +210,7 @@ func (c *Client) PullImage(ctx context.Context, image string) error {
 	}
 }
 
-func logImagePullStatus(m *sync.Map) {
+func logImagePullStatus(ctx context.Context, m *sync.Map) {
 	withUnits := map[string]*zerolog.Event{}
 	withoutUnits := map[string][]string{}
 	m.Range(func(_, value any) bool {
@@ -235,7 +235,7 @@ func logImagePullStatus(m *sync.Map) {
 
 		return true
 	})
-	e := log.Debug()
+	e := log.Ctx(ctx).Debug()
 	for s, l := range withUnits {
 		e = e.Dict(s, l)
 	}

--- a/pkg/ipfs/client.go
+++ b/pkg/ipfs/client.go
@@ -66,7 +66,7 @@ func NewClientUsingRemoteHandler(ctx context.Context, apiAddr string) (Client, e
 	if err != nil {
 		return Client{}, fmt.Errorf("failed to connect to '%s': %w", apiAddr, err)
 	}
-	log.Debug().Msgf("Created remote IPFS client for node API address: %s, with id: %s", apiAddr, id)
+	log.Ctx(ctx).Debug().Msgf("Created remote IPFS client for node API address: %s, with id: %s", apiAddr, id)
 	return client, nil
 }
 

--- a/pkg/ipfs/node.go
+++ b/pkg/ipfs/node.go
@@ -178,7 +178,7 @@ func newNodeWithConfig(ctx context.Context, cm *system.CleanupManager, cfg Confi
 	}()
 
 	if err = connectToPeers(ctx, api, ipfsNode, cfg.getPeerAddrs()); err != nil {
-		log.Error().Msgf("ipfs node failed to connect to peers: %s", err)
+		log.Ctx(ctx).Error().Msgf("ipfs node failed to connect to peers: %s", err)
 	}
 
 	if err = serveAPI(cm, ipfsNode, repoPath); err != nil {
@@ -221,7 +221,7 @@ func newNodeWithConfig(ctx context.Context, cm *system.CleanupManager, cfg Confi
 	})
 
 	// Log details so that user can connect to the new node:
-	log.Trace().Msgf("IPFS node created with ID: %s", ipfsNode.Identity)
+	log.Ctx(ctx).Trace().Msgf("IPFS node created with ID: %s", ipfsNode.Identity)
 	n.LogDetails()
 
 	return &n, nil
@@ -316,7 +316,7 @@ func (n *Node) Close() error {
 }
 
 // createNode spawns a new IPFS node using a temporary repo path.
-func createNode(ctx context.Context, cm *system.CleanupManager, cfg Config) (icore.CoreAPI, *core.IpfsNode, string, error) {
+func createNode(ctx context.Context, _ *system.CleanupManager, cfg Config) (icore.CoreAPI, *core.IpfsNode, string, error) {
 	repoPath, err := os.MkdirTemp("", "ipfs-tmp")
 	if err != nil {
 		return nil, nil, "", fmt.Errorf("failed to create repo dir: %w", err)
@@ -409,8 +409,8 @@ func serveAPI(cm *system.CleanupManager, node *core.IpfsNode, repoPath string) e
 // connectToPeers connects the node to a list of IPFS bootstrap peers.
 // event though we have Peering enabled, some test scenarios relies on the node being eagerly connected to the peers
 func connectToPeers(ctx context.Context, api icore.CoreAPI, node *core.IpfsNode, peerAddrs []string) error {
-	log.Debug().Msgf("IPFS node %s has current peers: %v", node.Identity, node.Peerstore.Peers())
-	log.Debug().Msgf("IPFS node %s is connecting to new peers: %v", node.Identity, peerAddrs)
+	log.Ctx(ctx).Debug().Msgf("IPFS node %s has current peers: %v", node.Identity, node.Peerstore.Peers())
+	log.Ctx(ctx).Debug().Msgf("IPFS node %s is connecting to new peers: %v", node.Identity, peerAddrs)
 
 	// Parse the bootstrap node multiaddrs and fetch their IPFS peer info:
 	peerInfos, err := ParsePeersString(peerAddrs)
@@ -427,7 +427,7 @@ func connectToPeers(ctx context.Context, api icore.CoreAPI, node *core.IpfsNode,
 			defer wg.Done()
 			if err := api.Swarm().Connect(ctx, peerInfo); err != nil {
 				anyErr = err
-				log.Debug().Msgf(
+				log.Ctx(ctx).Debug().Msgf(
 					"failed to connect to ipfs peer %s, skipping: %s",
 					peerInfo.ID, err)
 			}

--- a/pkg/job/state.go
+++ b/pkg/job/state.go
@@ -181,7 +181,7 @@ func (resolver *StateResolver) WaitWithOptions(
 			// If all the jobs are in terminal states, then nothing is going
 			// to change if we keep polling, so we should exit early.
 			if allTerminal && !options.AllowAllTerminal {
-				log.Error().Msgf("all executions are in terminal state, but not all expected states are met: %+v", jobState)
+				log.Ctx(ctx).Error().Msgf("all executions are in terminal state, but not all expected states are met: %+v", jobState)
 				return false, fmt.Errorf("all jobs are in terminal states and conditions aren't met")
 			}
 			return false, nil

--- a/pkg/model/job.go
+++ b/pkg/model/job.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/imdario/mergo"
-	"github.com/rs/zerolog/log"
 	"k8s.io/apimachinery/pkg/selection"
 )
 
@@ -62,7 +61,6 @@ func NewJobWithSaneProductionDefaults() (*Job, error) {
 		},
 	})
 	if err != nil {
-		log.Err(err).Msg("failed to merge sane defaults into job")
 		return nil, err
 	}
 	return j, nil

--- a/pkg/model/v1alpha1/job.go
+++ b/pkg/model/v1alpha1/job.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/imdario/mergo"
-	"github.com/rs/zerolog/log"
 )
 
 // Job contains data about a job request in the bacalhau network.
@@ -73,7 +72,6 @@ func NewJobWithSaneProductionDefaults() (*Job, error) {
 		},
 	})
 	if err != nil {
-		log.Err(err).Msg("failed to merge sane defaults into job")
 		return nil, err
 	}
 	return j, nil

--- a/pkg/model/v1beta1/job.go
+++ b/pkg/model/v1beta1/job.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/imdario/mergo"
-	"github.com/rs/zerolog/log"
 	"k8s.io/apimachinery/pkg/selection"
 )
 
@@ -75,7 +74,6 @@ func NewJobWithSaneProductionDefaults() (*Job, error) {
 		},
 	})
 	if err != nil {
-		log.Err(err).Msg("failed to merge sane defaults into job")
 		return nil, err
 	}
 	return j, nil

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -133,7 +133,7 @@ func NewNode(
 
 	var simulatorRequestHandler *simulator.RequestHandler
 	if config.SimulatorNodeID == config.Host.ID().String() {
-		log.Info().Msgf("Node %s is the simulator node. Setting proper event handlers", config.Host.ID().String())
+		log.Ctx(ctx).Info().Msgf("Node %s is the simulator node. Setting proper event handlers", config.Host.ID().String())
 		simulatorRequestHandler = simulator.NewRequestHandler()
 	}
 
@@ -266,13 +266,13 @@ func NewNode(
 		nodeInfoPublisher.Stop()
 		cleanupErr := nodeInfoPubSub.Close(cleanupCtx)
 		if cleanupErr != nil {
-			log.Error().Err(cleanupErr).Msg("failed to close libp2p node info pubsub")
+			log.Ctx(ctx).Error().Err(cleanupErr).Msg("failed to close libp2p node info pubsub")
 		}
 		gossipSubCancel()
 
 		cleanupErr = config.Host.Close()
 		if cleanupErr != nil {
-			log.Error().Err(cleanupErr).Msg("failed to close host")
+			log.Ctx(ctx).Error().Err(cleanupErr).Msg("failed to close host")
 		}
 		return cleanupErr
 	})

--- a/pkg/node/requester.go
+++ b/pkg/node/requester.go
@@ -217,21 +217,21 @@ func NewRequesterNode(
 
 		cleanupErr := bufferedJobEventPubSub.Close(ctx)
 		if cleanupErr != nil {
-			log.Error().Err(cleanupErr).Msg("failed to close job event pubsub")
+			log.Ctx(ctx).Error().Err(cleanupErr).Msg("failed to close job event pubsub")
 		}
 		cleanupErr = libp2p2JobEventPubSub.Close(ctx)
 		if cleanupErr != nil {
-			log.Error().Err(cleanupErr).Msg("failed to close libp2p job event pubsub")
+			log.Ctx(ctx).Error().Err(cleanupErr).Msg("failed to close libp2p job event pubsub")
 		}
 
 		cleanupErr = tracerContextProvider.Shutdown()
 		if cleanupErr != nil {
-			log.Error().Err(cleanupErr).Msg("failed to shutdown tracer context provider")
+			log.Ctx(ctx).Error().Err(cleanupErr).Msg("failed to shutdown tracer context provider")
 		}
 
 		cleanupErr = eventTracer.Shutdown()
 		if cleanupErr != nil {
-			log.Error().Err(cleanupErr).Msg("failed to shutdown event tracer")
+			log.Ctx(ctx).Error().Err(cleanupErr).Msg("failed to shutdown event tracer")
 		}
 	}
 

--- a/pkg/publicapi/endpoint_health.go
+++ b/pkg/publicapi/endpoint_health.go
@@ -32,12 +32,12 @@ func GenerateHealthData() types.HealthInfo {
 //	@Router		/livez [get]
 func (apiServer *APIServer) livez(res http.ResponseWriter, req *http.Request) {
 	// Extremely simple liveness check (should be fine to be public / no-auth)
-	log.Debug().Msg("Received OK request")
+	log.Ctx(req.Context()).Debug().Msg("Received OK request")
 	res.Header().Add("Content-Type", "text/plain")
 	res.WriteHeader(http.StatusOK)
 	_, err := res.Write([]byte("OK"))
 	if err != nil {
-		log.Warn().Err(err).Msg("Error writing body for OK request.")
+		log.Ctx(req.Context()).Warn().Err(err).Msg("Error writing body for OK request.")
 	}
 }
 
@@ -49,22 +49,22 @@ func (apiServer *APIServer) livez(res http.ResponseWriter, req *http.Request) {
 //	@Success	200	{object}	string	"TODO"
 //	@Router		/logz [get]
 func (apiServer *APIServer) logz(res http.ResponseWriter, req *http.Request) {
-	log.Debug().Msg("Received logz request")
+	log.Ctx(req.Context()).Debug().Msg("Received logz request")
 	res.Header().Add("Content-Type", "text/plain")
 	res.WriteHeader(http.StatusOK)
 	fileOutput, err := TailFile(LINESOFLOGTOPRINT, "/tmp/ipfs.log")
 	if err != nil {
 		missingLogFileMsg := "File not found at /tmp/ipfs.log"
-		log.Warn().Msgf(missingLogFileMsg)
+		log.Ctx(req.Context()).Warn().Msgf(missingLogFileMsg)
 		_, err = res.Write([]byte("File not found at /tmp/ipfs.log"))
 		if err != nil {
-			log.Warn().Msgf("Could not write response body for missing log file to response.")
+			log.Ctx(req.Context()).Warn().Msgf("Could not write response body for missing log file to response.")
 		}
 		return
 	}
 	_, err = res.Write(fileOutput)
 	if err != nil {
-		log.Warn().Msg("Error writing body for logz request.")
+		log.Ctx(req.Context()).Warn().Msg("Error writing body for logz request.")
 	}
 }
 
@@ -76,7 +76,7 @@ func (apiServer *APIServer) logz(res http.ResponseWriter, req *http.Request) {
 //	@Success	200	{object}	string
 //	@Router		/readyz [get]
 func (apiServer *APIServer) readyz(res http.ResponseWriter, req *http.Request) {
-	log.Debug().Msg("Received readyz request.")
+	log.Ctx(req.Context()).Debug().Msg("Received readyz request.")
 	// TODO: Add checker for queue that this node can accept submissions
 	isReady := true
 
@@ -87,7 +87,7 @@ func (apiServer *APIServer) readyz(res http.ResponseWriter, req *http.Request) {
 	res.WriteHeader(http.StatusOK)
 	_, err := res.Write([]byte("READY"))
 	if err != nil {
-		log.Warn().Msg("Error writing body for readyz request.")
+		log.Ctx(req.Context()).Warn().Msg("Error writing body for readyz request.")
 	}
 }
 
@@ -100,7 +100,7 @@ func (apiServer *APIServer) readyz(res http.ResponseWriter, req *http.Request) {
 //	@Router		/healthz [get]
 func (apiServer *APIServer) healthz(res http.ResponseWriter, req *http.Request) {
 	// TODO: A list of health information. Should require authing (of some kind)
-	log.Debug().Msg("Received healthz request.")
+	log.Ctx(req.Context()).Debug().Msg("Received healthz request.")
 	res.Header().Add("Content-Type", "application/json")
 	res.WriteHeader(http.StatusOK)
 
@@ -112,7 +112,7 @@ func (apiServer *APIServer) healthz(res http.ResponseWriter, req *http.Request) 
 
 	_, err := res.Write(healthJSONBlob)
 	if err != nil {
-		log.Warn().Msg("Error writing body for healthz request.")
+		log.Ctx(req.Context()).Warn().Msg("Error writing body for healthz request.")
 	}
 }
 
@@ -130,6 +130,6 @@ func (apiServer *APIServer) varz(res http.ResponseWriter, req *http.Request) {
 
 	_, err := res.Write([]byte("{}"))
 	if err != nil {
-		log.Warn().Msg("Error writing body for varz request.")
+		log.Ctx(req.Context()).Warn().Msg("Error writing body for varz request.")
 	}
 }

--- a/pkg/publicapi/server.go
+++ b/pkg/publicapi/server.go
@@ -172,7 +172,7 @@ func (apiServer *APIServer) ListenAndServe(ctx context.Context, cm *system.Clean
 		}
 	}
 
-	log.Debug().Msgf(
+	log.Ctx(ctx).Debug().Msgf(
 		"API server listening for host %s on %s...", apiServer.Address, listener.Addr().String())
 
 	// Cleanup resources when system is done:

--- a/pkg/requester/discovery/chained.go
+++ b/pkg/requester/discovery/chained.go
@@ -42,7 +42,7 @@ func (c *Chain) FindNodes(ctx context.Context, job model.Job) ([]model.NodeInfo,
 				uniqueNodes[nodeInfo.PeerInfo.ID] = nodeInfo
 			}
 		}
-		log.Debug().Msgf("found %d more nodes by %s", len(uniqueNodes)-currentNodesCount, reflect.TypeOf(discoverer))
+		log.Ctx(ctx).Debug().Msgf("found %d more nodes by %s", len(uniqueNodes)-currentNodesCount, reflect.TypeOf(discoverer))
 	}
 	nodeInfos := make([]model.NodeInfo, 0, len(uniqueNodes))
 	for _, nodeInfo := range uniqueNodes {

--- a/pkg/requester/publicapi/client.go
+++ b/pkg/requester/publicapi/client.go
@@ -118,7 +118,7 @@ func (apiClient *RequesterAPIClient) GetJobState(ctx context.Context, jobID stri
 		if err == nil {
 			return res.State, nil
 		} else {
-			log.Debug().Err(err).Msg("apiclient read state error")
+			log.Ctx(ctx).Debug().Err(err).Msg("apiclient read state error")
 			outerErr = err
 		}
 	}
@@ -163,7 +163,7 @@ func (apiClient *RequesterAPIClient) GetEvents(ctx context.Context, jobID string
 		if err == nil {
 			return res.Events, nil
 		} else {
-			log.Debug().Err(err).Msg("apiclient read events error")
+			log.Ctx(ctx).Debug().Err(err).Msg("apiclient read events error")
 			outerErr = err
 			if strings.Contains(err.Error(), "context canceled") {
 				outerErr = bacerrors.NewContextCanceledError(ctx.Err().Error())

--- a/pkg/requester/publicapi/endpoints_websockets_events.go
+++ b/pkg/requester/publicapi/endpoints_websockets_events.go
@@ -21,7 +21,7 @@ func (s *RequesterAPIServer) websocketJobEvents(res http.ResponseWriter, req *ht
 		http.Error(res, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	log.Debug().Msgf("New websocketJobEvents connection.")
+	log.Ctx(req.Context()).Debug().Msgf("New websocketJobEvents connection.")
 	defer conn.Close()
 
 	// NB: jobId == "" is the case for subscriptions to "all events"
@@ -45,13 +45,13 @@ func (s *RequesterAPIServer) websocketJobEvents(res http.ResponseWriter, req *ht
 		// list events for job out of localDB and send them to the client
 		events, err := s.jobStore.GetJobHistory(context.Background(), jobID)
 		if err != nil {
-			log.Error().Msgf("error listing job events: %s\n", err.Error())
+			log.Ctx(req.Context()).Error().Msgf("error listing job events: %s\n", err.Error())
 			return
 		}
 		for _, event := range events {
 			err := conn.WriteJSON(event)
 			if err != nil {
-				log.Error().Msgf("error writing event JSON: %s\n", err.Error())
+				log.Ctx(req.Context()).Error().Msgf("error writing event JSON: %s\n", err.Error())
 			}
 		}
 	}
@@ -81,7 +81,7 @@ func (s *RequesterAPIServer) HandleJobEvent(ctx context.Context, event model.Job
 			// reader slowing all the others down.
 			err := connection.WriteJSON(event)
 			if err != nil {
-				log.Error().Msgf(
+				log.Ctx(ctx).Error().Msgf(
 					"error writing event to subscriber '%s'/%d: %s, closing ws\n",
 					jobId, idx, err.Error(),
 				)

--- a/pkg/requester/ranking/engines.go
+++ b/pkg/requester/ranking/engines.go
@@ -32,7 +32,7 @@ func (s *EnginesNodeRanker) RankNodes(ctx context.Context, job model.Job, nodes 
 			}
 			// engine wasn't found
 			if rank == 0 {
-				log.Trace().Msgf("filtering node %s doesn't support engine %s", node.PeerInfo.ID, job.Spec.Engine)
+				log.Ctx(ctx).Trace().Msgf("filtering node %s doesn't support engine %s", node.PeerInfo.ID, job.Spec.Engine)
 				rank = -1
 			}
 		}

--- a/pkg/requester/ranking/labels.go
+++ b/pkg/requester/ranking/labels.go
@@ -36,7 +36,7 @@ func (s *LabelsNodeRanker) RankNodes(ctx context.Context, job model.Job, nodes [
 			if selector.Matches(labels.Set(node.Labels)) {
 				rank = 1
 			} else {
-				log.Trace().Msgf("filtering node %s with labels %s doesn't match selectors %+v",
+				log.Ctx(ctx).Trace().Msgf("filtering node %s with labels %s doesn't match selectors %+v",
 					node.PeerInfo.ID, node.Labels, job.Spec.NodeSelectors)
 				rank = -1
 			}

--- a/pkg/requester/ranking/max_usage.go
+++ b/pkg/requester/ranking/max_usage.go
@@ -30,7 +30,7 @@ func (s *MaxUsageNodeRanker) RankNodes(ctx context.Context, job model.Job, nodes
 			if jobResourceUsage.LessThanEq(node.ComputeNodeInfo.MaxJobRequirements) {
 				rank = 10
 			} else {
-				log.Trace().Msgf("filtering node %s doesn't accept MaxJobRequirements %s", node.PeerInfo.ID, jobResourceUsage)
+				log.Ctx(ctx).Trace().Msgf("filtering node %s doesn't accept MaxJobRequirements %s", node.PeerInfo.ID, jobResourceUsage)
 				rank = -1
 			}
 		}

--- a/pkg/requester/scheduler.go
+++ b/pkg/requester/scheduler.go
@@ -89,7 +89,7 @@ func (s *Scheduler) StartJob(ctx context.Context, req StartJobRequest) error {
 		}
 	}
 	rankedNodes = filteredNodes
-	log.Debug().Msgf("ranked %d nodes for job %s", len(rankedNodes), req.Job.Metadata.ID)
+	log.Ctx(ctx).Debug().Msgf("ranked %d nodes for job %s", len(rankedNodes), req.Job.Metadata.ID)
 
 	minBids := system.Max(req.Job.Spec.Deal.MinBids, req.Job.Spec.Deal.Concurrency)
 	if len(rankedNodes) < minBids {

--- a/pkg/simulator/handler.go
+++ b/pkg/simulator/handler.go
@@ -127,7 +127,7 @@ func (e *RequestHandler) CancelExecution(
 func (e *RequestHandler) OnRunComplete(ctx context.Context, result compute.RunResult) {
 	event, err := e.constructEventFromExecution(result.RoutingMetadata, result.ExecutionID, model.JobEventResultsProposed)
 	if err != nil {
-		log.Error().Err(err).Msgf("failed to construct event %s from execution %s", model.JobEventResultsProposed, result.ExecutionID)
+		log.Ctx(ctx).Error().Err(err).Msgf("failed to construct event %s from execution %s", model.JobEventResultsProposed, result.ExecutionID)
 	}
 	event.VerificationProposal = result.ResultProposal
 	event.RunOutput = result.RunCommandResult
@@ -135,7 +135,7 @@ func (e *RequestHandler) OnRunComplete(ctx context.Context, result compute.RunRe
 
 	err = e.wallets.addEvent(event)
 	if err != nil {
-		log.Error().Err(err).Msgf("failed to add event %s from execution %s", model.JobEventResultsProposed, result.ExecutionID)
+		log.Ctx(ctx).Error().Err(err).Msgf("failed to add event %s from execution %s", model.JobEventResultsProposed, result.ExecutionID)
 	}
 	e.requesterProxy.OnRunComplete(ctx, result)
 }
@@ -143,14 +143,14 @@ func (e *RequestHandler) OnRunComplete(ctx context.Context, result compute.RunRe
 func (e *RequestHandler) OnPublishComplete(ctx context.Context, result compute.PublishResult) {
 	event, err := e.constructEventFromExecution(result.RoutingMetadata, result.ExecutionID, model.JobEventResultsPublished)
 	if err != nil {
-		log.Error().Err(err).Msgf("failed to construct event %s from execution %s", model.JobEventResultsPublished, result.ExecutionID)
+		log.Ctx(ctx).Error().Err(err).Msgf("failed to construct event %s from execution %s", model.JobEventResultsPublished, result.ExecutionID)
 	}
 	event.PublishedResult = result.PublishResult
 	event.TargetNodeID = "" // requester node is never targeted
 
 	err = e.wallets.addEvent(event)
 	if err != nil {
-		log.Error().Err(err).Msgf("failed to add event %s from execution %s", model.JobEventResultsPublished, result.ExecutionID)
+		log.Ctx(ctx).Error().Err(err).Msgf("failed to add event %s from execution %s", model.JobEventResultsPublished, result.ExecutionID)
 	}
 	e.requesterProxy.OnPublishComplete(ctx, result)
 }
@@ -162,14 +162,14 @@ func (e *RequestHandler) OnCancelComplete(ctx context.Context, result compute.Ca
 func (e *RequestHandler) OnComputeFailure(ctx context.Context, result compute.ComputeError) {
 	event, err := e.constructEventFromExecution(result.RoutingMetadata, result.ExecutionID, model.JobEventComputeError)
 	if err != nil {
-		log.Error().Err(err).Msgf("failed to construct event %s from execution %s", model.JobEventComputeError, result.ExecutionID)
+		log.Ctx(ctx).Error().Err(err).Msgf("failed to construct event %s from execution %s", model.JobEventComputeError, result.ExecutionID)
 	}
 	event.Status = result.Error()
 	event.TargetNodeID = "" // requester node is never targeted
 
 	err = e.wallets.addEvent(event)
 	if err != nil {
-		log.Error().Err(err).Msgf("failed to add event %s from execution %s", model.JobEventComputeError, result.ExecutionID)
+		log.Ctx(ctx).Error().Err(err).Msgf("failed to add event %s from execution %s", model.JobEventComputeError, result.ExecutionID)
 	}
 	e.requesterProxy.OnComputeFailure(ctx, result)
 }

--- a/pkg/storage/url/urldownload/storage.go
+++ b/pkg/storage/url/urldownload/storage.go
@@ -224,6 +224,8 @@ var _ storage.Storage = (*StorageProvider)(nil)
 
 var _ retryablehttp.LeveledLogger = retryLogger{}
 
+// This logger needs to change to fetch the logger from the context once
+// https://github.com/hashicorp/go-retryablehttp/issues/182 is implemented and released.
 type retryLogger struct {
 }
 

--- a/pkg/system/tracer.go
+++ b/pkg/system/tracer.go
@@ -85,12 +85,12 @@ func addFieldToBaggage(ctx context.Context, key, value string) context.Context {
 	b := baggage.FromContext(ctx)
 	m, err := baggage.NewMember(key, value)
 	if err != nil {
-		log.Warn().Msgf("failed to add key %s to baggage: %s", key, err)
+		log.Ctx(ctx).Warn().Msgf("failed to add key %s to baggage: %s", key, err)
 	}
 
 	b, err = b.SetMember(m)
 	if err != nil {
-		log.Warn().Msgf("failed to add baggage member to baggage: %s", err)
+		log.Ctx(ctx).Warn().Msgf("failed to add baggage member to baggage: %s", err)
 	}
 
 	return baggage.ContextWithBaggage(ctx, b)
@@ -102,12 +102,12 @@ func AddJobIDFromBaggageToSpan(ctx context.Context, span oteltrace.Span) {
 
 func addAttributeToSpanFromBaggage(ctx context.Context, span oteltrace.Span, name string) {
 	b := baggage.FromContext(ctx)
-	log.Trace().Msgf("adding %s from baggage to span as attribute: %+v", name, b)
+	log.Ctx(ctx).Trace().Msgf("adding %s from baggage to span as attribute: %+v", name, b)
 	m := b.Member(name)
 	if m.Value() != "" {
 		span.SetAttributes(attribute.String(name, m.Value()))
 	} else {
-		log.Trace().Err(errors.WithStack(errors.New("missing value"))).
+		log.Ctx(ctx).Trace().Err(errors.WithStack(errors.New("missing value"))).
 			Str("baggage_key", name).Msg("No value found for baggage key")
 	}
 }

--- a/pkg/telemetry/logging_trace.go
+++ b/pkg/telemetry/logging_trace.go
@@ -1,0 +1,49 @@
+package telemetry
+
+import (
+	"context"
+
+	"github.com/filecoin-project/bacalhau/pkg/model"
+	"github.com/rs/zerolog"
+	"go.opentelemetry.io/otel/baggage"
+	oteltrace "go.opentelemetry.io/otel/trace"
+)
+
+type loggingTracerProvider struct {
+	delegate shutdownTracerProvider
+}
+
+func (l loggingTracerProvider) Shutdown(ctx context.Context) error {
+	return l.delegate.Shutdown(ctx)
+}
+
+func (l loggingTracerProvider) Tracer(name string, options ...oteltrace.TracerOption) oteltrace.Tracer {
+	tracer := l.delegate.Tracer(name, options...)
+	return loggingTracer{
+		delegate: tracer,
+	}
+}
+
+type loggingTracer struct {
+	delegate oteltrace.Tracer
+}
+
+func (l loggingTracer) Start(ctx context.Context, spanName string, opts ...oteltrace.SpanStartOption) (context.Context, oteltrace.Span) {
+	ctx, span := l.delegate.Start(ctx, spanName, opts...)
+
+	// Name of the attributes taken from https://opentelemetry.io/docs/reference/specification/logs/#json-formats
+	logger := zerolog.Ctx(ctx).With().
+		Stringer("trace_id", span.SpanContext().TraceID()).
+		Stringer("span_id", span.SpanContext().SpanID())
+
+	if v := baggage.FromContext(ctx).Member(model.TracerAttributeNameJobID).Value(); v != "" {
+		logger = logger.Str(model.TracerAttributeNameJobID, v)
+	}
+
+	ctx = logger.Logger().WithContext(ctx)
+
+	return ctx, span
+}
+
+var _ shutdownTracerProvider = loggingTracerProvider{}
+var _ oteltrace.Tracer = loggingTracer{}

--- a/pkg/telemetry/logging_trace_test.go
+++ b/pkg/telemetry/logging_trace_test.go
@@ -1,0 +1,58 @@
+//go:build unit || !integration
+
+package telemetry
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/filecoin-project/bacalhau/pkg/model"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/baggage"
+	"go.opentelemetry.io/otel/sdk/trace"
+)
+
+func TestLoggingTracerProvider_addsSpanIDToLogger(t *testing.T) {
+	oldLogger := log.Logger
+	oldContextLogger := zerolog.DefaultContextLogger
+	t.Cleanup(func() {
+		log.Logger = oldLogger
+		zerolog.DefaultContextLogger = oldContextLogger
+	})
+
+	sb := &strings.Builder{}
+	log.Logger = zerolog.New(sb)
+	zerolog.DefaultContextLogger = &log.Logger
+
+	subject := loggingTracerProvider{trace.NewTracerProvider()}
+	t.Cleanup(func() {
+		assert.NoError(t, subject.Shutdown(context.Background()))
+	})
+
+	ctx := context.Background()
+	expectedJobId := "job-id"
+
+	m, err := baggage.NewMember(model.TracerAttributeNameJobID, expectedJobId)
+	require.NoError(t, err)
+	b, err := baggage.New(m)
+	require.NoError(t, err)
+	ctx = baggage.ContextWithBaggage(ctx, b)
+
+	ctx, span := subject.Tracer("test").Start(ctx, "dummy")
+
+	log.Ctx(ctx).Error().Msg("test message")
+
+	t.Log(sb.String())
+
+	var message map[string]string
+	require.NoError(t, json.Unmarshal([]byte(sb.String()), &message))
+
+	assert.Equal(t, expectedJobId, message[model.TracerAttributeNameJobID])
+	assert.Equal(t, span.SpanContext().SpanID().String(), message["span_id"])
+	assert.Equal(t, span.SpanContext().TraceID().String(), message["trace_id"])
+}

--- a/pkg/telemetry/metrics.go
+++ b/pkg/telemetry/metrics.go
@@ -25,7 +25,7 @@ func newMeterProvider() {
 	ctx := context.Background()
 	exp, err := getMetricsClient(ctx)
 	if err != nil {
-		log.Error().Err(err).Msg("failed to initialize OLTP metric exporter")
+		log.Ctx(ctx).Error().Err(err).Msg("failed to initialize OLTP metric exporter")
 		return
 	}
 

--- a/pkg/telemetry/tracing_helpers_test.go
+++ b/pkg/telemetry/tracing_helpers_test.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestRecordErrorOnSpan(t *testing.T) {
@@ -216,7 +217,9 @@ func TestRecordErrorOnSpanTwoChannels_withoutError(t *testing.T) {
 	assert.False(t, span.ended, "span should only be closed once the channel has received a response")
 	paramChan <- expectedParam
 	actualParam := <-actualParamChan
-	assert.True(t, span.ended, "span should only be closed once the channel has received a response")
+	assert.Eventually(t, func() bool {
+		return span.ended
+	}, 1*time.Second, 5*time.Millisecond, "span should only be closed once the channel has received a response")
 
 	assert.Empty(t, span.err)
 	assert.Empty(t, span.statusCode)


### PR DESCRIPTION
This ensures that log statements contain the job ID and tracing information to make it easier to correlate traces with the log statements associated with them.

This also updates as many log statements as possible to use `log.Ctx` so that the log statements include the node, span, trace & job IDs.

Fixes #1152