### PR TITLE
Move SystemManager & span handling to root command

### DIFF
--- a/cmd/bacalhau/cancel.go
+++ b/cmd/bacalhau/cancel.go
@@ -4,9 +4,6 @@ import (
 	"fmt"
 
 	"github.com/filecoin-project/bacalhau/pkg/bacerrors"
-	"github.com/filecoin-project/bacalhau/pkg/telemetry"
-
-	"github.com/filecoin-project/bacalhau/pkg/system"
 	"github.com/filecoin-project/bacalhau/pkg/util/templates"
 	"github.com/spf13/cobra"
 	"k8s.io/kubectl/pkg/util/i18n"
@@ -52,13 +49,7 @@ func newCancelCmd() *cobra.Command {
 }
 
 func cancel(cmd *cobra.Command, cmdArgs []string, options *CancelOptions) error {
-	cm := system.NewCleanupManager()
-	defer cm.Cleanup()
 	ctx := cmd.Context()
-
-	ctx, span := system.NewRootSpan(ctx, system.GetTracer(), "cmd/bacalhau.cancel")
-	defer span.End()
-	cm.RegisterCallback(telemetry.Cleanup)
 
 	var err error
 

--- a/cmd/bacalhau/create.go
+++ b/cmd/bacalhau/create.go
@@ -8,10 +8,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/filecoin-project/bacalhau/pkg/downloader/util"
-	"github.com/filecoin-project/bacalhau/pkg/telemetry"
-
 	"github.com/filecoin-project/bacalhau/pkg/bacerrors"
+	"github.com/filecoin-project/bacalhau/pkg/downloader/util"
 	jobutils "github.com/filecoin-project/bacalhau/pkg/job"
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/filecoin-project/bacalhau/pkg/system"
@@ -83,13 +81,9 @@ func newCreateCmd() *cobra.Command {
 }
 
 func create(cmd *cobra.Command, cmdArgs []string, OC *CreateOptions) error { //nolint:funlen,gocyclo
-	cm := system.NewCleanupManager()
-	defer cm.Cleanup()
 	ctx := cmd.Context()
 
-	ctx, rootSpan := system.NewRootSpan(ctx, system.GetTracer(), "cmd/bacalhau.create")
-	defer rootSpan.End()
-	cm.RegisterCallback(telemetry.Cleanup)
+	cm := cmd.Context().Value(systemManagerKey).(*system.CleanupManager)
 
 	// Custom unmarshaller
 	// https://stackoverflow.com/questions/70635636/unmarshaling-yaml-into-different-struct-based-off-yaml-field?rq=1

--- a/cmd/bacalhau/describe.go
+++ b/cmd/bacalhau/describe.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 
 	"github.com/filecoin-project/bacalhau/pkg/bacerrors"
-	"github.com/filecoin-project/bacalhau/pkg/system"
-	"github.com/filecoin-project/bacalhau/pkg/telemetry"
 	"github.com/filecoin-project/bacalhau/pkg/util/templates"
 	"github.com/spf13/cobra"
 	"k8s.io/kubectl/pkg/util/i18n"
@@ -78,17 +76,11 @@ func newDescribeCmd() *cobra.Command {
 }
 
 func describe(cmd *cobra.Command, cmdArgs []string, OD *DescribeOptions) error {
-	cm := system.NewCleanupManager()
-	defer cm.Cleanup()
 	ctx := cmd.Context()
 
 	if err := cmd.ParseFlags(cmdArgs[1:]); err != nil {
 		Fatal(cmd, fmt.Sprintf("Failed to parse flags: %v\n", err), 1)
 	}
-
-	ctx, rootSpan := system.NewRootSpan(ctx, system.GetTracer(), "cmd/bacalhau.describe")
-	defer rootSpan.End()
-	cm.RegisterCallback(telemetry.Cleanup)
 
 	var err error
 	inputJobID := cmdArgs[0]

--- a/cmd/bacalhau/devstack.go
+++ b/cmd/bacalhau/devstack.go
@@ -127,12 +127,9 @@ func newDevStackCmd() *cobra.Command {
 }
 
 func runDevstack(cmd *cobra.Command, ODs *devstack.DevStackOptions, OS *ServeOptions, IsNoop bool) error {
-	cm := system.NewCleanupManager()
-	defer cm.Cleanup()
 	ctx := cmd.Context()
 
-	ctx, rootSpan := system.NewRootSpan(ctx, system.GetTracer(), "cmd/bacalhau.runDevstack")
-	defer rootSpan.End()
+	cm := ctx.Value(systemManagerKey).(*system.CleanupManager)
 
 	if config.DevstackShouldWriteEnvFile() {
 		cm.RegisterCallback(cleanupDevstackDotEnv)

--- a/cmd/bacalhau/get.go
+++ b/cmd/bacalhau/get.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/filecoin-project/bacalhau/pkg/downloader/util"
 	"github.com/filecoin-project/bacalhau/pkg/model"
-	"github.com/filecoin-project/bacalhau/pkg/telemetry"
-
 	"github.com/filecoin-project/bacalhau/pkg/system"
 	"github.com/filecoin-project/bacalhau/pkg/util/templates"
 	"github.com/pkg/errors"
@@ -60,13 +58,9 @@ func newGetCmd() *cobra.Command {
 }
 
 func get(cmd *cobra.Command, cmdArgs []string, OG *GetOptions) error {
-	cm := system.NewCleanupManager()
-	defer cm.Cleanup()
 	ctx := cmd.Context()
 
-	ctx, span := system.NewRootSpan(ctx, system.GetTracer(), "cmd/bacalhau.get")
-	defer span.End()
-	cm.RegisterCallback(telemetry.Cleanup)
+	cm := cmd.Context().Value(systemManagerKey).(*system.CleanupManager)
 
 	var err error
 

--- a/cmd/bacalhau/id.go
+++ b/cmd/bacalhau/id.go
@@ -5,8 +5,6 @@ import (
 	"os"
 
 	"github.com/filecoin-project/bacalhau/pkg/libp2p"
-	"github.com/filecoin-project/bacalhau/pkg/system"
-	"github.com/filecoin-project/bacalhau/pkg/telemetry"
 	"github.com/spf13/cobra"
 )
 
@@ -31,11 +29,6 @@ func newIDCmd() *cobra.Command {
 }
 
 func id(_ *cobra.Command, OS *ServeOptions) error {
-	// Cleanup manager ensures that resources are freed before exiting:
-	cm := system.NewCleanupManager()
-	cm.RegisterCallback(telemetry.Cleanup)
-	defer cm.Cleanup()
-
 	libp2pHost, err := libp2p.NewHost(OS.SwarmPort)
 	if err != nil {
 		return err

--- a/cmd/bacalhau/list.go
+++ b/cmd/bacalhau/list.go
@@ -8,7 +8,6 @@ import (
 	"github.com/filecoin-project/bacalhau/pkg/job"
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/filecoin-project/bacalhau/pkg/system"
-	"github.com/filecoin-project/bacalhau/pkg/telemetry"
 	"github.com/filecoin-project/bacalhau/pkg/util/templates"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/rs/zerolog/log"
@@ -148,13 +147,7 @@ func (c *ColumnEnum) Set(v string) error {
 }
 
 func list(cmd *cobra.Command, OL *ListOptions) error {
-	cm := system.NewCleanupManager()
-	defer cm.Cleanup()
 	ctx := cmd.Context()
-
-	ctx, rootSpan := system.NewRootSpan(ctx, system.GetTracer(), "cmd/bacalhau.list")
-	defer rootSpan.End()
-	cm.RegisterCallback(telemetry.Cleanup)
 
 	log.Ctx(ctx).Debug().Msgf("Table filter flag set to: %s", OL.IDFilter)
 	log.Ctx(ctx).Debug().Msgf("Table limit flag set to: %d", OL.MaxJobs)

--- a/cmd/bacalhau/run.go
+++ b/cmd/bacalhau/run.go
@@ -1,27 +1,15 @@
 package bacalhau
 
 import (
-	"fmt"
-
-	"github.com/filecoin-project/bacalhau/pkg/version"
 	"github.com/spf13/cobra"
 )
 
 func newRunCmd() *cobra.Command {
 	runCmd := &cobra.Command{
-		Use:    "run",
-		Short:  "Run a job on the network (see subcommands for supported flavors)",
-		PreRun: applyPorcelainLogLevel,
-		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
-			// Check that the server version is compatible with the client version
-			serverVersion, _ := GetAPIClient().Version(cmd.Context()) // Ok if this fails, version validation will skip
-			if err := ensureValidVersion(cmd.Context(), version.Get(), serverVersion); err != nil {
-				Fatal(cmd, fmt.Sprintf("version validation failed: %s", err), 1)
-				return err
-			}
-
-			return nil
-		},
+		Use:               "run",
+		Short:             "Run a job on the network (see subcommands for supported flavors)",
+		PreRun:            applyPorcelainLogLevel,
+		PersistentPreRunE: checkVersion,
 	}
 	runCmd.AddCommand(newRunPythonCmd())
 	return runCmd

--- a/cmd/bacalhau/run_python.go
+++ b/cmd/bacalhau/run_python.go
@@ -5,10 +5,8 @@ import (
 	"time"
 
 	"github.com/filecoin-project/bacalhau/pkg/downloader/util"
-	"github.com/filecoin-project/bacalhau/pkg/model"
-	"github.com/filecoin-project/bacalhau/pkg/telemetry"
-
 	"github.com/filecoin-project/bacalhau/pkg/job"
+	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/filecoin-project/bacalhau/pkg/storage/inline"
 	"github.com/filecoin-project/bacalhau/pkg/system"
 	"github.com/filecoin-project/bacalhau/pkg/util/templates"
@@ -165,13 +163,9 @@ func newRunPythonCmd() *cobra.Command {
 }
 
 func runPython(cmd *cobra.Command, cmdArgs []string, OLR *LanguageRunOptions) error {
-	cm := system.NewCleanupManager()
-	defer cm.Cleanup()
 	ctx := cmd.Context()
 
-	ctx, rootSpan := system.NewRootSpan(ctx, system.GetTracer(), "cmd/bacalhau.runPython")
-	defer rootSpan.End()
-	cm.RegisterCallback(telemetry.Cleanup)
+	cm := cmd.Context().Value(systemManagerKey).(*system.CleanupManager)
 
 	// error if determinism is false
 	if !OLR.Deterministic {

--- a/cmd/bacalhau/simulator.go
+++ b/cmd/bacalhau/simulator.go
@@ -24,19 +24,15 @@ func newSimulatorCmd() *cobra.Command {
 }
 
 func runSimulator(cmd *cobra.Command) error {
-	//Cleanup manager ensures that resources are freed before exiting:
-	cm := system.NewCleanupManager()
-	//cm.RegisterCallback(telemetry.Cleanup)
-	defer cm.Cleanup()
 	ctx := cmd.Context()
+	cm := ctx.Value(systemManagerKey).(*system.CleanupManager)
+	//Cleanup manager ensures that resources are freed before exiting:
 	datastore := inmemory.NewJobStore()
 	libp2pHost, err := libp2p.NewHost(9075) //nolint:gomnd
 	if err != nil {
 		Fatal(cmd, fmt.Sprintf("Error creating libp2p host: %s", err), 1)
 	}
-	cm.RegisterCallback(func() error {
-		return libp2pHost.Close()
-	})
+	cm.RegisterCallback(libp2pHost.Close)
 
 	// print out simulator multi-address
 	p2pAddr, err := multiaddr.NewMultiaddr("/p2p/" + libp2pHost.ID().String())

--- a/cmd/bacalhau/utils.go
+++ b/cmd/bacalhau/utils.go
@@ -14,14 +14,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/filecoin-project/bacalhau/pkg/downloader/util"
-
-	"github.com/filecoin-project/bacalhau/pkg/downloader"
-
 	"github.com/Masterminds/semver"
 	"github.com/filecoin-project/bacalhau/pkg/bacerrors"
 	"github.com/filecoin-project/bacalhau/pkg/compute/capacity"
 	"github.com/filecoin-project/bacalhau/pkg/devstack"
+	"github.com/filecoin-project/bacalhau/pkg/downloader"
+	"github.com/filecoin-project/bacalhau/pkg/downloader/util"
 	"github.com/filecoin-project/bacalhau/pkg/job"
 	"github.com/filecoin-project/bacalhau/pkg/model"
 	"github.com/filecoin-project/bacalhau/pkg/requester/publicapi"

--- a/cmd/bacalhau/version.go
+++ b/cmd/bacalhau/version.go
@@ -23,8 +23,6 @@ import (
 	"strings"
 
 	"github.com/filecoin-project/bacalhau/pkg/model"
-	"github.com/filecoin-project/bacalhau/pkg/system"
-	"github.com/filecoin-project/bacalhau/pkg/telemetry"
 	"github.com/filecoin-project/bacalhau/pkg/version"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
@@ -66,13 +64,7 @@ func newVersionCmd() *cobra.Command {
 }
 
 func runVersion(cmd *cobra.Command, oV *VersionOptions) error {
-	cm := system.NewCleanupManager()
-	defer cm.Cleanup()
 	ctx := cmd.Context()
-
-	ctx, rootSpan := system.NewRootSpan(ctx, system.GetTracer(), "cmd/bacalhau.version")
-	defer rootSpan.End()
-	cm.RegisterCallback(telemetry.Cleanup)
 
 	oV.Output = strings.TrimSpace(strings.ToLower(oV.Output))
 

--- a/pkg/devstack/devstack.go
+++ b/pkg/devstack/devstack.go
@@ -214,9 +214,7 @@ func NewDevStack(
 		if err != nil {
 			return nil, err
 		}
-		cm.RegisterCallback(func() error {
-			return libp2pHost.Close()
-		})
+		cm.RegisterCallback(libp2pHost.Close)
 
 		// add NodeID to logging context
 		ctx = logger.ContextWithNodeIDLogger(ctx, libp2pHost.ID().String())


### PR DESCRIPTION
Moving the creation & clean up of the SystemManager and root span avoids having the same code copied between all the commands. This also gives the opportunity to give the root spans a more coherent name rather than the code location.

This also fixes an issue with the wasm command which didn't apply the root commands PersistentPreRun.

Fixes #2023