### PR TITLE
Add support for passing a context when cleaning up

### DIFF
--- a/cmd/bacalhau/base_test.go
+++ b/cmd/bacalhau/base_test.go
@@ -52,6 +52,6 @@ func (s *BaseSuite) SetupTest() {
 func (s *BaseSuite) TearDownTest() {
 	Fatal = FatalErrorHandler
 	if s.node != nil {
-		s.node.CleanupManager.Cleanup()
+		s.node.CleanupManager.Cleanup(context.Background())
 	}
 }

--- a/cmd/bacalhau/root.go
+++ b/cmd/bacalhau/root.go
@@ -80,7 +80,7 @@ func NewRootCmd() *cobra.Command {
 		PersistentPostRun: func(cmd *cobra.Command, args []string) {
 			ctx := cmd.Context()
 			ctx.Value(spanKey).(trace.Span).End()
-			ctx.Value(systemManagerKey).(*system.CleanupManager).Cleanup()
+			ctx.Value(systemManagerKey).(*system.CleanupManager).Cleanup(cmd.Context())
 		},
 	}
 	// ====== Start a job
@@ -154,12 +154,12 @@ func Execute() {
 
 	err := viper.BindEnv("API_HOST")
 	if err != nil {
-		log.Fatal().Msgf("API_HOST was set, but could not bind.")
+		log.Ctx(RootCmd.Context()).Fatal().Msgf("API_HOST was set, but could not bind.")
 	}
 
 	err = viper.BindEnv("API_PORT")
 	if err != nil {
-		log.Fatal().Msgf("API_PORT was set, but could not bind.")
+		log.Ctx(RootCmd.Context()).Fatal().Msgf("API_PORT was set, but could not bind.")
 	}
 
 	viper.AutomaticEnv()
@@ -174,7 +174,7 @@ func Execute() {
 		var parseErr error
 		apiPort, parseErr = strconv.Atoi(envAPIPort.(string))
 		if parseErr != nil {
-			log.Fatal().Msgf("could not parse API_PORT into an int. %s", envAPIPort)
+			log.Ctx(RootCmd.Context()).Fatal().Msgf("could not parse API_PORT into an int. %s", envAPIPort)
 		}
 	}
 

--- a/cmd/bacalhau/serve.go
+++ b/cmd/bacalhau/serve.go
@@ -481,7 +481,7 @@ func ipfsClient(ctx context.Context, OS *ServeOptions, cm *system.CleanupManager
 		if err != nil {
 			return ipfs.Client{}, fmt.Errorf("error creating IPFS node: %s", err)
 		}
-		cm.RegisterCallback(ipfsNode.Close)
+		cm.RegisterCallbackWithContext(ipfsNode.Close)
 		client := ipfsNode.Client()
 
 		swarmAddresses, err := client.SwarmAddresses(ctx)

--- a/cmd/bacalhau/serve_test.go
+++ b/cmd/bacalhau/serve_test.go
@@ -44,7 +44,9 @@ func (s *ServeSuite) SetupTest() {
 	s.Require().NoError(system.InitConfigForTesting(s.T()))
 
 	cm := system.NewCleanupManager()
-	s.T().Cleanup(cm.Cleanup)
+	s.T().Cleanup(func() {
+		cm.Cleanup(context.Background())
+	})
 
 	node, err := ipfs.NewLocalNode(context.Background(), cm, []string{})
 	s.NoError(err)

--- a/dashboard/api/cmd/dashboard/serve.go
+++ b/dashboard/api/cmd/dashboard/serve.go
@@ -87,7 +87,7 @@ func serve(cmd *cobra.Command, options *ServeOptions) error {
 	// Cleanup manager ensures that resources are freed before exiting:
 	cm := system.NewCleanupManager()
 	cm.RegisterCallback(telemetry.Cleanup)
-	defer cm.Cleanup()
+	defer cm.Cleanup(cmd.Context())
 	ctx := cmd.Context()
 
 	if options.ServerOptions.JWTSecret == "" {
@@ -121,7 +121,7 @@ func serve(cmd *cobra.Command, options *ServeOptions) error {
 	if err != nil {
 		return err
 	}
-	cm.RegisterCallback(model.Stop)
+	cm.RegisterCallbackWithContext(model.Stop)
 
 	// Start transport layer
 	err = libp2p.ConnectToPeersContinuously(ctx, cm, libp2pHost, peers)

--- a/dashboard/api/pkg/model/api.go
+++ b/dashboard/api/pkg/model/api.go
@@ -169,9 +169,9 @@ func (api *ModelAPI) Start(ctx context.Context) error {
 	return nil
 }
 
-func (api *ModelAPI) Stop() error {
+func (api *ModelAPI) Stop(ctx context.Context) error {
 	if api.cleanupFunc != nil {
-		api.cleanupFunc(context.Background())
+		api.cleanupFunc(ctx)
 	}
 	return nil
 }

--- a/dashboard/api/pkg/server/utils.go
+++ b/dashboard/api/pkg/server/utils.go
@@ -34,21 +34,6 @@ func GetRequestBody[T any](w http.ResponseWriter, r *http.Request) (*T, error) {
 	return &requestBody, nil
 }
 
-func HTTPGet[T any](url string) (T, error) {
-	var data T
-	//nolint:gosec
-	resp, err := http.Get(url)
-	if err != nil {
-		return data, err
-	}
-	err = json.NewDecoder(resp.Body).Decode(&data)
-	if err != nil {
-		return data, err
-	}
-	resp.Body.Close()
-	return data, nil
-}
-
 func generateJWT(
 	secret string,
 	username string,

--- a/go.mod
+++ b/go.mod
@@ -94,7 +94,6 @@ require (
 	golang.org/x/crypto v0.5.0
 	golang.org/x/exp v0.0.0-20221106115401-f9659909a136
 	golang.org/x/mod v0.7.0
-	golang.org/x/net v0.7.0
 	k8s.io/apimachinery v0.26.1
 	k8s.io/kubectl v0.26.1
 	modernc.org/sqlite v1.20.2
@@ -333,6 +332,7 @@ require (
 	go.uber.org/dig v1.14.1 // indirect
 	go.uber.org/fx v1.17.1 // indirect
 	go4.org v0.0.0-20201209231011-d4a079459e60 // indirect
+	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/oauth2 v0.1.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.5.0 // indirect

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -55,17 +55,12 @@ type contextKey int
 
 const (
 	getVolumeSizeRequestTimeoutKey contextKey = iota
-	downloadCidRequestTimeoutKey
 )
 
 const (
 	// by default we wait 2 minutes for the IPFS network to resolve a CID
 	// tests will override this using config.SetVolumeSizeRequestTimeout(2)
-	getVolumeSizeRequestTimeout time.Duration = 2 * time.Minute
-
-	// by default we wait 5 minutes for the IPFS network to download a CID
-	// tests will override this using config.SetVolumeSizeRequestTimeout(2)
-	downloadCidRequestTimeout time.Duration = 5 * time.Minute
+	getVolumeSizeRequestTimeout = 2 * time.Minute
 )
 
 // how long do we wait for a volume size request to timeout
@@ -85,19 +80,6 @@ func GetVolumeSizeRequestTimeout(ctx context.Context) time.Duration {
 
 func SetVolumeSizeRequestTimeout(ctx context.Context, value time.Duration) context.Context {
 	return context.WithValue(ctx, getVolumeSizeRequestTimeoutKey, value)
-}
-
-// how long do we wait for a cid to download
-func GetDownloadCidRequestTimeout(ctx context.Context) time.Duration {
-	value := ctx.Value(downloadCidRequestTimeoutKey)
-	if value == nil {
-		value = downloadCidRequestTimeout
-	}
-	return value.(time.Duration)
-}
-
-func SetDownloadCidRequestTimeout(ctx context.Context, value time.Duration) context.Context {
-	return context.WithValue(ctx, downloadCidRequestTimeoutKey, value)
 }
 
 // by default we wait 5 minutes for a URL to download
@@ -135,7 +117,7 @@ func GetConfigPath() string {
 		// e.g. /home/francesca/.bacalhau
 		dirname, err := os.UserHomeDir()
 		if err != nil {
-			log.Fatal().Err(err)
+			log.Fatal().Err(err).Send()
 		}
 		d = filepath.Join(dirname, suffix)
 	} else {
@@ -144,7 +126,7 @@ func GetConfigPath() string {
 	}
 	// create dir if not exists
 	if err := os.MkdirAll(d, util.OS_USER_RWX); err != nil {
-		log.Fatal().Err(err)
+		log.Fatal().Err(err).Send()
 	}
 	return d
 }

--- a/pkg/devstack/devstack.go
+++ b/pkg/devstack/devstack.go
@@ -131,7 +131,7 @@ func NewDevStack(
 			return nil, err
 		}
 
-		cm.RegisterCallback(lotus.Close)
+		cm.RegisterCallbackWithContext(lotus.Close)
 
 		if err := lotus.start(ctx); err != nil { //nolint:govet
 			return nil, err
@@ -323,9 +323,9 @@ func NewDevStack(
 	}
 
 	// only start profiling after we've set everything up!
-	profiler := StartProfiling(options.CPUProfilingFile, options.MemoryProfilingFile)
+	profiler := StartProfiling(ctx, options.CPUProfilingFile, options.MemoryProfilingFile)
 	if profiler != nil {
-		cm.RegisterCallback(profiler.Close)
+		cm.RegisterCallbackWithContext(profiler.Close)
 	}
 
 	return &DevStack{

--- a/pkg/devstack/devstack_ipfs.go
+++ b/pkg/devstack/devstack_ipfs.go
@@ -47,20 +47,3 @@ func NewDevStackIPFS(ctx context.Context, cm *system.CleanupManager, count int) 
 
 	return stack, nil
 }
-
-func (stack *DevStackIPFS) PrintNodeInfo() {
-	logString := `
--------------------------------
-ipfs
--------------------------------
-
-command="add -q testdata/grep_file.txt"
-	`
-	for _, node := range stack.IPFSClients {
-		logString += fmt.Sprintf(`
-cid=$(ipfs --api %s ipfs $command)
-curl -XPOST %s`, node.APIAddress(), node.APIAddress())
-	}
-
-	log.Trace().Msg(logString + "\n")
-}

--- a/pkg/devstack/lotus.go
+++ b/pkg/devstack/lotus.go
@@ -2,6 +2,7 @@ package devstack
 
 import (
 	"archive/tar"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -18,7 +19,6 @@ import (
 	"github.com/filecoin-project/bacalhau/pkg/util/closer"
 	"github.com/hashicorp/go-multierror"
 	"github.com/rs/zerolog/log"
-	"golang.org/x/net/context"
 )
 
 const defaultImage = "ghcr.io/bacalhau-project/lotus-filecoin-image:v0.0.2"
@@ -111,7 +111,7 @@ func (l *LotusNode) start(ctx context.Context) error {
 	}
 
 	if err := l.waitForLotusToBeHealthy(ctx); err != nil {
-		if err := l.Close(); err != nil { //nolint:govet
+		if err := l.Close(ctx); err != nil { //nolint:govet
 			log.Ctx(ctx).Err(err).Msgf(`Problem occurred when giving up waiting for Lotus to become healthy`)
 		}
 		return err
@@ -196,12 +196,12 @@ ListenAddress = "/ip4/0.0.0.0/tcp/%s/http"
 	return nil
 }
 
-func (l *LotusNode) Close() error {
+func (l *LotusNode) Close(ctx context.Context) error {
 	var errs error
 
 	defer closer.CloseWithLogOnError("Docker client", l.client)
 	if l.container != "" {
-		if err := l.client.RemoveContainer(context.Background(), l.container); err != nil {
+		if err := l.client.RemoveContainer(ctx, l.container); err != nil {
 			errs = multierror.Append(errs, err)
 		}
 	}

--- a/pkg/downloader/download_test.go
+++ b/pkg/downloader/download_test.go
@@ -41,7 +41,9 @@ func (ds *DownloaderSuite) SetupSuite() {
 // Before each test
 func (ds *DownloaderSuite) SetupTest() {
 	ds.cm = system.NewCleanupManager()
-	ds.T().Cleanup(ds.cm.Cleanup)
+	ds.T().Cleanup(func() {
+		ds.cm.Cleanup(context.Background())
+	})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	ds.T().Cleanup(cancel)

--- a/pkg/downloader/ipfs/downloader.go
+++ b/pkg/downloader/ipfs/downloader.go
@@ -40,7 +40,7 @@ func (ipfsDownloader *Downloader) FetchResult(ctx context.Context, result model.
 		return err
 	}
 	defer func() {
-		if closeErr := n.Close(); closeErr != nil {
+		if closeErr := n.Close(ctx); closeErr != nil {
 			log.Ctx(ctx).Error().Err(closeErr).Msg("Failed to close IPFS node")
 		}
 	}()

--- a/pkg/executor/docker/executor_test.go
+++ b/pkg/executor/docker/executor_test.go
@@ -39,7 +39,9 @@ func (s *ExecutorTestSuite) SetupTest() {
 
 	var err error
 	s.cm = system.NewCleanupManager()
-	s.T().Cleanup(s.cm.Cleanup)
+	s.T().Cleanup(func() {
+		s.cm.Cleanup(context.Background())
+	})
 
 	s.executor, err = NewExecutor(
 		context.Background(),

--- a/pkg/ipfs/node.go
+++ b/pkg/ipfs/node.go
@@ -216,9 +216,7 @@ func newNodeWithConfig(ctx context.Context, cm *system.CleanupManager, cfg Confi
 		SwarmPort: swarmPort,
 	}
 
-	cm.RegisterCallback(func() error {
-		return n.Close()
-	})
+	cm.RegisterCallbackWithContext(n.Close)
 
 	// Log details so that user can connect to the new node:
 	log.Ctx(ctx).Trace().Msgf("IPFS node created with ID: %s", ipfsNode.Identity)
@@ -290,8 +288,8 @@ func (n *Node) Client() Client {
 	return NewClient(n.api)
 }
 
-func (n *Node) Close() error {
-	log.Debug().Msgf("Closing IPFS node %s", n.ID())
+func (n *Node) Close(ctx context.Context) error {
+	log.Ctx(ctx).Debug().Msgf("Closing IPFS node %s", n.ID())
 	var errs *multierror.Error
 	if n.ipfsNode != nil {
 		errs = multierror.Append(errs, n.ipfsNode.Close())
@@ -537,9 +535,7 @@ func loadPlugins(cm *system.CleanupManager) error {
 
 	// Set the global cache so we can use it in the ipfs daemon:
 	pluginLoader = plugins
-	cm.RegisterCallback(func() error {
-		return plugins.Close()
-	})
+	cm.RegisterCallback(plugins.Close)
 	return nil
 }
 

--- a/pkg/ipfs/node_test.go
+++ b/pkg/ipfs/node_test.go
@@ -35,7 +35,9 @@ func (s *NodeSuite) TestFunctionality() {
 	defer cancel()
 
 	cm := system.NewCleanupManager()
-	s.T().Cleanup(cm.Cleanup)
+	s.T().Cleanup(func() {
+		cm.Cleanup(context.Background())
+	})
 
 	n1, err := NewLocalNode(ctx, cm, nil)
 	s.Require().NoError(err)

--- a/pkg/model/v1alpha1/utils.go
+++ b/pkg/model/v1alpha1/utils.go
@@ -5,10 +5,8 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
-	"unsafe"
 
 	"github.com/c2h5oh/datasize"
-	"github.com/rs/zerolog/log"
 	"sigs.k8s.io/yaml"
 )
 
@@ -29,33 +27,6 @@ func equal(a, b string) bool {
 	a = strings.TrimSpace(a)
 	b = strings.TrimSpace(b)
 	return strings.EqualFold(a, b)
-}
-
-func PrintContextInternals(ctx interface{}, inner bool) {
-	contextValues := reflect.ValueOf(ctx).Elem()
-	contextKeys := reflect.TypeOf(ctx).Elem()
-
-	if !inner {
-		log.Debug().Msgf("\nFields for %s.%s\n", contextKeys.PkgPath(), contextKeys.Name())
-	}
-
-	if contextKeys.Kind() == reflect.Struct {
-		for i := 0; i < contextValues.NumField(); i++ {
-			reflectValue := contextValues.Field(i)
-			reflectValue = reflect.NewAt(reflectValue.Type(), unsafe.Pointer(reflectValue.UnsafeAddr())).Elem()
-
-			reflectField := contextKeys.Field(i)
-
-			if reflectField.Name == "Context" {
-				PrintContextInternals(reflectValue.Interface(), true)
-			} else {
-				log.Debug().Msgf("field name: %+v\n", reflectField.Name)
-				log.Debug().Msgf("value: %+v\n", reflectValue.Interface())
-			}
-		}
-	} else {
-		log.Debug().Msgf("context is empty (int)\n")
-	}
 }
 
 const (

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -255,16 +255,15 @@ func NewNode(
 	}
 
 	// cleanup libp2p resources in the desired order
-	config.CleanupManager.RegisterCallback(func() error {
-		cleanupCtx := context.Background()
+	config.CleanupManager.RegisterCallbackWithContext(func(ctx context.Context) error {
 		if computeNode != nil {
-			computeNode.cleanup(cleanupCtx)
+			computeNode.cleanup(ctx)
 		}
 		if requesterNode != nil {
-			requesterNode.cleanup(cleanupCtx)
+			requesterNode.cleanup(ctx)
 		}
-		nodeInfoPublisher.Stop()
-		cleanupErr := nodeInfoPubSub.Close(cleanupCtx)
+		nodeInfoPublisher.Stop(ctx)
+		cleanupErr := nodeInfoPubSub.Close(ctx)
 		if cleanupErr != nil {
 			log.Ctx(ctx).Error().Err(cleanupErr).Msg("failed to close libp2p node info pubsub")
 		}

--- a/pkg/publicapi/server.go
+++ b/pkg/publicapi/server.go
@@ -176,11 +176,7 @@ func (apiServer *APIServer) ListenAndServe(ctx context.Context, cm *system.Clean
 		"API server listening for host %s on %s...", apiServer.Address, listener.Addr().String())
 
 	// Cleanup resources when system is done:
-	cm.RegisterCallback(func() error {
-		// We have to use a separate context, rather than the one passed in, as it may have already been
-		// canceled and so would prevent us from performing any cleanup work.
-		return srv.Shutdown(context.Background())
-	})
+	cm.RegisterCallbackWithContext(srv.Shutdown)
 
 	err = srv.Serve(listener)
 	if err == http.ErrServerClosed {

--- a/pkg/publicapi/server_test.go
+++ b/pkg/publicapi/server_test.go
@@ -4,7 +4,7 @@ package publicapi
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -42,7 +42,7 @@ func (s *ServerSuite) SetupTest() {
 
 // After each test
 func (s *ServerSuite) TearDownTest() {
-	s.cleanupManager.Cleanup()
+	s.cleanupManager.Cleanup(context.Background())
 }
 
 func (s *ServerSuite) TestHealthz() {
@@ -95,7 +95,7 @@ func (s *ServerSuite) TestTimeout() {
 	require.Equal(s.T(), http.StatusServiceUnavailable, res.StatusCode)
 
 	// validate response body
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	require.NoError(s.T(), err, "Could not read %s response body", endpoint)
 	require.Equal(s.T(), body, []byte("Server Timeout!"))
 
@@ -154,7 +154,7 @@ func (s *ServerSuite) testEndpoint(t *testing.T, endpoint string, contentToCheck
 	defer res.Body.Close()
 
 	require.Equal(t, res.StatusCode, http.StatusOK)
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	require.NoError(t, err, "Could not read %s response body", endpoint)
 	require.Contains(t, string(body), contentToCheck, "%s body does not contain '%s'.", endpoint, contentToCheck)
 	return body

--- a/pkg/routing/node_info_publisher.go
+++ b/pkg/routing/node_info_publisher.go
@@ -67,9 +67,9 @@ func (n *NodeInfoPublisher) publishBackgroundTask() {
 }
 
 // Stop stops the background task that publishes the node info periodically
-func (n *NodeInfoPublisher) Stop() {
+func (n *NodeInfoPublisher) Stop(ctx context.Context) {
 	n.stopOnce.Do(func() {
 		n.stopChannel <- struct{}{}
 	})
-	log.Info().Msg("done stopping compute node info publisher")
+	log.Ctx(ctx).Info().Msg("done stopping compute node info publisher")
 }

--- a/pkg/storage/copy/copy_test.go
+++ b/pkg/storage/copy/copy_test.go
@@ -84,7 +84,9 @@ func TestCopyOversize(t *testing.T) {
 	for _, testCase := range copyOversizeTestCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			cm := system.NewCleanupManager()
-			t.Cleanup(cm.Cleanup)
+			t.Cleanup(func() {
+				cm.Cleanup(context.Background())
+			})
 
 			originals := preserveSlice(testCase.specs)
 

--- a/pkg/storage/ipfs/storage_test.go
+++ b/pkg/storage/ipfs/storage_test.go
@@ -21,7 +21,9 @@ const IpfsMetadataSize uint64 = 8
 func getIpfsStorage(t *testing.T) *StorageProvider {
 	ctx := context.Background()
 	cm := system.NewCleanupManager()
-	t.Cleanup(cm.Cleanup)
+	t.Cleanup(func() {
+		cm.Cleanup(context.Background())
+	})
 
 	node, err := ipfs.NewLocalNode(ctx, cm, []string{})
 	require.NoError(t, err)

--- a/pkg/system/cleanup.go
+++ b/pkg/system/cleanup.go
@@ -3,12 +3,11 @@ package system
 import (
 	"context"
 	"errors"
+	realsync "sync"
 	"time"
 
-	realsync "sync"
-
 	sync "github.com/bacalhau-project/golang-mutex-tracer"
-
+	"github.com/filecoin-project/bacalhau/pkg/telemetry"
 	"github.com/rs/zerolog/log"
 )
 
@@ -16,10 +15,8 @@ import (
 // clean up their resources before the main goroutine exits. Can be used to
 // register callbacks for long-running system processes.
 type CleanupManager struct {
-	wg realsync.WaitGroup
-
 	fnsMutex sync.Mutex
-	fns      []func() error
+	fns      []any
 	fnsDone  bool
 }
 
@@ -34,7 +31,16 @@ func NewCleanupManager() *CleanupManager {
 }
 
 // RegisterCallback registers a clean-up function.
-func (cm *CleanupManager) RegisterCallback(fn func() error) {
+func (cm *CleanupManager) RegisterCallback(fn cleanUpWithoutContext) {
+	cm.registerCallback(fn)
+}
+
+// RegisterCallbackWithContext registers a clean-up function. The context passed is guaranteed not to be already canceled.
+func (cm *CleanupManager) RegisterCallbackWithContext(fn cleanUpWithContext) {
+	cm.registerCallback(fn)
+}
+
+func (cm *CleanupManager) registerCallback(fn any) {
 	cm.fnsMutex.Lock()
 	defer cm.fnsMutex.Unlock()
 
@@ -43,33 +49,48 @@ func (cm *CleanupManager) RegisterCallback(fn func() error) {
 		return
 	}
 
-	cm.wg.Add(1)
 	cm.fns = append(cm.fns, fn)
 }
 
 // Cleanup runs all registered clean-up functions in sub-goroutines and
 // waits for them all to complete before exiting.
-func (cm *CleanupManager) Cleanup() {
+func (cm *CleanupManager) Cleanup(ctx context.Context) {
 	cm.fnsMutex.Lock()
 	defer cm.fnsMutex.Unlock()
 
 	if cm.fnsDone {
-		log.Warn().Msg("CleanupManager: Cleanup called again after already called")
+		log.Ctx(ctx).Warn().Msg("CleanupManager: Cleanup called again after already called")
 		return
 	}
 
-	for i := 0; i < len(cm.fns); i++ {
-		go func(fn func() error) {
-			defer cm.wg.Done()
+	var wg realsync.WaitGroup
+	wg.Add(len(cm.fns))
 
-			if err := fn(); err != nil {
+	detachedContext := telemetry.NewDetachedContext(ctx)
+
+	for i := 0; i < len(cm.fns); i++ {
+		go func(fn any) {
+			defer wg.Done()
+
+			var err error
+			switch f := fn.(type) {
+			case cleanUpWithContext:
+				err = f(detachedContext)
+			case cleanUpWithoutContext:
+				err = f()
+			}
+
+			if err != nil {
 				if !errors.Is(err, context.Canceled) {
-					log.Error().Err(err).Msg("Error during clean-up callback")
+					log.Ctx(detachedContext).Error().Err(err).Msg("Error during clean-up callback")
 				}
 			}
 		}(cm.fns[i])
 	}
 
-	cm.wg.Wait()
+	wg.Wait()
 	cm.fnsDone = true
 }
+
+type cleanUpWithoutContext func() error
+type cleanUpWithContext func(context.Context) error

--- a/pkg/telemetry/common.go
+++ b/pkg/telemetry/common.go
@@ -15,12 +15,6 @@ func SetupFromEnvs() {
 	newMeterProvider()
 
 	otel.SetErrorHandler(otel.ErrorHandlerFunc(func(err error) {
-		// Block this common message from spamming the logs. It seems to be coming from
-		// go.opentelemetry.io/otel/exporters/otlp/internal PartialSuccess
-		// Should be fixed by https://github.com/open-telemetry/opentelemetry-go/issues/3432 (v1.12+)
-		if err.Error() == "OTLP partial success: empty message (0 spans rejected)" {
-			return
-		}
 		log.Err(err).Msg("Error occurred while handling spans")
 	}))
 }

--- a/pkg/telemetry/metrics.go
+++ b/pkg/telemetry/metrics.go
@@ -16,13 +16,14 @@ import (
 var meterProvider *sdkmetric.MeterProvider
 
 func newMeterProvider() {
+	// The context passed in to the exporter is only passed to the client and used when connecting to the endpoint
+	ctx := context.Background()
+
 	if !isMetricsEnabled() {
-		log.Debug().Msgf("OLTP metrics endpoints are not defined. No metrics will be exported")
+		log.Ctx(ctx).Debug().Msgf("OLTP metrics endpoints are not defined. No metrics will be exported")
 		return
 	}
 
-	// The context passed in to the exporter is only passed to the client and used when connecting to the endpoint
-	ctx := context.Background()
 	exp, err := getMetricsClient(ctx)
 	if err != nil {
 		log.Ctx(ctx).Error().Err(err).Msg("failed to initialize OLTP metric exporter")

--- a/pkg/telemetry/tracing.go
+++ b/pkg/telemetry/tracing.go
@@ -19,13 +19,14 @@ import (
 // Tracer Setup and Teardown
 // ----------------------------------------
 func newTraceProvider() {
+	// The context passed in to the exporter is only passed to the client and used when connecting to the endpoint
+	ctx := context.Background()
+
 	if !isTracingEnabled() {
-		log.Debug().Msgf("OLTP tracing endpoints are not defined. No traces will be exported")
+		log.Ctx(ctx).Debug().Msgf("OLTP tracing endpoints are not defined. No traces will be exported")
 		return
 	}
 
-	// The context passed in to the exporter is only passed to the client and used when connecting to the endpoint
-	ctx := context.Background()
 	client, err := getTraceClient()
 	if err != nil {
 		log.Ctx(ctx).Error().Err(err).Msg("failed to initialize OLTP trace client")

--- a/pkg/test/devstack/utils.go
+++ b/pkg/test/devstack/utils.go
@@ -21,36 +21,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func SetupTest(
-	ctx context.Context,
-	t *testing.T,
-	nodes int, badActors int,
-	lotusNode bool,
-	//nolint:gocritic
-	computeConfig node.ComputeConfig,
-	requesterConfig node.RequesterConfig,
-) (*devstack.DevStack, *system.CleanupManager) {
-	require.NoError(t, system.InitConfigForTesting(t))
-
-	cm := system.NewCleanupManager()
-
-	options := devstack.DevStackOptions{
-		NumberOfHybridNodes:      nodes,
-		NumberOfBadComputeActors: badActors,
-		LocalNetworkLotus:        lotusNode,
-	}
-
-	stack, err := devstack.NewStandardDevStack(ctx, cm, options, computeConfig, requesterConfig)
-	require.NoError(t, err)
-
-	t.Cleanup(cm.Cleanup)
-
-	// important to give the pubsub network time to connect
-	time.Sleep(time.Second)
-
-	return stack, cm
-}
-
 func prepareFolderWithFiles(t *testing.T, fileCount int) string { //nolint:unused
 	basePath := t.TempDir()
 	for i := 0; i < fileCount; i++ {
@@ -83,7 +53,7 @@ func RunDeterministicVerifierTest( //nolint:funlen
 	args DeterministicVerifierTestArgs,
 ) {
 	cm := system.NewCleanupManager()
-	defer cm.Cleanup()
+	defer cm.Cleanup(ctx)
 
 	options := devstack.DevStackOptions{
 		NumberOfHybridNodes:      args.NodeCount,

--- a/pkg/test/ipfs/ipfs_host_storage_test.go
+++ b/pkg/test/ipfs/ipfs_host_storage_test.go
@@ -70,7 +70,7 @@ func runFileTest(t *testing.T, engine model.StorageSourceType, getStorageDriver 
 	ctx := context.Background()
 	// get a single IPFS server
 	stack, cm := SetupTest(ctx, t, 1)
-	defer TeardownTest(stack, cm)
+	defer TeardownTest(cm)
 
 	// add this file to the server
 	EXAMPLE_TEXT := `hello world`
@@ -110,7 +110,7 @@ func runFolderTest(t *testing.T, engine model.StorageSourceType, getStorageDrive
 	ctx := context.Background()
 	// get a single IPFS server
 	stack, cm := SetupTest(ctx, t, 1)
-	defer TeardownTest(stack, cm)
+	defer TeardownTest(cm)
 
 	dir := t.TempDir()
 

--- a/pkg/test/ipfs/utils.go
+++ b/pkg/test/ipfs/utils.go
@@ -1,12 +1,12 @@
 package ipfs
 
 import (
+	"context"
 	"testing"
 
 	"github.com/filecoin-project/bacalhau/pkg/devstack"
 	"github.com/filecoin-project/bacalhau/pkg/system"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 )
 
 func SetupTest(ctx context.Context, t *testing.T, nodes int) (*devstack.DevStackIPFS, *system.CleanupManager) {
@@ -16,7 +16,6 @@ func SetupTest(ctx context.Context, t *testing.T, nodes int) (*devstack.DevStack
 	return stack, cm
 }
 
-func TeardownTest(stack *devstack.DevStackIPFS, cm *system.CleanupManager) {
-	stack.PrintNodeInfo()
-	cm.Cleanup()
+func TeardownTest(cm *system.CleanupManager) {
+	cm.Cleanup(context.Background())
 }

--- a/pkg/test/requester/node_selection_test.go
+++ b/pkg/test/requester/node_selection_test.go
@@ -88,10 +88,10 @@ func (s *NodeSelectionSuite) SetupSuite() {
 
 func (s *NodeSelectionSuite) TearDownSuite() {
 	if s.requester != nil {
-		s.requester.CleanupManager.Cleanup()
+		s.requester.CleanupManager.Cleanup(context.Background())
 	}
 	for _, n := range s.computeNodes {
-		n.CleanupManager.Cleanup()
+		n.CleanupManager.Cleanup(context.Background())
 	}
 }
 

--- a/pkg/test/requester/publicapi/client_test.go
+++ b/pkg/test/requester/publicapi/client_test.go
@@ -15,7 +15,7 @@ import (
 func TestGet(t *testing.T) {
 	logger.ConfigureTestLogging(t)
 	n, c := setupNodeForTest(t)
-	defer n.CleanupManager.Cleanup()
+	defer n.CleanupManager.Cleanup(context.Background())
 
 	ctx := context.Background()
 

--- a/pkg/test/requester/publicapi/server_test.go
+++ b/pkg/test/requester/publicapi/server_test.go
@@ -41,7 +41,7 @@ func (s *ServerSuite) SetupTest() {
 
 // After each test
 func (s *ServerSuite) TearDownTest() {
-	s.node.CleanupManager.Cleanup()
+	s.node.CleanupManager.Cleanup(context.Background())
 }
 
 func (s *ServerSuite) TestList() {

--- a/pkg/test/requester/publicapi/websocket_test.go
+++ b/pkg/test/requester/publicapi/websocket_test.go
@@ -42,7 +42,7 @@ func (s *WebsocketSuite) SetupTest() {
 
 // After each test
 func (s *WebsocketSuite) TearDownTest() {
-	s.node.CleanupManager.Cleanup()
+	s.node.CleanupManager.Cleanup(context.Background())
 }
 
 func (s *WebsocketSuite) TestWebsocketEverything() {

--- a/pkg/test/scenario/storage.go
+++ b/pkg/test/scenario/storage.go
@@ -38,7 +38,7 @@ func StoredText(
 				Path:          mountPath,
 			},
 		}
-		log.Debug().Msgf("Added file with cid %s", fileCid)
+		log.Ctx(ctx).Debug().Msgf("Added file with cid %s", fileCid)
 		return inputStorageSpecs, nil
 	}
 }

--- a/pkg/test/utils/stack.go
+++ b/pkg/test/utils/stack.go
@@ -25,7 +25,9 @@ func SetupTest(
 	nodeOverrides ...node.NodeConfig,
 ) (*devstack.DevStack, *system.CleanupManager) {
 	cm := system.NewCleanupManager()
-	t.Cleanup(cm.Cleanup)
+	t.Cleanup(func() {
+		cm.Cleanup(ctx)
+	})
 
 	options := devstack.DevStackOptions{
 		NumberOfHybridNodes:      nodes,
@@ -88,7 +90,9 @@ func SetupTestWithNoopExecutor(
 	}
 
 	cm := system.NewCleanupManager()
-	t.Cleanup(cm.Cleanup)
+	t.Cleanup(func() {
+		cm.Cleanup(ctx)
+	})
 
 	stack, err := devstack.NewDevStack(ctx, cm, options, computeConfig, requesterConfig, injector, nodeOverrides...)
 	require.NoError(t, err)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -24,21 +24,14 @@ var (
 	//
 	// A good article on how to use buildflags is
 	// https://www.digitalocean.com/community/tutorials/using-ldflags-to-set-version-information-for-go-applications.
-	GITVERSION   = "v0.0.0-xxxxxxx"
-	tracerPrefix = "bacalhau-"
+	GITVERSION = "v0.0.0-xxxxxxx"
 )
-
-// TracerName is the Tracer name used to identify this instrumentation library.
-func TracerName() string {
-	return fmt.Sprintf(tracerPrefix + GITVERSION)
-}
 
 // Get returns the overall codebase version. It's for detecting what code a binary was built from.
 func Get() *model.BuildVersionInfo {
 	revision, revisionTime, err := getBuildInformation()
 	if err != nil {
 		log.Fatal().Err(err).Msg("Could not build client information")
-		return nil
 	}
 
 	s, err := semver.NewVersion(GITVERSION)


### PR DESCRIPTION
This adds a second type of clean up function - one that takes a `context.Context`. This makes it easier to avoid problems of using a cancelled context when cleaning up, as the logic doesn't need to be spread about, and makes it easy to migrate a portion of log statements that aren't using `log.Ctx` to do so.

Part of #2001