### PR TITLE
Use context for more logging statements

### DIFF
--- a/cmd/bacalhau/create.go
+++ b/cmd/bacalhau/create.go
@@ -83,7 +83,7 @@ func newCreateCmd() *cobra.Command {
 func create(cmd *cobra.Command, cmdArgs []string, OC *CreateOptions) error { //nolint:funlen,gocyclo
 	ctx := cmd.Context()
 
-	cm := cmd.Context().Value(systemManagerKey).(*system.CleanupManager)
+	cm := ctx.Value(systemManagerKey).(*system.CleanupManager)
 
 	// Custom unmarshaller
 	// https://stackoverflow.com/questions/70635636/unmarshaling-yaml-into-different-struct-based-off-yaml-field?rq=1

--- a/cmd/bacalhau/devstack.go
+++ b/cmd/bacalhau/devstack.go
@@ -3,7 +3,6 @@ package bacalhau
 import (
 	"fmt"
 	"os"
-	"os/signal"
 	"path/filepath"
 	"strconv"
 
@@ -148,10 +147,6 @@ func runDevstack(cmd *cobra.Command, ODs *devstack.DevStackOptions, OS *ServeOpt
 		Fatal(cmd, fmt.Sprintf("You cannot have more bad requester actors (%d) than there are nodes (%d).",
 			ODs.NumberOfBadRequesterActors, totalRequesterNodes), 1)
 	}
-
-	// Context ensures main goroutine waits until killed with ctrl+c:
-	ctx, cancel := signal.NotifyContext(ctx, ShutdownSignals...)
-	defer cancel()
 
 	portFileName := filepath.Join(os.TempDir(), "bacalhau-devstack.port")
 	pidFileName := filepath.Join(os.TempDir(), "bacalhau-devstack.pid")

--- a/cmd/bacalhau/docker_run.go
+++ b/cmd/bacalhau/docker_run.go
@@ -1,6 +1,7 @@
 package bacalhau
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -272,9 +273,9 @@ func newDockerRunCmd() *cobra.Command { //nolint:funlen
 func dockerRun(cmd *cobra.Command, cmdArgs []string, ODR *DockerRunOptions) error {
 	ctx := cmd.Context()
 
-	cm := cmd.Context().Value(systemManagerKey).(*system.CleanupManager)
+	cm := ctx.Value(systemManagerKey).(*system.CleanupManager)
 
-	j, err := CreateJob(cmdArgs, ODR)
+	j, err := CreateJob(ctx, cmdArgs, ODR)
 	if err != nil {
 		Fatal(cmd, fmt.Sprintf("Error creating job: %s", err), 1)
 		return nil
@@ -320,7 +321,7 @@ func dockerRun(cmd *cobra.Command, cmdArgs []string, ODR *DockerRunOptions) erro
 }
 
 // CreateJob creates a job object from the given command line arguments and options.
-func CreateJob(cmdArgs []string, odr *DockerRunOptions) (*model.Job, error) {
+func CreateJob(ctx context.Context, cmdArgs []string, odr *DockerRunOptions) (*model.Job, error) {
 	odr.Image = cmdArgs[0]
 	odr.Entrypoint = cmdArgs[1:]
 
@@ -370,6 +371,7 @@ func CreateJob(cmdArgs []string, odr *DockerRunOptions) (*model.Job, error) {
 	}
 
 	j, err := jobutils.ConstructDockerJob(
+		ctx,
 		model.APIVersionLatest(),
 		engineType,
 		verifierType,

--- a/cmd/bacalhau/run_python.go
+++ b/cmd/bacalhau/run_python.go
@@ -78,7 +78,7 @@ func NewLanguageRunOptions() *LanguageRunOptions {
 // TODO: move the adapter code (from wasm to docker) into a wasm executor, so
 // that the compute node can verify the job knowing that it was run properly,
 // rather than doing the translation in, and thereby trusting, the client (to
-// set up the wasm environment to be determinstic)
+// set up the wasm environment to be deterministic)
 
 func newRunPythonCmd() *cobra.Command {
 	OLR := NewLanguageRunOptions()
@@ -165,7 +165,7 @@ func newRunPythonCmd() *cobra.Command {
 func runPython(cmd *cobra.Command, cmdArgs []string, OLR *LanguageRunOptions) error {
 	ctx := cmd.Context()
 
-	cm := cmd.Context().Value(systemManagerKey).(*system.CleanupManager)
+	cm := ctx.Value(systemManagerKey).(*system.CleanupManager)
 
 	// error if determinism is false
 	if !OLR.Deterministic {
@@ -193,10 +193,10 @@ func runPython(cmd *cobra.Command, cmdArgs []string, OLR *LanguageRunOptions) er
 	// have ConstructLanguageJob and ConstructDockerJob as separate means
 	// manually keeping them in sync.
 	j, err := job.ConstructLanguageJob(
+		ctx,
 		OLR.InputVolumes,
 		OLR.InputUrls,
 		OLR.OutputVolumes,
-		[]string{}, // no env vars (yet)
 		OLR.Concurrency,
 		OLR.Confidence,
 		OLR.MinBids,
@@ -206,7 +206,6 @@ func runPython(cmd *cobra.Command, cmdArgs []string, OLR *LanguageRunOptions) er
 		OLR.Command,
 		programPath,
 		OLR.RequirementsPath,
-		OLR.ContextPath,
 		OLR.Deterministic,
 		OLR.Labels,
 		doNotTrack,

--- a/cmd/bacalhau/serve.go
+++ b/cmd/bacalhau/serve.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/signal"
 	"sort"
 	"strings"
 	"time"
@@ -302,12 +301,8 @@ func newServeCmd() *cobra.Command {
 
 //nolint:funlen,gocyclo
 func serve(cmd *cobra.Command, OS *ServeOptions) error {
-	cm := cmd.Context().Value(systemManagerKey).(*system.CleanupManager)
-
-	// TODO this should be for all commands
-	// Context ensures main goroutine waits until killed with ctrl+c:
-	ctx, cancel := signal.NotifyContext(cmd.Context(), ShutdownSignals...)
-	defer cancel()
+	ctx := cmd.Context()
+	cm := ctx.Value(systemManagerKey).(*system.CleanupManager)
 
 	isComputeNode, isRequesterNode := false, false
 	for _, nodeType := range OS.NodeType {

--- a/cmd/bacalhau/version.go
+++ b/cmd/bacalhau/version.go
@@ -105,7 +105,7 @@ func (oV *VersionOptions) Run(ctx context.Context, cmd *cobra.Command) error {
 	if !oV.ClientOnly {
 		serverVersion, err := GetAPIClient().Version(ctx)
 		if err != nil {
-			log.Ctx(cmd.Context()).Error().Err(err).Msgf("could not get server version")
+			log.Ctx(ctx).Error().Err(err).Msgf("could not get server version")
 			return err
 		}
 

--- a/cmd/bacalhau/wasm_run.go
+++ b/cmd/bacalhau/wasm_run.go
@@ -191,7 +191,7 @@ func runWasm(
 		time.Sleep(1 * time.Second)
 
 		storage := inline.NewStorage()
-		inlineData, err := storage.Upload(cmd.Context(), info.Name())
+		inlineData, err := storage.Upload(ctx, info.Name())
 		if err != nil {
 			return err
 		}

--- a/pkg/devstack/profiler.go
+++ b/pkg/devstack/profiler.go
@@ -41,7 +41,7 @@ func StartProfiling(ctx context.Context, cpuFile, memoryFile string) CloserWithC
 
 func (p *profiler) Close(ctx context.Context) error {
 	// stop profiling now, just before we clean up, if we're profiling.
-	log.Trace().Msg("============= STOPPING PROFILING ============")
+	log.Ctx(ctx).Trace().Msg("============= STOPPING PROFILING ============")
 	if p.cpuFile != nil {
 		pprof.StopCPUProfile()
 		closer.CloseWithLogOnError(p.cpuFile.Name(), p.cpuFile)

--- a/pkg/job/factory.go
+++ b/pkg/job/factory.go
@@ -1,6 +1,7 @@
 package job
 
 import (
+	"context"
 	"strings"
 
 	"github.com/filecoin-project/bacalhau/pkg/model"
@@ -12,6 +13,7 @@ import (
 // to pass in the collection of CLI args as strings
 // and have a Job struct returned
 func ConstructDockerJob( //nolint:funlen
+	ctx context.Context,
 	a model.APIVersion,
 	e model.Engine,
 	v model.Verifier,
@@ -48,7 +50,7 @@ func ConstructDockerJob( //nolint:funlen
 	if err != nil {
 		return &model.Job{}, err
 	}
-	jobOutputs, err := buildJobOutputs(outputVolumes)
+	jobOutputs, err := buildJobOutputs(ctx, outputVolumes)
 	if err != nil {
 		return &model.Job{}, err
 	}
@@ -64,7 +66,7 @@ func ConstructDockerJob( //nolint:funlen
 	}
 
 	if len(unSafeAnnotations) > 0 {
-		log.Error().Msgf("The following labels are unsafe. Labels must fit the regex '/%s/' (and all emjois): %+v",
+		log.Ctx(ctx).Error().Msgf("The following labels are unsafe. Labels must fit the regex '/%s/' (and all emjois): %+v",
 			RegexString,
 			strings.Join(unSafeAnnotations, ", "))
 	}
@@ -77,7 +79,6 @@ func ConstructDockerJob( //nolint:funlen
 	if len(workingDir) > 0 {
 		err = system.ValidateWorkingDir(workingDir)
 		if err != nil {
-			log.Error().Msg(err.Error())
 			return &model.Job{}, err
 		}
 	}
@@ -136,10 +137,10 @@ func ConstructDockerJob( //nolint:funlen
 }
 
 func ConstructLanguageJob(
+	ctx context.Context,
 	inputVolumes []string,
 	inputUrls []string,
 	outputVolumes []string,
-	env []string,
 	concurrency int,
 	confidence int,
 	minBids int,
@@ -150,7 +151,6 @@ func ConstructLanguageJob(
 	command string,
 	programPath string,
 	requirementsPath string,
-	contextPath string, // we have to tar this up and POST it to the Requester node
 	deterministic bool,
 	annotations []string,
 	doNotTrack bool,
@@ -162,7 +162,7 @@ func ConstructLanguageJob(
 	if err != nil {
 		return &model.Job{}, err
 	}
-	jobOutputs, err := buildJobOutputs(outputVolumes)
+	jobOutputs, err := buildJobOutputs(ctx, outputVolumes)
 	if err != nil {
 		return &model.Job{}, err
 	}
@@ -178,7 +178,7 @@ func ConstructLanguageJob(
 	}
 
 	if len(unSafeAnnotations) > 0 {
-		log.Error().Msgf("The following labels are unsafe. Labels must fit the regex '/%s/' (and all emjois): %+v",
+		log.Ctx(ctx).Error().Msgf("The following labels are unsafe. Labels must fit the regex '/%s/' (and all emjois): %+v",
 			RegexString,
 			strings.Join(unSafeAnnotations, ", "))
 	}

--- a/pkg/job/factory_test.go
+++ b/pkg/job/factory_test.go
@@ -3,6 +3,7 @@
 package job
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -68,6 +69,7 @@ func (suite *JobFactorySuite) TestRun_DockerJobOutputs() {
 				}
 
 				j, err := ConstructDockerJob( //nolint:funlen
+					context.Background(),
 					model.APIVersionLatest(),
 					model.EngineNoop,
 					model.VerifierNoop,


### PR DESCRIPTION
Use `log.Ctx` for more logging statements. Also move the `signal.NotifyContext` calls to the root command so all commands can cleanly tidy up.

Part #2001