### PR TITLE
Log all messages in the correct format

### DIFF
--- a/cmd/bacalhau/flags.go
+++ b/cmd/bacalhau/flags.go
@@ -228,11 +228,11 @@ func NetworkFlag(value *model.Network) *ValueFlag[model.Network] {
 	}
 }
 
-func LoggingFlag(value *logger.Logmode) *ValueFlag[logger.Logmode] {
-	return &ValueFlag[logger.Logmode]{
+func LoggingFlag(value *logger.LogMode) *ValueFlag[logger.LogMode] {
+	return &ValueFlag[logger.LogMode]{
 		value:    value,
-		parser:   logger.ParseLogmode,
-		stringer: func(p *logger.Logmode) string { return string(*p) },
+		parser:   logger.ParseLogMode,
+		stringer: func(p *logger.LogMode) string { return string(*p) },
 		typeStr:  "logging-mode",
 	}
 }

--- a/cmd/bacalhau/root.go
+++ b/cmd/bacalhau/root.go
@@ -18,7 +18,7 @@ var apiHost string
 var apiPort int
 var doNotTrack bool
 
-var loggingMode logger.Logmode = logger.LogModeDefault
+var loggingMode = logger.LogModeDefault
 
 var Fatal = FatalErrorHandler
 
@@ -41,7 +41,7 @@ func init() { //nolint:gochecknoinits
 	}
 
 	if logtype, set := os.LookupEnv("LOG_TYPE"); set {
-		loggingMode = logger.Logmode(strings.ToLower(logtype))
+		loggingMode = logger.LogMode(strings.ToLower(logtype))
 	}
 
 	// Force cobra to set apiHost & apiPort
@@ -154,7 +154,9 @@ func Execute() {
 
 	// Use stdout, not stderr for cmd.Print output, so that
 	// e.g. ID=$(bacalhau run) works
-	RootCmd.SetOutput(system.Stdout)
+	RootCmd.SetOut(system.Stdout)
+	// TODO this is from fixing a deprecation warning for SetOutput. Shouldn't this be system.Stderr?
+	RootCmd.SetErr(system.Stdout)
 
 	if err := RootCmd.Execute(); err != nil {
 		Fatal(RootCmd, err.Error(), 1)

--- a/main.go
+++ b/main.go
@@ -8,12 +8,18 @@ import (
 
 	"github.com/filecoin-project/bacalhau/cmd/bacalhau"
 
+	"github.com/filecoin-project/bacalhau/pkg/logger"
 	"github.com/filecoin-project/bacalhau/pkg/system"
 	"github.com/joho/godotenv"
 	"github.com/rs/zerolog/log"
 )
 
 func main() {
+	defer func() {
+		// Make sure any buffered logs are written if something failed before logging was configured.
+		logger.LogBufferedLogs(nil)
+	}()
+
 	_ = godotenv.Load()
 
 	devstackEnvFile := config.DevstackEnvFile()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -185,7 +185,7 @@ func GetPrivateKey(keyName string) (crypto.PrivKey, error) {
 		if err := keyOut.Close(); err != nil {
 			return nil, fmt.Errorf("error closing key file: %v", err)
 		}
-		log.Printf("wrote %s", privKeyPath)
+		log.Debug().Msgf("wrote %s", privKeyPath)
 	}
 
 	// Now that we've ensured the private key is written to disk, read it! This

--- a/pkg/logger/buffering.go
+++ b/pkg/logger/buffering.go
@@ -1,0 +1,68 @@
+package logger
+
+import (
+	"io"
+	"sync"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/rs/zerolog/log"
+	"golang.org/x/exp/slices"
+)
+
+var logBufferedLogs func(io.Writer) error
+
+// LogBufferedLogs will log any log messages written from before logging was configured to the given writer. If writer
+// is nil, then the default logging will be used instead. This function will do nothing once the buffer has been outputted.
+func LogBufferedLogs(writer io.Writer) {
+	if logBufferedLogs == nil {
+		return
+	}
+	if writer == nil {
+		writer = defaultLogging()
+	}
+
+	if err := logBufferedLogs(writer); err != nil {
+		log.Err(err).Msg("Failed to log messages")
+	}
+	logBufferedLogs = nil
+}
+
+// bufferLogs is an io.Writer to be used with zerolog which will buffer log messages until LogBufferedLogs is called with
+// the real log writer, such as from defaultLogging or jsonLogging.
+func bufferLogs() io.Writer {
+	buffer := &bufferingLogWriter{}
+	logBufferedLogs = buffer.writeLogs
+	return buffer
+}
+
+type bufferingLogWriter struct {
+	buffer [][]byte
+	mu     sync.Mutex
+}
+
+func (b *bufferingLogWriter) Write(p []byte) (n int, err error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	// make sure p isn't reused while it's being kept on the buffer
+	p = slices.Clone(p)
+
+	b.buffer = append(b.buffer, p)
+
+	return 0, nil
+}
+
+func (b *bufferingLogWriter) writeLogs(w io.Writer) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	var errs error
+	for _, line := range b.buffer {
+		if _, err := w.Write(line); err != nil {
+			errs = multierror.Append(errs, err)
+		}
+	}
+	return errs
+}
+
+var _ io.Writer = &bufferingLogWriter{}

--- a/pkg/logger/buffering_test.go
+++ b/pkg/logger/buffering_test.go
@@ -1,0 +1,43 @@
+package logger
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestBufferingLogger_allowsBufferedLogsToBeWritten(t *testing.T) {
+	w := bufferLogs()
+	assert.NotNil(t, logBufferedLogs)
+
+	logger := zerolog.New(w).With().Caller().Logger()
+	logger.Info().Msg("test message")
+	// repeated so we can check the details are from when the message was logged not buffered
+	logger.Info().Msg("test message")
+
+	var sb bytes.Buffer
+	LogBufferedLogs(&sb)
+	assert.Nil(t, logBufferedLogs)
+
+	scan := bufio.NewScanner(&sb)
+
+	t.Log(sb.String())
+
+	var lines []map[string]string
+	for scan.Scan() {
+		var line map[string]string
+		require.NoError(t, json.Unmarshal(scan.Bytes(), &line))
+
+		lines = append(lines, line)
+	}
+
+	require.Len(t, lines, 2)
+
+	assert.Equal(t, lines[0]["level"], lines[1]["level"])
+	assert.Equal(t, lines[0]["message"], lines[1]["message"])
+	assert.NotEqual(t, lines[0]["caller"], lines[1]["caller"])
+}

--- a/pkg/telemetry/metrics.go
+++ b/pkg/telemetry/metrics.go
@@ -17,7 +17,7 @@ var meterProvider *sdkmetric.MeterProvider
 
 func newMeterProvider() {
 	if !isMetricsEnabled() {
-		log.Debug().Msgf("OLTP metrics endpoints are not defined. Not metrics will be exported")
+		log.Debug().Msgf("OLTP metrics endpoints are not defined. No metrics will be exported")
 		return
 	}
 


### PR DESCRIPTION
We need to avoid outputting logging messages before logging has been properly configured, otherwise it may be in the wrong format - JSON format vs human-readable. We also need to be careful so that, if something goes wrong _before_ logging is configured, the messages are still logged (although in an arbitrary format rather than one the user selected). To avoid causing too much refactoring, we also need to _not_ buffer logs when running as a test.

This adds a simple buffer to store log messages so that can be printed out once logging has been configured.

Fixes #2004