### PR TITLE
Ensure successful publishing is favoured over errors

### DIFF
--- a/pkg/publisher/combo/fanout.go
+++ b/pkg/publisher/combo/fanout.go
@@ -119,6 +119,7 @@ func (f *fanoutPublisher) PublishShardResult(
 	hostID string,
 	shardResultPath string,
 ) (model.StorageSpec, error) {
+	var err error
 	ctx = log.Ctx(ctx).With().Str("Method", "PublishShardResult").Logger().WithContext(ctx)
 
 	valueChannel, errorChannel := fanout(ctx, f.publishers, func(p publisher.Publisher) (model.StorageSpec, error) {
@@ -160,8 +161,8 @@ loop:
 
 		case <-timeoutChannel:
 			break loop
-		case err := <-errorChannel:
-			return model.StorageSpec{}, err
+		case err = <-errorChannel:
+			break loop
 		}
 	}
 
@@ -173,7 +174,7 @@ loop:
 		}
 	}
 
-	return model.StorageSpec{}, nil
+	return model.StorageSpec{}, err
 }
 
 var _ publisher.Publisher = (*fanoutPublisher)(nil)

--- a/pkg/publisher/combo/fanout_test.go
+++ b/pkg/publisher/combo/fanout_test.go
@@ -32,5 +32,6 @@ func TestFanoutPublisher(t *testing.T) {
 		"returns error for all":            {NewFanoutPublisher(&errorPublisher, &errorPublisher), errorPublisher},
 		"waits for highest priority value": {NewPrioritizedFanoutPublisher(time.Millisecond*100, &sleepyPublisher, &healthyPublisher), sleepyPublisher},
 		"only waits for max time":          {NewPrioritizedFanoutPublisher(time.Millisecond*20, &sleepyPublisher, &healthyPublisher), healthyPublisher},
+		"waits for unprioritized value":    {NewPrioritizedFanoutPublisher(time.Millisecond*100, &errorPublisher, &sleepyPublisher), sleepyPublisher},
 	})
 }


### PR DESCRIPTION
The previous code would return an error from the prioritized publisher if it finished last but within the timeout window. Now, if it errors, any other successful publish call will be used instead. This is to ensure that Estuary errors don't fail jobs where our own IPFS publish succeeds.

Resolves #2014.